### PR TITLE
Set conditions to the ready message after completion

### DIFF
--- a/api/v1beta1/conditions.go
+++ b/api/v1beta1/conditions.go
@@ -28,6 +28,9 @@ const (
 	// DataPlaneNodeReadyMessage ready
 	DataPlaneNodeReadyMessage = "DataPlaneNode ready"
 
+	// DataPlaneNodeReadyWaitingMessage ready
+	DataPlaneNodeReadyWaitingMessage = "DataPlaneNode not yet ready"
+
 	// ConfigureNetworkReadyCondition Status=True condition indicates if the
 	// network configuration is finished and successful.
 	ConfigureNetworkReadyCondition condition.Type = "ConfigureNetworkReady"


### PR DESCRIPTION
After a specific deployment condition has completed, we need to
transition the condition waiting message to the ready message.

This also sets the DataPlaneNodeReadyCondition to requested when the
deployment first starts.

Signed-off-by: James Slagle <jslagle@redhat.com>
