### PR TITLE
Update status based on subconditions

### DIFF
--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -372,7 +372,7 @@ func ConditionalDeploy(
 			status.Conditions.Set(condition.FalseCondition(
 				readyCondition,
 				condition.ErrorReason,
-				condition.SeverityWarning,
+				condition.SeverityError,
 				readyErrorMessage,
 				err.Error()))
 			return ctrl.Result{}, err


### PR DESCRIPTION
before:
```
 oc get openstackdataplanenode -w                                              
NAME                                       STATUS    MESSAGE
openstackdataplanenode-sample-deployment   Unknown   Setup started
```

now:
```
oc get openstackdataplanenode -w
NAME                                       STATUS   MESSAGE
openstackdataplanenode-sample-deployment   False    ConfigureNetwork error occurred failed: job.name dataplane-deployment-configure-networkg9cdq job.namespace default
```