### PR TITLE
Create nodes from roles which inherit the role template

### DIFF
--- a/controllers/openstackdataplanerole_controller.go
+++ b/controllers/openstackdataplanerole_controller.go
@@ -23,10 +23,12 @@ import (
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/go-logr/logr"
@@ -77,7 +79,6 @@ func (r *OpenStackDataPlaneRoleReconciler) Reconcile(ctx context.Context, req ct
 		// Error reading the object - requeue the request.
 		return ctrl.Result{}, err
 	}
-
 	err = r.ReconcileNodes(ctx, instance)
 	if err != nil {
 		util.LogErrorForObject(helper, err, fmt.Sprintf("Unable to reconcile nodes for %s", instance.Name), instance)
@@ -96,11 +97,71 @@ func (r *OpenStackDataPlaneRoleReconciler) SetupWithManager(mgr ctrl.Manager) er
 
 // ReconcileNodes ensure the desired state for the nodes
 func (r *OpenStackDataPlaneRoleReconciler) ReconcileNodes(ctx context.Context, instance *dataplanev1beta1.OpenStackDataPlaneRole) error {
-	// loop over r.Spec.DataPlaneNodes:
+	// loop over instance.Spec.DataPlaneNodes:
 	//   for each node:
 	//     (1) complete node.Spec based r.Spec.nodeTemplate, and values set on the
 	//         node (values on the node take precedence over those from the template)
 	//     (2) Create a CR of OpenStackDataPlaneNode from the node
+
+	var NodeName string
+	for _, node := range instance.Spec.DataPlaneNodes {
+		if node.HostName == "" {
+			NodeName = node.AnsibleHost
+		} else {
+			NodeName = node.HostName
+		}
+		newNode := &dataplanev1beta1.OpenStackDataPlaneNode{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      NodeName,
+				Namespace: instance.Namespace,
+			},
+		}
+		// Set new node with values from its entry on the DataPlaneNodes list
+		_, err := controllerutil.CreateOrUpdate(ctx, r.Client, newNode, func() error {
+			newNode.TypeMeta = metav1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "OpenStackDataPlaneNode",
+			}
+			newNode.ObjectMeta = metav1.ObjectMeta{
+				Name:      NodeName,
+				Namespace: instance.Namespace,
+			}
+			newNode.Spec.Role = instance.Name
+			newNode.Spec.Node.Networks = node.Node.Networks
+			// Set new node with optional overriding node values, if found.
+			// The OpenStackDataPlaneNode (not the role) will ensure that
+			// values on the node take precedence over those from the template.
+
+			if node.AnsibleHost != "" {
+				newNode.Spec.AnsibleHost = node.AnsibleHost
+			}
+			if node.HostName != "" {
+				newNode.Spec.HostName = node.HostName
+			}
+			if node.Node.AnsiblePort > 0 {
+				newNode.Spec.Node.AnsiblePort = node.Node.AnsiblePort
+			}
+			if node.Node.AnsibleUser != "" {
+				newNode.Spec.Node.AnsibleUser = node.Node.AnsibleUser
+			}
+			if node.Node.Managed {
+				newNode.Spec.Node.Managed = node.Node.Managed
+			}
+			if node.Node.ManagementNetwork != "" {
+				newNode.Spec.Node.ManagementNetwork = node.Node.ManagementNetwork
+			}
+			if node.Node.NetworkConfig != instance.Spec.NodeTemplate.NetworkConfig {
+				newNode.Spec.Node.NetworkConfig = node.Node.NetworkConfig
+			}
+			if node.Node.AnsibleVars != "" {
+				newNode.Spec.Node.AnsibleVars = node.Node.AnsibleVars
+			}
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
 
 	return nil
 }

--- a/docs/inheritance.md
+++ b/docs/inheritance.md
@@ -65,10 +65,10 @@ kind: OpenStackDataPlaneNode
 metadata:
   name: openstackdataplanenode-sample-2
 spec:
+  ansibleHost: 192.168.122.19
   hostName: openstackdataplanenode-sample-2.localdomain
-  networks:
   node:
-    ansibleHost: 192.168.122.19
+    networks:
     - fixedIP: 192.168.122.19
       network: ctlplane
   role: openstackdataplanerole-sample
@@ -78,7 +78,7 @@ provided to both nodes. Only the information which differed per node,
 e.g. `ansibleHost`, had to be specified. Furthermore, the redundant
 information is not seen in the two nodes' CRs. I.e. we do not see the
 following from the `nodeTemplate` in node 1 and 2 above.
-```
+```yaml
     ansiblePort: 22
     ansibleUser: root
     managed: false
@@ -98,3 +98,45 @@ updating only that node (e.g. with `oc edit`). In that case we'd see
 an `ansiblePort` set directly in that node's CR. This allows the user
 to change the `nodeTemplate` after creation and once reconciliation is
 completed all existing nodes will inherit the new value.
+
+Any top level property in the node overrides the whole property in the
+role so that there is no merging of any sub-properties. E.g. if the
+role `nodeTemplate` had a list like the following:
+```
+    foo:
+      - bar: baz
+```
+and a node had a list like the following:
+```
+    foo:
+      - qux: quux
+```
+Then the node will only have `{"qux": "quux"}` in its list. I.e. there
+would not be any merging and the node would not have also have
+`{"bar": "baz"}` in its list. This is the same way that Ansible merges
+variables and was done by design for simplicity.
+
+It's also possible to create a node directly outside of a role CR
+and define its role. If the following CR is created:
+```yaml
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneNode
+metadata:
+  name: openstackdataplanenode-sample-3-from
+spec:
+  role: openstackdataplanerole-sample
+  hostName: openstackdataplanenode-sample-3.localdomain
+  ansibleHost: 192.168.122.20
+  node:
+    networks:
+      - network: ctlplane
+        fixedIP: 192.168.122.20
+```
+After the above CR is created, the node
+openstackdataplanenode-sample-3-from may then be inspected further
+using a command like
+`oc get OpenStackDataPlaneNode openstackdataplanenode-sample-3-from -o
+yaml` which should show that it inherited values from the role
+`nodeTemplate`. In cases like these, the `dataPlaneNodes` list will
+not reflect all of the nodes within the role.


### PR DESCRIPTION
This patch creates nodes from roles which inherit the role template. It does the following:

- Creates CRs of type OpenStackDataPlaneNodes from the OpenStackDataPlaneRole's DataPlaneNodes list.
- Each node CR is populated with values from the node entry in the DataPlaneNodes list.
- Inheritance is implemented by having the node look up its role and setting Ansible inventory values from the role template in the node configMap.
- Node values take precedence over template values when the inventory configMap values are set.
- Creating a node directly and setting its role will result in the node inheriting that role's nodeTemplate in its inventory.

Signed-off-by: John Fulton <fulton@redhat.com>