### PR TITLE
Make node's role field optional

### DIFF
--- a/controllers/openstackdataplanenode_controller.go
+++ b/controllers/openstackdataplanenode_controller.go
@@ -102,10 +102,8 @@ func (r *OpenStackDataPlaneNodeReconciler) Reconcile(ctx context.Context, req ct
 		return ctrl.Result{}, err
 	}
 
-	instanceRole, err := r.GetInstanceRole(ctx, instance)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
+	// An instance can be created without a role so ignore error
+	instanceRole, _ := r.GetInstanceRole(ctx, instance)
 
 	ansibleSSHPrivateKeySecret := r.GetAnsibleSSHPrivateKeySecret(instance, instanceRole)
 	_, result, err = secret.VerifySecret(


### PR DESCRIPTION
If an OpenStackDataPlaneNode CR is created before any OpenStackDataPlaneRole exists then do not fail with the error below.

This patch assumes we want to support creating nodes without roles. If we want to refuse to create nodes unless there is a role, then a validation should be added to the API so that the role field of the node is required.
```
{
  "controller": "openstackdataplanenode",
  "controllerGroup": "dataplane.openstack.org",
  "controllerKind": "OpenStackDataPlaneNode",
  "OpenStackDataPlaneNode": {
    "name": "network-edpm-compute-0",
    "namespace": "openstack"
  },
  "namespace": "openstack",
  "name": "network-edpm-compute-0",
  "reconcileID": "ada7594e-65b2-446e-b4bc-49d8989d5ad3",
  "error": "OpenStackDataPlaneRole.dataplane.openstack.org \"\" not found"
}
```