### PR TITLE
OpenStackDataPlaneNode Network should not be a template

### DIFF
--- a/api/v1beta1/openstackdataplanenode_types.go
+++ b/api/v1beta1/openstackdataplanenode_types.go
@@ -89,7 +89,7 @@ type NetworksSection struct {
 
 	// +kubebuilder:validation:Optional
 	// Network - Network name to configure
-	Network string `json:"template,omitempty"`
+	Network string `json:"network,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// FixedIP - Specific IP address to use for this network

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
@@ -84,7 +84,7 @@ spec:
                           description: FixedIP - Specific IP address to use for this
                             network
                           type: string
-                        template:
+                        network:
                           description: Network - Network name to configure
                           type: string
                       type: object

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
@@ -90,7 +90,7 @@ spec:
                                 description: FixedIP - Specific IP address to use
                                   for this network
                                 type: string
-                              template:
+                              network:
                                 description: Network - Network name to configure
                                 type: string
                             type: object
@@ -150,7 +150,7 @@ spec:
                           description: FixedIP - Specific IP address to use for this
                             network
                           type: string
-                        template:
+                        network:
                           description: Network - Network name to configure
                           type: string
                       type: object

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanes.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanes.yaml
@@ -97,7 +97,7 @@ spec:
                                       description: FixedIP - Specific IP address to
                                         use for this network
                                       type: string
-                                    template:
+                                    network:
                                       description: Network - Network name to configure
                                       type: string
                                   type: object
@@ -158,7 +158,7 @@ spec:
                                 description: FixedIP - Specific IP address to use
                                   for this network
                                 type: string
-                              template:
+                              network:
                                 description: Network - Network name to configure
                                 type: string
                             type: object

--- a/docs/openstack_dataplanenode.md
+++ b/docs/openstack_dataplanenode.md
@@ -27,7 +27,7 @@ NetworksSection is a specification of the network attributes
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| template | Network - Network name to configure | string | false |
+| network | Network - Network name to configure | string | false |
 | fixedIP | FixedIP - Specific IP address to use for this network | string | false |
 
 [Back to Custom Resources](#custom-resources)


### PR DESCRIPTION
Change OpenStackDataPlaneNode NetworksSection JSON tag from "template" to "network". Without this change, the network name "ctlplane" in the `config` sample for this type is not retained when the sample is created.

Signed-off-by: John Fulton <fulton@redhat.com>