### PR TITLE
Add RBAC for watching ConfigMaps

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -18,6 +18,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - dataplane.openstack.org
   resources:
   - openstackdataplanenodes

--- a/controllers/openstackdataplanenode_controller.go
+++ b/controllers/openstackdataplanenode_controller.go
@@ -52,6 +52,7 @@ type OpenStackDataPlaneNodeReconciler struct {
 //+kubebuilder:rbac:groups=dataplane.openstack.org,resources=openstackdataplanenodes/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=dataplane.openstack.org,resources=openstackdataplanenodes/finalizers,verbs=update
 //+kubebuilder:rbac:groups=ansibleee.openstack.org,resources=openstackansibleees,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete;
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
As the OpenStackDataPlaneNode declares that it Owns some ConfigMap it needs RBAC declaration to have right to watch the ConfigMaps.

Without this you get the following log periodically in the operator
```
 failed to list *v1.ConfigMap: configmaps is forbidden:
 User "system:serviceaccount:openstack:dataplane-operator-controller-manager"
 cannot list resource "configmaps" in API group "" at the cluster scope
```
and then eventually the operator gets killed by:
```
 ERROR	Could not wait for Cache to sync
 {"controller": "openstackdataplanenode",
  "controllerGroup": "dataplane.openstack.org",
  "controllerKind": "OpenStackDataPlaneNode",
  "error":
    "failed to wait for openstackdataplanenode caches to sync: timed out waiting for cache to be synced"}
```