### PR TITLE
Make AnsibleSSHPrivateKeySecret optional and inherited

### DIFF
--- a/api/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
@@ -113,8 +113,6 @@ spec:
                           type: string
                       type: object
                     type: array
-                required:
-                - ansibleSSHPrivateKeySecret
                 type: object
               nodeFrom:
                 description: NodeFrom - Existing node name to reference. Can only

--- a/api/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
@@ -110,8 +110,6 @@ spec:
                                 type: string
                             type: object
                           type: array
-                      required:
-                      - ansibleSSHPrivateKeySecret
                       type: object
                     nodeFrom:
                       description: NodeFrom - Existing node name to reference. Can
@@ -180,8 +178,6 @@ spec:
                           type: string
                       type: object
                     type: array
-                required:
-                - ansibleSSHPrivateKeySecret
                 type: object
             type: object
           status:

--- a/api/bases/dataplane.openstack.org_openstackdataplanes.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplanes.yaml
@@ -118,8 +118,6 @@ spec:
                                       type: string
                                   type: object
                                 type: array
-                            required:
-                            - ansibleSSHPrivateKeySecret
                             type: object
                           nodeFrom:
                             description: NodeFrom - Existing node name to reference.
@@ -189,8 +187,6 @@ spec:
                                 type: string
                             type: object
                           type: array
-                      required:
-                      - ansibleSSHPrivateKeySecret
                       type: object
                   type: object
                 type: array

--- a/api/v1beta1/openstackdataplanenode_types.go
+++ b/api/v1beta1/openstackdataplanenode_types.go
@@ -96,6 +96,7 @@ type NodeSection struct {
 	// AnsibleVars for configuring ansible
 	AnsibleVars string `json:"ansibleVars,omitempty"`
 
+	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:io.kubernetes:Secret"}
 	// AnsibleSSHPrivateKeySecret Private SSH Key secret containing private SSH
 	// key for connecting to node. Must be of the form:

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
@@ -113,8 +113,6 @@ spec:
                           type: string
                       type: object
                     type: array
-                required:
-                - ansibleSSHPrivateKeySecret
                 type: object
               nodeFrom:
                 description: NodeFrom - Existing node name to reference. Can only

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
@@ -110,8 +110,6 @@ spec:
                                 type: string
                             type: object
                           type: array
-                      required:
-                      - ansibleSSHPrivateKeySecret
                       type: object
                     nodeFrom:
                       description: NodeFrom - Existing node name to reference. Can
@@ -180,8 +178,6 @@ spec:
                           type: string
                       type: object
                     type: array
-                required:
-                - ansibleSSHPrivateKeySecret
                 type: object
             type: object
           status:

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanes.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanes.yaml
@@ -118,8 +118,6 @@ spec:
                                       type: string
                                   type: object
                                 type: array
-                            required:
-                            - ansibleSSHPrivateKeySecret
                             type: object
                           nodeFrom:
                             description: NodeFrom - Existing node name to reference.
@@ -189,8 +187,6 @@ spec:
                                 type: string
                             type: object
                           type: array
-                      required:
-                      - ansibleSSHPrivateKeySecret
                       type: object
                   type: object
                 type: array


### PR DESCRIPTION
This field should be inherited from the role if set. It also should be
optional within the NodeSection, otherwise it's required to be set on
every node.

The lib-common VerifySecret function will ensure that the secret is
actually a value and exists.

Signed-off-by: James Slagle <jslagle@redhat.com>
