### PR TITLE
OpenStackDataPlaneNode role should not be a templateRef

### DIFF
--- a/api/v1beta1/openstackdataplanenode_types.go
+++ b/api/v1beta1/openstackdataplanenode_types.go
@@ -29,7 +29,7 @@ type OpenStackDataPlaneNodeSpec struct {
 
 	// +kubebuilder:validation:Optional
 	// Role - role name for this node
-	Role string `json:"templateRef,omitempty"`
+	Role string `json:"role,omitempty"`
 }
 
 // NodeSection is a specification of the node attributes

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
@@ -90,7 +90,7 @@ spec:
                       type: object
                     type: array
                 type: object
-              templateRef:
+              role:
                 description: Role - role name for this node
                 type: string
             type: object

--- a/docs/openstack_dataplanenode.md
+++ b/docs/openstack_dataplanenode.md
@@ -80,6 +80,6 @@ OpenStackDataPlaneNodeSpec defines the desired state of OpenStackDataPlaneNode
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | node | Node - node attributes specific to this node | [NodeSection](#nodesection) | false |
-| templateRef | Role - role name for this node | string | false |
+| role | Role - role name for this node | string | false |
 
 [Back to Custom Resources](#custom-resources)


### PR DESCRIPTION
OpenStackDataPlaneNode types had a typo in its JSON tag where the role string was set to a templateRef. This was from an earlier prototype. Set it to to the role value.

Signed-off-by: John Fulton <fulton@redhat.com>