### PR TITLE
DataPlaneRoleSpec.DataPlaneNodes should be []DataPlaneNodeSpec

### DIFF
--- a/api/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
@@ -101,6 +101,10 @@ spec:
                       type: object
                     type: array
                 type: object
+              nodeFrom:
+                description: NodeFrom - Existing node name to reference. Can only
+                  be used if Node is empty.
+                type: string
               role:
                 description: Role - role name for this node
                 type: string

--- a/api/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
@@ -39,9 +39,19 @@ spec:
               dataPlaneNodes:
                 description: DataPlaneNodes - List of nodes
                 items:
-                  description: DataPlaneNodeSection is a specification of the data
-                    plane node attributes
+                  description: OpenStackDataPlaneNodeSpec defines the desired state
+                    of OpenStackDataPlaneNode
                   properties:
+                    ansibleHost:
+                      description: AnsibleHost SSH host for Ansible connection
+                      type: string
+                    deploy:
+                      default: true
+                      description: Deploy boolean to trigger ansible execution
+                      type: boolean
+                    hostName:
+                      description: HostName - node name
+                      type: string
                     node:
                       description: Node - node attributes specific to this node
                       properties:
@@ -92,6 +102,11 @@ spec:
                       description: NodeFrom - Existing node name to reference. Can
                         only be used if Node is empty.
                       type: string
+                    role:
+                      description: Role - role name for this node
+                      type: string
+                  required:
+                  - deploy
                   type: object
                 type: array
               nodeTemplate:

--- a/api/bases/dataplane.openstack.org_openstackdataplanes.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplanes.yaml
@@ -45,9 +45,19 @@ spec:
                     dataPlaneNodes:
                       description: DataPlaneNodes - List of nodes
                       items:
-                        description: DataPlaneNodeSection is a specification of the
-                          data plane node attributes
+                        description: OpenStackDataPlaneNodeSpec defines the desired
+                          state of OpenStackDataPlaneNode
                         properties:
+                          ansibleHost:
+                            description: AnsibleHost SSH host for Ansible connection
+                            type: string
+                          deploy:
+                            default: true
+                            description: Deploy boolean to trigger ansible execution
+                            type: boolean
+                          hostName:
+                            description: HostName - node name
+                            type: string
                           node:
                             description: Node - node attributes specific to this node
                             properties:
@@ -99,6 +109,11 @@ spec:
                             description: NodeFrom - Existing node name to reference.
                               Can only be used if Node is empty.
                             type: string
+                          role:
+                            description: Role - role name for this node
+                            type: string
+                        required:
+                        - deploy
                         type: object
                       type: array
                     nodeTemplate:

--- a/api/v1beta1/openstackdataplanenode_types.go
+++ b/api/v1beta1/openstackdataplanenode_types.go
@@ -43,6 +43,11 @@ type OpenStackDataPlaneNodeSpec struct {
 	// +kubebuilder:default=true
 	// Deploy boolean to trigger ansible execution
 	Deploy bool `json:"deploy"`
+
+	// +kubebuilder:validation:Optional
+	// NodeFrom - Existing node name to reference. Can only be used if Node is
+	// empty.
+	NodeFrom string `json:"nodeFrom,omitempty"`
 }
 
 // NodeSection is a specification of the node attributes

--- a/api/v1beta1/openstackdataplanerole_types.go
+++ b/api/v1beta1/openstackdataplanerole_types.go
@@ -27,7 +27,7 @@ import (
 type OpenStackDataPlaneRoleSpec struct {
 	// +kubebuilder:validation:Optional
 	// DataPlaneNodes - List of nodes
-	DataPlaneNodes []DataPlaneNodeSection `json:"dataPlaneNodes,omitempty"`
+	DataPlaneNodes []OpenStackDataPlaneNodeSpec `json:"dataPlaneNodes,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// NodeTemplate - node attributes specific to this roles

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -313,7 +313,7 @@ func (in *OpenStackDataPlaneRoleSpec) DeepCopyInto(out *OpenStackDataPlaneRoleSp
 	*out = *in
 	if in.DataPlaneNodes != nil {
 		in, out := &in.DataPlaneNodes, &out.DataPlaneNodes
-		*out = make([]DataPlaneNodeSection, len(*in))
+		*out = make([]OpenStackDataPlaneNodeSpec, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
@@ -101,6 +101,10 @@ spec:
                       type: object
                     type: array
                 type: object
+              nodeFrom:
+                description: NodeFrom - Existing node name to reference. Can only
+                  be used if Node is empty.
+                type: string
               role:
                 description: Role - role name for this node
                 type: string

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
@@ -39,9 +39,19 @@ spec:
               dataPlaneNodes:
                 description: DataPlaneNodes - List of nodes
                 items:
-                  description: DataPlaneNodeSection is a specification of the data
-                    plane node attributes
+                  description: OpenStackDataPlaneNodeSpec defines the desired state
+                    of OpenStackDataPlaneNode
                   properties:
+                    ansibleHost:
+                      description: AnsibleHost SSH host for Ansible connection
+                      type: string
+                    deploy:
+                      default: true
+                      description: Deploy boolean to trigger ansible execution
+                      type: boolean
+                    hostName:
+                      description: HostName - node name
+                      type: string
                     node:
                       description: Node - node attributes specific to this node
                       properties:
@@ -92,6 +102,11 @@ spec:
                       description: NodeFrom - Existing node name to reference. Can
                         only be used if Node is empty.
                       type: string
+                    role:
+                      description: Role - role name for this node
+                      type: string
+                  required:
+                  - deploy
                   type: object
                 type: array
               nodeTemplate:

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanes.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanes.yaml
@@ -45,9 +45,19 @@ spec:
                     dataPlaneNodes:
                       description: DataPlaneNodes - List of nodes
                       items:
-                        description: DataPlaneNodeSection is a specification of the
-                          data plane node attributes
+                        description: OpenStackDataPlaneNodeSpec defines the desired
+                          state of OpenStackDataPlaneNode
                         properties:
+                          ansibleHost:
+                            description: AnsibleHost SSH host for Ansible connection
+                            type: string
+                          deploy:
+                            default: true
+                            description: Deploy boolean to trigger ansible execution
+                            type: boolean
+                          hostName:
+                            description: HostName - node name
+                            type: string
                           node:
                             description: Node - node attributes specific to this node
                             properties:
@@ -99,6 +109,11 @@ spec:
                             description: NodeFrom - Existing node name to reference.
                               Can only be used if Node is empty.
                             type: string
+                          role:
+                            description: Role - role name for this node
+                            type: string
+                        required:
+                        - deploy
                         type: object
                       type: array
                     nodeTemplate:

--- a/config/samples/dataplane_v1beta1_openstackdataplanenode.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenode.yaml
@@ -4,9 +4,9 @@ metadata:
   name: openstackdataplanenode-sample
 spec:
   role: openstackdataplanerole-sample
+  hostName: openstackdataplanenode-sample.localdomain
+  ansibleHost: 192.168.122.18
   node:
-    hostName: openstackdataplanenode-sample.localdomain
     networks:
       - network: ctlplane
         fixedIP: 192.168.122.18
-    ansibleHost: 192.168.122.18

--- a/config/samples/dataplane_v1beta1_openstackdataplanenode_deployment.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenode_deployment.yaml
@@ -5,11 +5,11 @@ metadata:
 spec:
   role: openstackdataplanerole-sample
   hostName: edpm-compute-0
+  ansibleHost: 192.168.122.228
   node:
     networks:
       - network: ctlplane
         fixedIP: 192.168.122.228
-    ansibleHost: 192.168.122.228
     ansibleUser: root
     ansibleVars: |
       edpm_network_config_template: templates/net_config_bridge.j2

--- a/config/samples/dataplane_v1beta1_openstackdataplanenode_from.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenode_from.yaml
@@ -3,10 +3,10 @@ kind: OpenStackDataPlaneNode
 metadata:
   name: openstackdataplanenode-from-sample
 spec:
+  hostName: openstackdataplanenode-from-sample.localdomain
+  ansibleHost: 192.168.122.18
   role: openstackdataplanerole-sample
   node:
-    hostName: openstackdataplanenode-from-sample.localdomain
     networks:
       - network: ctlplane
         fixedIP: 192.168.122.18
-    ansibleHost: 192.168.122.18

--- a/config/samples/dataplane_v1beta1_openstackdataplanerole.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanerole.yaml
@@ -5,12 +5,12 @@ metadata:
 spec:
   dataPlaneNodes:
     - name: openstackdataplanenode-sample
+      hostName: openstackdataplanenode-sample.localdomain
+      ansibleHost: 192.168.122.18
       node:
-        hostName: openstackdataplanenode-sample.localdomain
         networks:
           - network: ctlplane
             fixedIP: 192.168.122.18
-        ansibleHost: 192.168.122.18
     - name: openstackdataplanenode-sample-from
       nodeFrom: openstackdataplanenode-sample-from
   nodeTemplate:

--- a/docs/inheritance.md
+++ b/docs/inheritance.md
@@ -16,16 +16,16 @@ metadata:
 spec:
   dataPlaneNodes:
   - name: openstackdataplanenode-sample-1
+    ansibleHost: 192.168.122.18
+    hostName: openstackdataplanenode-sample-1.localdomain
     node:
-      ansibleHost: 192.168.122.18
-      hostName: openstackdataplanenode-sample-1.localdomain
       networks:
       - fixedIP: 192.168.122.18
         network: ctlplane
   - name: openstackdataplanenode-sample-2
+    ansibleHost: 192.168.122.19
+    hostName: openstackdataplanenode-sample-2.localdomain
     node:
-      ansibleHost: 192.168.122.19
-      hostName: openstackdataplanenode-sample-2.localdomain
       networks:
       - fixedIP: 192.168.122.19
         network: ctlplane
@@ -49,9 +49,9 @@ kind: OpenStackDataPlaneNode
 metadata:
   name: openstackdataplanenode-sample-1
 spec:
+  ansibleHost: 192.168.122.18
+  hostName: openstackdataplanenode-sample-1.localdomain
   node:
-    ansibleHost: 192.168.122.18
-    hostName: openstackdataplanenode-sample-1.localdomain
     networks:
     - fixedIP: 192.168.122.18
       network: ctlplane
@@ -65,10 +65,10 @@ kind: OpenStackDataPlaneNode
 metadata:
   name: openstackdataplanenode-sample-2
 spec:
+  hostName: openstackdataplanenode-sample-2.localdomain
+  networks:
   node:
     ansibleHost: 192.168.122.19
-    hostName: openstackdataplanenode-sample-2.localdomain
-    networks:
     - fixedIP: 192.168.122.19
       network: ctlplane
   role: openstackdataplanerole-sample

--- a/docs/openstack_dataplanenode.md
+++ b/docs/openstack_dataplanenode.md
@@ -83,6 +83,7 @@ OpenStackDataPlaneNodeSpec defines the desired state of OpenStackDataPlaneNode
 | role | Role - role name for this node | string | false |
 | ansibleHost | AnsibleHost SSH host for Ansible connection | string | false |
 | deploy | Deploy boolean to trigger ansible execution | bool | true |
+| nodeFrom | NodeFrom - Existing node name to reference. Can only be used if Node is empty. | string | false |
 
 [Back to Custom Resources](#custom-resources)
 

--- a/docs/openstack_dataplanerole.md
+++ b/docs/openstack_dataplanerole.md
@@ -49,7 +49,7 @@ OpenStackDataPlaneRoleSpec defines the desired state of OpenStackDataPlaneRole
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| dataPlaneNodes | DataPlaneNodes - List of nodes | [][DataPlaneNodeSection](#dataplanenodesection) | false |
+| dataPlaneNodes | DataPlaneNodes - List of nodes | []OpenStackDataPlaneNodeSpec | false |
 | nodeTemplate | NodeTemplate - node attributes specific to this roles | NodeSection | false |
 
 [Back to Custom Resources](#custom-resources)


### PR DESCRIPTION
Change OpenStackDataPlaneRoleSpec.DataPlaneNodes type to []OpenStackDataPlaneNodeSpec.

When OpenStackDataPlaneRoleSpec uses []OpenStackDataPlaneNodeSpec in place of []DataPlaneNodeSection, the nodeFrom field is removed from the API bases. Any node in the OpenStackDataPlaneNodeSpec list could have a nodeFrom field so move it to OpenStackDataPlaneNodeSpec.

This also has the desired side effect of fixing the structure change from f4a04c40f27c0ead2132479b901760d093c3c32c where ansibleHost and hostName were moved out of NodeSection and up into OpenStackDataPlaneNodeSpec. Update the sample YAML files and documentation to be consistent with this change.

closes [OSP-22490](https://issues.redhat.com//browse/OSP-22490)