### PR TITLE
Add AnsibleSSHPrivateKey to CRD

### DIFF
--- a/api/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
@@ -61,6 +61,12 @@ spec:
                   ansiblePort:
                     description: AnsiblePort SSH port for Ansible connection
                     type: integer
+                  ansibleSSHPrivateKeySecret:
+                    description: 'AnsibleSSHPrivateKeySecret Private SSH Key secret
+                      containing private SSH key for connecting to node. Must be of
+                      the form: Secret.data.ssh_private_key: <base64 encoded private
+                      key contents>'
+                    type: string
                   ansibleUser:
                     description: AnsibleUser SSH user for Ansible connection
                     type: string

--- a/api/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
@@ -48,6 +48,12 @@ spec:
                         ansiblePort:
                           description: AnsiblePort SSH port for Ansible connection
                           type: integer
+                        ansibleSSHPrivateKeySecret:
+                          description: 'AnsibleSSHPrivateKeySecret Private SSH Key
+                            secret containing private SSH key for connecting to node.
+                            Must be of the form: Secret.data.ssh_private_key: <base64
+                            encoded private key contents>'
+                          type: string
                         ansibleUser:
                           description: AnsibleUser SSH user for Ansible connection
                           type: string
@@ -100,6 +106,12 @@ spec:
                   ansiblePort:
                     description: AnsiblePort SSH port for Ansible connection
                     type: integer
+                  ansibleSSHPrivateKeySecret:
+                    description: 'AnsibleSSHPrivateKeySecret Private SSH Key secret
+                      containing private SSH key for connecting to node. Must be of
+                      the form: Secret.data.ssh_private_key: <base64 encoded private
+                      key contents>'
+                    type: string
                   ansibleUser:
                     description: AnsibleUser SSH user for Ansible connection
                     type: string

--- a/api/bases/dataplane.openstack.org_openstackdataplanes.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplanes.yaml
@@ -54,6 +54,12 @@ spec:
                               ansiblePort:
                                 description: AnsiblePort SSH port for Ansible connection
                                 type: integer
+                              ansibleSSHPrivateKeySecret:
+                                description: 'AnsibleSSHPrivateKeySecret Private SSH
+                                  Key secret containing private SSH key for connecting
+                                  to node. Must be of the form: Secret.data.ssh_private_key:
+                                  <base64 encoded private key contents>'
+                                type: string
                               ansibleUser:
                                 description: AnsibleUser SSH user for Ansible connection
                                 type: string
@@ -108,6 +114,12 @@ spec:
                         ansiblePort:
                           description: AnsiblePort SSH port for Ansible connection
                           type: integer
+                        ansibleSSHPrivateKeySecret:
+                          description: 'AnsibleSSHPrivateKeySecret Private SSH Key
+                            secret containing private SSH key for connecting to node.
+                            Must be of the form: Secret.data.ssh_private_key: <base64
+                            encoded private key contents>'
+                          type: string
                         ansibleUser:
                           description: AnsibleUser SSH user for Ansible connection
                           type: string

--- a/api/v1beta1/openstackdataplanenode_types.go
+++ b/api/v1beta1/openstackdataplanenode_types.go
@@ -77,6 +77,12 @@ type NodeSection struct {
 	// +kubebuilder:validation:Optional
 	// AnsibleVars for configuring ansible
 	AnsibleVars string `json:"ansibleVars,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// AnsibleSSHPrivateKeySecret Private SSH Key secret containing private SSH
+	// key for connecting to node. Must be of the form:
+	// Secret.data.ssh_private_key: <base64 encoded private key contents>
+	AnsibleSSHPrivateKeySecret string `json:"ansibleSSHPrivateKeySecret"`
 }
 
 // NetworkConfigSection is a specification of the Network configuration details

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
@@ -61,6 +61,12 @@ spec:
                   ansiblePort:
                     description: AnsiblePort SSH port for Ansible connection
                     type: integer
+                  ansibleSSHPrivateKeySecret:
+                    description: 'AnsibleSSHPrivateKeySecret Private SSH Key secret
+                      containing private SSH key for connecting to node. Must be of
+                      the form: Secret.data.ssh_private_key: <base64 encoded private
+                      key contents>'
+                    type: string
                   ansibleUser:
                     description: AnsibleUser SSH user for Ansible connection
                     type: string

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
@@ -48,6 +48,12 @@ spec:
                         ansiblePort:
                           description: AnsiblePort SSH port for Ansible connection
                           type: integer
+                        ansibleSSHPrivateKeySecret:
+                          description: 'AnsibleSSHPrivateKeySecret Private SSH Key
+                            secret containing private SSH key for connecting to node.
+                            Must be of the form: Secret.data.ssh_private_key: <base64
+                            encoded private key contents>'
+                          type: string
                         ansibleUser:
                           description: AnsibleUser SSH user for Ansible connection
                           type: string
@@ -100,6 +106,12 @@ spec:
                   ansiblePort:
                     description: AnsiblePort SSH port for Ansible connection
                     type: integer
+                  ansibleSSHPrivateKeySecret:
+                    description: 'AnsibleSSHPrivateKeySecret Private SSH Key secret
+                      containing private SSH key for connecting to node. Must be of
+                      the form: Secret.data.ssh_private_key: <base64 encoded private
+                      key contents>'
+                    type: string
                   ansibleUser:
                     description: AnsibleUser SSH user for Ansible connection
                     type: string

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanes.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanes.yaml
@@ -54,6 +54,12 @@ spec:
                               ansiblePort:
                                 description: AnsiblePort SSH port for Ansible connection
                                 type: integer
+                              ansibleSSHPrivateKeySecret:
+                                description: 'AnsibleSSHPrivateKeySecret Private SSH
+                                  Key secret containing private SSH key for connecting
+                                  to node. Must be of the form: Secret.data.ssh_private_key:
+                                  <base64 encoded private key contents>'
+                                type: string
                               ansibleUser:
                                 description: AnsibleUser SSH user for Ansible connection
                                 type: string
@@ -108,6 +114,12 @@ spec:
                         ansiblePort:
                           description: AnsiblePort SSH port for Ansible connection
                           type: integer
+                        ansibleSSHPrivateKeySecret:
+                          description: 'AnsibleSSHPrivateKeySecret Private SSH Key
+                            secret containing private SSH key for connecting to node.
+                            Must be of the form: Secret.data.ssh_private_key: <base64
+                            encoded private key contents>'
+                          type: string
                         ansibleUser:
                           description: AnsibleUser SSH user for Ansible connection
                           type: string

--- a/config/samples/dataplane_v1beta1_openstackdataplanenode_deployment.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenode_deployment.yaml
@@ -20,3 +20,4 @@ spec:
       - 192.168.122.1
       dns_search_domains: []
     deploy: true
+    ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret

--- a/controllers/openstackdataplanenode_controller.go
+++ b/controllers/openstackdataplanenode_controller.go
@@ -138,11 +138,8 @@ func (r *OpenStackDataPlaneNodeReconciler) Reconcile(ctx context.Context, req ct
 		return ctrl.Result{}, err
 	}
 
-	// TODO(slagle): fix hardcoded secret name
-	sshKeySecret := "ansibleee-ssh-key-secret"
-
 	if instance.Spec.Deploy {
-		result, err = deployment.Deploy(ctx, helper, instance, sshKeySecret, inventoryConfigMap, &instance.Status)
+		result, err = deployment.Deploy(ctx, helper, instance, instance.Spec.Node.AnsibleSSHPrivateKeySecret, inventoryConfigMap, &instance.Status)
 		if err != nil {
 			util.LogErrorForObject(helper, err, fmt.Sprintf("Unable to deploy %s", instance.Name), instance)
 			return ctrl.Result{}, err

--- a/docs/openstack_dataplanenode.md
+++ b/docs/openstack_dataplanenode.md
@@ -46,6 +46,7 @@ NodeSection is a specification of the node attributes
 | ansibleUser | AnsibleUser SSH user for Ansible connection | string | false |
 | ansiblePort | AnsiblePort SSH port for Ansible connection | int | false |
 | ansibleVars | AnsibleVars for configuring ansible | string | false |
+| ansibleSSHPrivateKeySecret | AnsibleSSHPrivateKeySecret Private SSH Key secret containing private SSH key for connecting to node. Must be of the form: Secret.data.ssh_private_key: <base64 encoded private key contents> | string | true |
 
 [Back to Custom Resources](#custom-resources)
 

--- a/pkg/util/ansible_execution.go
+++ b/pkg/util/ansible_execution.go
@@ -62,14 +62,6 @@ func AnsibleExecution(ctx context.Context, helper *helper.Helper, obj client.Obj
 		ansibleEE.Spec.Image = "quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest"
 		// TODO(slagle): Handle either play or role being specified
 		ansibleEE.Spec.Role = role
-		// 	ansibleEE.Spec.Play = `
-		// - name: Play
-		//   hosts: localhost
-		//   gather_facts: no
-		//   tasks:
-		//     - name: sleep
-		//       shell: sleep infinity
-		// `
 
 		ansibleEEMounts := storage.VolMounts{}
 		sshKeyVolume := corev1.Volume{
@@ -79,7 +71,7 @@ func AnsibleExecution(ctx context.Context, helper *helper.Helper, obj client.Obj
 					SecretName: sshKeySecret,
 					Items: []corev1.KeyToPath{
 						{
-							Key:  "private_ssh_key",
+							Key:  "ssh_private_key",
 							Path: "ssh_key",
 						},
 					},


### PR DESCRIPTION
AnsibleSSHPrivateKey holds the contents of the private key that will be
used by the Ansible SSH connection to nodes. A secret is created with
the private key contents.

Signed-off-by: James Slagle <jslagle@redhat.com>
