### PR TITLE
Drop paths-ignore from build operator workflow

### DIFF
--- a/.github/workflows/build-dataplane-operator.yaml
+++ b/.github/workflows/build-dataplane-operator.yaml
@@ -5,20 +5,6 @@ on:
   push:
     branches:
       - '*'
-    paths-ignore:
-      - .gitignore
-      - .pull_request_pipeline
-      - changelog.txt
-      - kuttl-test.yaml
-      - LICENSE
-      - Makefile
-      - OWNERS
-      - PROJECT
-      - README.md
-      - .github/
-      - build/
-      - docs/
-      - tests/
 
 env:
   imageregistry: 'quay.io'


### PR DESCRIPTION
We build containers and push to registry in post merge workflow. Not building container for each hash can cause issue becuase of missing container tags. Pin-custom-bundle-dockerfile.sh (openstack-operator) can pin to hash for which images are not available.