### PR TITLE
Support OwnNamespace installMode

### DIFF
--- a/config/manifests/bases/dataplane-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/dataplane-operator.clusterserviceversion.yaml
@@ -37,7 +37,7 @@ spec:
       deployments: null
     strategy: ""
   installModes:
-  - supported: false
+  - supported: true
     type: OwnNamespace
   - supported: false
     type: SingleNamespace


### PR DESCRIPTION
This is required for deploying the operator in the openstack namespace
so it can manage resources in the openstack namespace, and thus
install_yamls integration.

Signed-off-by: James Slagle <jslagle@redhat.com>
