### PR TITLE
Expose ExtraMounts in OpenStackDataPlaneNode

### DIFF
--- a/api/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
@@ -89,6 +89,1758 @@ spec:
                   ansibleVars:
                     description: AnsibleVars for configuring ansible
                     type: string
+                  extraMounts:
+                    description: ExtraMounts containing files which can be mounted
+                      into an Ansible Execution Pod
+                    items:
+                      description: VolMounts is the data structure used to expose
+                        Volumes and Mounts that can be added to a pod according to
+                        the defined Propagation policy
+                      properties:
+                        extraVolType:
+                          description: Label associated to a given extraMount
+                          type: string
+                        mounts:
+                          items:
+                            description: VolumeMount describes a mounting of a Volume
+                              within a container.
+                            properties:
+                              mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.  Must not contain ':'.
+                                type: string
+                              mountPropagation:
+                                description: mountPropagation determines how mounts
+                                  are propagated from the host to container and the
+                                  other way around. When not set, MountPropagationNone
+                                  is used. This field is beta in 1.10.
+                                type: string
+                              name:
+                                description: This must match the Name of a Volume.
+                                type: string
+                              readOnly:
+                                description: Mounted read-only if true, read-write
+                                  otherwise (false or unspecified). Defaults to false.
+                                type: boolean
+                              subPath:
+                                description: Path within the volume from which the
+                                  container's volume should be mounted. Defaults to
+                                  "" (volume's root).
+                                type: string
+                              subPathExpr:
+                                description: Expanded path within the volume from
+                                  which the container's volume should be mounted.
+                                  Behaves similarly to SubPath but environment variable
+                                  references $(VAR_NAME) are expanded using the container's
+                                  environment. Defaults to "" (volume's root). SubPathExpr
+                                  and SubPath are mutually exclusive.
+                                type: string
+                            required:
+                            - mountPath
+                            - name
+                            type: object
+                          type: array
+                        propagation:
+                          description: Propagation defines which pod should mount
+                            the volume
+                          items:
+                            description: PropagationType identifies the Service, Group
+                              or instance (e.g. the backend) that receives an Extra
+                              Volume that can potentially be mounted
+                            type: string
+                          type: array
+                        volumes:
+                          items:
+                            description: Volume represents a named volume in a pod
+                              that may be accessed by any container in the pod.
+                            properties:
+                              awsElasticBlockStore:
+                                description: 'awsElasticBlockStore represents an AWS
+                                  Disk resource that is attached to a kubelet''s host
+                                  machine and then exposed to the pod. More info:
+                                  https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                properties:
+                                  fsType:
+                                    description: 'fsType is the filesystem type of
+                                      the volume that you want to mount. Tip: Ensure
+                                      that the filesystem type is supported by the
+                                      host operating system. Examples: "ext4", "xfs",
+                                      "ntfs". Implicitly inferred to be "ext4" if
+                                      unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                      TODO: how do we prevent errors in the filesystem
+                                      from compromising the machine'
+                                    type: string
+                                  partition:
+                                    description: 'partition is the partition in the
+                                      volume that you want to mount. If omitted, the
+                                      default is to mount by volume name. Examples:
+                                      For volume /dev/sda1, you specify the partition
+                                      as "1". Similarly, the volume partition for
+                                      /dev/sda is "0" (or you can leave the property
+                                      empty).'
+                                    format: int32
+                                    type: integer
+                                  readOnly:
+                                    description: 'readOnly value true will force the
+                                      readOnly setting in VolumeMounts. More info:
+                                      https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                    type: boolean
+                                  volumeID:
+                                    description: 'volumeID is unique ID of the persistent
+                                      disk resource in AWS (Amazon EBS volume). More
+                                      info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                    type: string
+                                required:
+                                - volumeID
+                                type: object
+                              azureDisk:
+                                description: azureDisk represents an Azure Data Disk
+                                  mount on the host and bind mount to the pod.
+                                properties:
+                                  cachingMode:
+                                    description: 'cachingMode is the Host Caching
+                                      mode: None, Read Only, Read Write.'
+                                    type: string
+                                  diskName:
+                                    description: diskName is the Name of the data
+                                      disk in the blob storage
+                                    type: string
+                                  diskURI:
+                                    description: diskURI is the URI of data disk in
+                                      the blob storage
+                                    type: string
+                                  fsType:
+                                    description: fsType is Filesystem type to mount.
+                                      Must be a filesystem type supported by the host
+                                      operating system. Ex. "ext4", "xfs", "ntfs".
+                                      Implicitly inferred to be "ext4" if unspecified.
+                                    type: string
+                                  kind:
+                                    description: 'kind expected values are Shared:
+                                      multiple blob disks per storage account  Dedicated:
+                                      single blob disk per storage account  Managed:
+                                      azure managed data disk (only in managed availability
+                                      set). defaults to shared'
+                                    type: string
+                                  readOnly:
+                                    description: readOnly Defaults to false (read/write).
+                                      ReadOnly here will force the ReadOnly setting
+                                      in VolumeMounts.
+                                    type: boolean
+                                required:
+                                - diskName
+                                - diskURI
+                                type: object
+                              azureFile:
+                                description: azureFile represents an Azure File Service
+                                  mount on the host and bind mount to the pod.
+                                properties:
+                                  readOnly:
+                                    description: readOnly defaults to false (read/write).
+                                      ReadOnly here will force the ReadOnly setting
+                                      in VolumeMounts.
+                                    type: boolean
+                                  secretName:
+                                    description: secretName is the  name of secret
+                                      that contains Azure Storage Account Name and
+                                      Key
+                                    type: string
+                                  shareName:
+                                    description: shareName is the azure share Name
+                                    type: string
+                                required:
+                                - secretName
+                                - shareName
+                                type: object
+                              cephfs:
+                                description: cephFS represents a Ceph FS mount on
+                                  the host that shares a pod's lifetime
+                                properties:
+                                  monitors:
+                                    description: 'monitors is Required: Monitors is
+                                      a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                    items:
+                                      type: string
+                                    type: array
+                                  path:
+                                    description: 'path is Optional: Used as the mounted
+                                      root, rather than the full Ceph tree, default
+                                      is /'
+                                    type: string
+                                  readOnly:
+                                    description: 'readOnly is Optional: Defaults to
+                                      false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts. More info:
+                                      https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                    type: boolean
+                                  secretFile:
+                                    description: 'secretFile is Optional: SecretFile
+                                      is the path to key ring for User, default is
+                                      /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                    type: string
+                                  secretRef:
+                                    description: 'secretRef is Optional: SecretRef
+                                      is reference to the authentication secret for
+                                      User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  user:
+                                    description: 'user is optional: User is the rados
+                                      user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                    type: string
+                                required:
+                                - monitors
+                                type: object
+                              cinder:
+                                description: 'cinder represents a cinder volume attached
+                                  and mounted on kubelets host machine. More info:
+                                  https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                properties:
+                                  fsType:
+                                    description: 'fsType is the filesystem type to
+                                      mount. Must be a filesystem type supported by
+                                      the host operating system. Examples: "ext4",
+                                      "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                      if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                    type: string
+                                  readOnly:
+                                    description: 'readOnly defaults to false (read/write).
+                                      ReadOnly here will force the ReadOnly setting
+                                      in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                    type: boolean
+                                  secretRef:
+                                    description: 'secretRef is optional: points to
+                                      a secret object containing parameters used to
+                                      connect to OpenStack.'
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  volumeID:
+                                    description: 'volumeID used to identify the volume
+                                      in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                    type: string
+                                required:
+                                - volumeID
+                                type: object
+                              configMap:
+                                description: configMap represents a configMap that
+                                  should populate this volume
+                                properties:
+                                  defaultMode:
+                                    description: 'defaultMode is optional: mode bits
+                                      used to set permissions on created files by
+                                      default. Must be an octal value between 0000
+                                      and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values,
+                                      JSON requires decimal values for mode bits.
+                                      Defaults to 0644. Directories within the path
+                                      are not affected by this setting. This might
+                                      be in conflict with other options that affect
+                                      the file mode, like fsGroup, and the result
+                                      can be other mode bits set.'
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    description: items if unspecified, each key-value
+                                      pair in the Data field of the referenced ConfigMap
+                                      will be projected into the volume as a file
+                                      whose name is the key and content is the value.
+                                      If specified, the listed keys will be projected
+                                      into the specified paths, and unlisted keys
+                                      will not be present. If a key is specified which
+                                      is not present in the ConfigMap, the volume
+                                      setup will error unless it is marked optional.
+                                      Paths must be relative and may not contain the
+                                      '..' path or start with '..'.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: 'mode is Optional: mode bits
+                                            used to set permissions on this file.
+                                            Must be an octal value between 0000 and
+                                            0777 or a decimal value between 0 and
+                                            511. YAML accepts both octal and decimal
+                                            values, JSON requires decimal values for
+                                            mode bits. If not specified, the volume
+                                            defaultMode will be used. This might be
+                                            in conflict with other options that affect
+                                            the file mode, like fsGroup, and the result
+                                            can be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: path is the relative path of
+                                            the file to map the key to. May not be
+                                            an absolute path. May not contain the
+                                            path element '..'. May not start with
+                                            the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: optional specify whether the ConfigMap
+                                      or its keys must be defined
+                                    type: boolean
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              csi:
+                                description: csi (Container Storage Interface) represents
+                                  ephemeral storage that is handled by certain external
+                                  CSI drivers (Beta feature).
+                                properties:
+                                  driver:
+                                    description: driver is the name of the CSI driver
+                                      that handles this volume. Consult with your
+                                      admin for the correct name as registered in
+                                      the cluster.
+                                    type: string
+                                  fsType:
+                                    description: fsType to mount. Ex. "ext4", "xfs",
+                                      "ntfs". If not provided, the empty value is
+                                      passed to the associated CSI driver which will
+                                      determine the default filesystem to apply.
+                                    type: string
+                                  nodePublishSecretRef:
+                                    description: nodePublishSecretRef is a reference
+                                      to the secret object containing sensitive information
+                                      to pass to the CSI driver to complete the CSI
+                                      NodePublishVolume and NodeUnpublishVolume calls.
+                                      This field is optional, and  may be empty if
+                                      no secret is required. If the secret object
+                                      contains more than one secret, all secret references
+                                      are passed.
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  readOnly:
+                                    description: readOnly specifies a read-only configuration
+                                      for the volume. Defaults to false (read/write).
+                                    type: boolean
+                                  volumeAttributes:
+                                    additionalProperties:
+                                      type: string
+                                    description: volumeAttributes stores driver-specific
+                                      properties that are passed to the CSI driver.
+                                      Consult your driver's documentation for supported
+                                      values.
+                                    type: object
+                                required:
+                                - driver
+                                type: object
+                              downwardAPI:
+                                description: downwardAPI represents downward API about
+                                  the pod that should populate this volume
+                                properties:
+                                  defaultMode:
+                                    description: 'Optional: mode bits to use on created
+                                      files by default. Must be a Optional: mode bits
+                                      used to set permissions on created files by
+                                      default. Must be an octal value between 0000
+                                      and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values,
+                                      JSON requires decimal values for mode bits.
+                                      Defaults to 0644. Directories within the path
+                                      are not affected by this setting. This might
+                                      be in conflict with other options that affect
+                                      the file mode, like fsGroup, and the result
+                                      can be other mode bits set.'
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    description: Items is a list of downward API volume
+                                      file
+                                    items:
+                                      description: DownwardAPIVolumeFile represents
+                                        information to create the file containing
+                                        the pod field
+                                      properties:
+                                        fieldRef:
+                                          description: 'Required: Selects a field
+                                            of the pod: only annotations, labels,
+                                            name and namespace are supported.'
+                                          properties:
+                                            apiVersion:
+                                              description: Version of the schema the
+                                                FieldPath is written in terms of,
+                                                defaults to "v1".
+                                              type: string
+                                            fieldPath:
+                                              description: Path of the field to select
+                                                in the specified API version.
+                                              type: string
+                                          required:
+                                          - fieldPath
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        mode:
+                                          description: 'Optional: mode bits used to
+                                            set permissions on this file, must be
+                                            an octal value between 0000 and 0777 or
+                                            a decimal value between 0 and 511. YAML
+                                            accepts both octal and decimal values,
+                                            JSON requires decimal values for mode
+                                            bits. If not specified, the volume defaultMode
+                                            will be used. This might be in conflict
+                                            with other options that affect the file
+                                            mode, like fsGroup, and the result can
+                                            be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: 'Required: Path is  the relative
+                                            path name of the file to be created. Must
+                                            not be absolute or contain the ''..''
+                                            path. Must be utf-8 encoded. The first
+                                            item of the relative path must not start
+                                            with ''..'''
+                                          type: string
+                                        resourceFieldRef:
+                                          description: 'Selects a resource of the
+                                            container: only resources limits and requests
+                                            (limits.cpu, limits.memory, requests.cpu
+                                            and requests.memory) are currently supported.'
+                                          properties:
+                                            containerName:
+                                              description: 'Container name: required
+                                                for volumes, optional for env vars'
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Specifies the output format
+                                                of the exposed resources, defaults
+                                                to "1"
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              description: 'Required: resource to
+                                                select'
+                                              type: string
+                                          required:
+                                          - resource
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      required:
+                                      - path
+                                      type: object
+                                    type: array
+                                type: object
+                              emptyDir:
+                                description: 'emptyDir represents a temporary directory
+                                  that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                properties:
+                                  medium:
+                                    description: 'medium represents what type of storage
+                                      medium should back this directory. The default
+                                      is "" which means to use the node''s default
+                                      medium. Must be an empty string (default) or
+                                      Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                    type: string
+                                  sizeLimit:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: 'sizeLimit is the total amount of
+                                      local storage required for this EmptyDir volume.
+                                      The size limit is also applicable for memory
+                                      medium. The maximum usage on memory medium EmptyDir
+                                      would be the minimum value between the SizeLimit
+                                      specified here and the sum of memory limits
+                                      of all containers in a pod. The default is nil
+                                      which means that the limit is undefined. More
+                                      info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                type: object
+                              ephemeral:
+                                description: "ephemeral represents a volume that is
+                                  handled by a cluster storage driver. The volume's
+                                  lifecycle is tied to the pod that defines it - it
+                                  will be created before the pod starts, and deleted
+                                  when the pod is removed. \n Use this if: a) the
+                                  volume is only needed while the pod runs, b) features
+                                  of normal volumes like restoring from snapshot or
+                                  capacity tracking are needed, c) the storage driver
+                                  is specified through a storage class, and d) the
+                                  storage driver supports dynamic volume provisioning
+                                  through a PersistentVolumeClaim (see EphemeralVolumeSource
+                                  for more information on the connection between this
+                                  volume type and PersistentVolumeClaim). \n Use PersistentVolumeClaim
+                                  or one of the vendor-specific APIs for volumes that
+                                  persist for longer than the lifecycle of an individual
+                                  pod. \n Use CSI for light-weight local ephemeral
+                                  volumes if the CSI driver is meant to be used that
+                                  way - see the documentation of the driver for more
+                                  information. \n A pod can use both types of ephemeral
+                                  volumes and persistent volumes at the same time."
+                                properties:
+                                  volumeClaimTemplate:
+                                    description: "Will be used to create a stand-alone
+                                      PVC to provision the volume. The pod in which
+                                      this EphemeralVolumeSource is embedded will
+                                      be the owner of the PVC, i.e. the PVC will be
+                                      deleted together with the pod.  The name of
+                                      the PVC will be `<pod name>-<volume name>` where
+                                      `<volume name>` is the name from the `PodSpec.Volumes`
+                                      array entry. Pod validation will reject the
+                                      pod if the concatenated name is not valid for
+                                      a PVC (for example, too long). \n An existing
+                                      PVC with that name that is not owned by the
+                                      pod will *not* be used for the pod to avoid
+                                      using an unrelated volume by mistake. Starting
+                                      the pod is then blocked until the unrelated
+                                      PVC is removed. If such a pre-created PVC is
+                                      meant to be used by the pod, the PVC has to
+                                      updated with an owner reference to the pod once
+                                      the pod exists. Normally this should not be
+                                      necessary, but it may be useful when manually
+                                      reconstructing a broken cluster. \n This field
+                                      is read-only and no changes will be made by
+                                      Kubernetes to the PVC after it has been created.
+                                      \n Required, must not be nil."
+                                    properties:
+                                      metadata:
+                                        description: May contain labels and annotations
+                                          that will be copied into the PVC when creating
+                                          it. No other fields are allowed and will
+                                          be rejected during validation.
+                                        type: object
+                                      spec:
+                                        description: The specification for the PersistentVolumeClaim.
+                                          The entire content is copied unchanged into
+                                          the PVC that gets created from this template.
+                                          The same fields as in a PersistentVolumeClaim
+                                          are also valid here.
+                                        properties:
+                                          accessModes:
+                                            description: 'accessModes contains the
+                                              desired access modes the volume should
+                                              have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                            items:
+                                              type: string
+                                            type: array
+                                          dataSource:
+                                            description: 'dataSource field can be
+                                              used to specify either: * An existing
+                                              VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                              * An existing PVC (PersistentVolumeClaim)
+                                              If the provisioner or an external controller
+                                              can support the specified data source,
+                                              it will create a new volume based on
+                                              the contents of the specified data source.
+                                              If the AnyVolumeDataSource feature gate
+                                              is enabled, this field will always have
+                                              the same contents as the DataSourceRef
+                                              field.'
+                                            properties:
+                                              apiGroup:
+                                                description: APIGroup is the group
+                                                  for the resource being referenced.
+                                                  If APIGroup is not specified, the
+                                                  specified Kind must be in the core
+                                                  API group. For any other third-party
+                                                  types, APIGroup is required.
+                                                type: string
+                                              kind:
+                                                description: Kind is the type of resource
+                                                  being referenced
+                                                type: string
+                                              name:
+                                                description: Name is the name of resource
+                                                  being referenced
+                                                type: string
+                                            required:
+                                            - kind
+                                            - name
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          dataSourceRef:
+                                            description: 'dataSourceRef specifies
+                                              the object from which to populate the
+                                              volume with data, if a non-empty volume
+                                              is desired. This may be any local object
+                                              from a non-empty API group (non core
+                                              object) or a PersistentVolumeClaim object.
+                                              When this field is specified, volume
+                                              binding will only succeed if the type
+                                              of the specified object matches some
+                                              installed volume populator or dynamic
+                                              provisioner. This field will replace
+                                              the functionality of the DataSource
+                                              field and as such if both fields are
+                                              non-empty, they must have the same value.
+                                              For backwards compatibility, both fields
+                                              (DataSource and DataSourceRef) will
+                                              be set to the same value automatically
+                                              if one of them is empty and the other
+                                              is non-empty. There are two important
+                                              differences between DataSource and DataSourceRef:
+                                              * While DataSource only allows two specific
+                                              types of objects, DataSourceRef allows
+                                              any non-core object, as well as PersistentVolumeClaim
+                                              objects. * While DataSource ignores
+                                              disallowed values (dropping them), DataSourceRef
+                                              preserves all values, and generates
+                                              an error if a disallowed value is specified.
+                                              (Beta) Using this field requires the
+                                              AnyVolumeDataSource feature gate to
+                                              be enabled.'
+                                            properties:
+                                              apiGroup:
+                                                description: APIGroup is the group
+                                                  for the resource being referenced.
+                                                  If APIGroup is not specified, the
+                                                  specified Kind must be in the core
+                                                  API group. For any other third-party
+                                                  types, APIGroup is required.
+                                                type: string
+                                              kind:
+                                                description: Kind is the type of resource
+                                                  being referenced
+                                                type: string
+                                              name:
+                                                description: Name is the name of resource
+                                                  being referenced
+                                                type: string
+                                            required:
+                                            - kind
+                                            - name
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          resources:
+                                            description: 'resources represents the
+                                              minimum resources the volume should
+                                              have. If RecoverVolumeExpansionFailure
+                                              feature is enabled users are allowed
+                                              to specify resource requirements that
+                                              are lower than previous value but must
+                                              still be higher than capacity recorded
+                                              in the status field of the claim. More
+                                              info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                            properties:
+                                              limits:
+                                                additionalProperties:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                description: 'Limits describes the
+                                                  maximum amount of compute resources
+                                                  allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                type: object
+                                              requests:
+                                                additionalProperties:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                description: 'Requests describes the
+                                                  minimum amount of compute resources
+                                                  required. If Requests is omitted
+                                                  for a container, it defaults to
+                                                  Limits if that is explicitly specified,
+                                                  otherwise to an implementation-defined
+                                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                type: object
+                                            type: object
+                                          selector:
+                                            description: selector is a label query
+                                              over volumes to consider for binding.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents
+                                                        a key's relationship to a
+                                                        set of values. Valid operators
+                                                        are In, NotIn, Exists and
+                                                        DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array
+                                                        of string values. If the operator
+                                                        is In or NotIn, the values
+                                                        array must be non-empty. If
+                                                        the operator is Exists or
+                                                        DoesNotExist, the values array
+                                                        must be empty. This array
+                                                        is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs. A single {key,value}
+                                                  in the matchLabels map is equivalent
+                                                  to an element of matchExpressions,
+                                                  whose key field is "key", the operator
+                                                  is "In", and the values array contains
+                                                  only "value". The requirements are
+                                                  ANDed.
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          storageClassName:
+                                            description: 'storageClassName is the
+                                              name of the StorageClass required by
+                                              the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                            type: string
+                                          volumeMode:
+                                            description: volumeMode defines what type
+                                              of volume is required by the claim.
+                                              Value of Filesystem is implied when
+                                              not included in claim spec.
+                                            type: string
+                                          volumeName:
+                                            description: volumeName is the binding
+                                              reference to the PersistentVolume backing
+                                              this claim.
+                                            type: string
+                                        type: object
+                                    required:
+                                    - spec
+                                    type: object
+                                type: object
+                              fc:
+                                description: fc represents a Fibre Channel resource
+                                  that is attached to a kubelet's host machine and
+                                  then exposed to the pod.
+                                properties:
+                                  fsType:
+                                    description: 'fsType is the filesystem type to
+                                      mount. Must be a filesystem type supported by
+                                      the host operating system. Ex. "ext4", "xfs",
+                                      "ntfs". Implicitly inferred to be "ext4" if
+                                      unspecified. TODO: how do we prevent errors
+                                      in the filesystem from compromising the machine'
+                                    type: string
+                                  lun:
+                                    description: 'lun is Optional: FC target lun number'
+                                    format: int32
+                                    type: integer
+                                  readOnly:
+                                    description: 'readOnly is Optional: Defaults to
+                                      false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.'
+                                    type: boolean
+                                  targetWWNs:
+                                    description: 'targetWWNs is Optional: FC target
+                                      worldwide names (WWNs)'
+                                    items:
+                                      type: string
+                                    type: array
+                                  wwids:
+                                    description: 'wwids Optional: FC volume world
+                                      wide identifiers (wwids) Either wwids or combination
+                                      of targetWWNs and lun must be set, but not both
+                                      simultaneously.'
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              flexVolume:
+                                description: flexVolume represents a generic volume
+                                  resource that is provisioned/attached using an exec
+                                  based plugin.
+                                properties:
+                                  driver:
+                                    description: driver is the name of the driver
+                                      to use for this volume.
+                                    type: string
+                                  fsType:
+                                    description: fsType is the filesystem type to
+                                      mount. Must be a filesystem type supported by
+                                      the host operating system. Ex. "ext4", "xfs",
+                                      "ntfs". The default filesystem depends on FlexVolume
+                                      script.
+                                    type: string
+                                  options:
+                                    additionalProperties:
+                                      type: string
+                                    description: 'options is Optional: this field
+                                      holds extra command options if any.'
+                                    type: object
+                                  readOnly:
+                                    description: 'readOnly is Optional: defaults to
+                                      false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.'
+                                    type: boolean
+                                  secretRef:
+                                    description: 'secretRef is Optional: secretRef
+                                      is reference to the secret object containing
+                                      sensitive information to pass to the plugin
+                                      scripts. This may be empty if no secret object
+                                      is specified. If the secret object contains
+                                      more than one secret, all secrets are passed
+                                      to the plugin scripts.'
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                required:
+                                - driver
+                                type: object
+                              flocker:
+                                description: flocker represents a Flocker volume attached
+                                  to a kubelet's host machine. This depends on the
+                                  Flocker control service being running
+                                properties:
+                                  datasetName:
+                                    description: datasetName is Name of the dataset
+                                      stored as metadata -> name on the dataset for
+                                      Flocker should be considered as deprecated
+                                    type: string
+                                  datasetUUID:
+                                    description: datasetUUID is the UUID of the dataset.
+                                      This is unique identifier of a Flocker dataset
+                                    type: string
+                                type: object
+                              gcePersistentDisk:
+                                description: 'gcePersistentDisk represents a GCE Disk
+                                  resource that is attached to a kubelet''s host machine
+                                  and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                properties:
+                                  fsType:
+                                    description: 'fsType is filesystem type of the
+                                      volume that you want to mount. Tip: Ensure that
+                                      the filesystem type is supported by the host
+                                      operating system. Examples: "ext4", "xfs", "ntfs".
+                                      Implicitly inferred to be "ext4" if unspecified.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                      TODO: how do we prevent errors in the filesystem
+                                      from compromising the machine'
+                                    type: string
+                                  partition:
+                                    description: 'partition is the partition in the
+                                      volume that you want to mount. If omitted, the
+                                      default is to mount by volume name. Examples:
+                                      For volume /dev/sda1, you specify the partition
+                                      as "1". Similarly, the volume partition for
+                                      /dev/sda is "0" (or you can leave the property
+                                      empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                    format: int32
+                                    type: integer
+                                  pdName:
+                                    description: 'pdName is unique name of the PD
+                                      resource in GCE. Used to identify the disk in
+                                      GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                    type: string
+                                  readOnly:
+                                    description: 'readOnly here will force the ReadOnly
+                                      setting in VolumeMounts. Defaults to false.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                    type: boolean
+                                required:
+                                - pdName
+                                type: object
+                              gitRepo:
+                                description: 'gitRepo represents a git repository
+                                  at a particular revision. DEPRECATED: GitRepo is
+                                  deprecated. To provision a container with a git
+                                  repo, mount an EmptyDir into an InitContainer that
+                                  clones the repo using git, then mount the EmptyDir
+                                  into the Pod''s container.'
+                                properties:
+                                  directory:
+                                    description: directory is the target directory
+                                      name. Must not contain or start with '..'.  If
+                                      '.' is supplied, the volume directory will be
+                                      the git repository.  Otherwise, if specified,
+                                      the volume will contain the git repository in
+                                      the subdirectory with the given name.
+                                    type: string
+                                  repository:
+                                    description: repository is the URL
+                                    type: string
+                                  revision:
+                                    description: revision is the commit hash for the
+                                      specified revision.
+                                    type: string
+                                required:
+                                - repository
+                                type: object
+                              glusterfs:
+                                description: 'glusterfs represents a Glusterfs mount
+                                  on the host that shares a pod''s lifetime. More
+                                  info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                                properties:
+                                  endpoints:
+                                    description: 'endpoints is the endpoint name that
+                                      details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                    type: string
+                                  path:
+                                    description: 'path is the Glusterfs volume path.
+                                      More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                    type: string
+                                  readOnly:
+                                    description: 'readOnly here will force the Glusterfs
+                                      volume to be mounted with read-only permissions.
+                                      Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                    type: boolean
+                                required:
+                                - endpoints
+                                - path
+                                type: object
+                              hostPath:
+                                description: 'hostPath represents a pre-existing file
+                                  or directory on the host machine that is directly
+                                  exposed to the container. This is generally used
+                                  for system agents or other privileged things that
+                                  are allowed to see the host machine. Most containers
+                                  will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                  --- TODO(jonesdl) We need to restrict who can use
+                                  host directory mounts and who can/can not mount
+                                  host directories as read/write.'
+                                properties:
+                                  path:
+                                    description: 'path of the directory on the host.
+                                      If the path is a symlink, it will follow the
+                                      link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                    type: string
+                                  type:
+                                    description: 'type for HostPath Volume Defaults
+                                      to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                    type: string
+                                required:
+                                - path
+                                type: object
+                              iscsi:
+                                description: 'iscsi represents an ISCSI Disk resource
+                                  that is attached to a kubelet''s host machine and
+                                  then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                                properties:
+                                  chapAuthDiscovery:
+                                    description: chapAuthDiscovery defines whether
+                                      support iSCSI Discovery CHAP authentication
+                                    type: boolean
+                                  chapAuthSession:
+                                    description: chapAuthSession defines whether support
+                                      iSCSI Session CHAP authentication
+                                    type: boolean
+                                  fsType:
+                                    description: 'fsType is the filesystem type of
+                                      the volume that you want to mount. Tip: Ensure
+                                      that the filesystem type is supported by the
+                                      host operating system. Examples: "ext4", "xfs",
+                                      "ntfs". Implicitly inferred to be "ext4" if
+                                      unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                      TODO: how do we prevent errors in the filesystem
+                                      from compromising the machine'
+                                    type: string
+                                  initiatorName:
+                                    description: initiatorName is the custom iSCSI
+                                      Initiator Name. If initiatorName is specified
+                                      with iscsiInterface simultaneously, new iSCSI
+                                      interface <target portal>:<volume name> will
+                                      be created for the connection.
+                                    type: string
+                                  iqn:
+                                    description: iqn is the target iSCSI Qualified
+                                      Name.
+                                    type: string
+                                  iscsiInterface:
+                                    description: iscsiInterface is the interface Name
+                                      that uses an iSCSI transport. Defaults to 'default'
+                                      (tcp).
+                                    type: string
+                                  lun:
+                                    description: lun represents iSCSI Target Lun number.
+                                    format: int32
+                                    type: integer
+                                  portals:
+                                    description: portals is the iSCSI Target Portal
+                                      List. The portal is either an IP or ip_addr:port
+                                      if the port is other than default (typically
+                                      TCP ports 860 and 3260).
+                                    items:
+                                      type: string
+                                    type: array
+                                  readOnly:
+                                    description: readOnly here will force the ReadOnly
+                                      setting in VolumeMounts. Defaults to false.
+                                    type: boolean
+                                  secretRef:
+                                    description: secretRef is the CHAP Secret for
+                                      iSCSI target and initiator authentication
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  targetPortal:
+                                    description: targetPortal is iSCSI Target Portal.
+                                      The Portal is either an IP or ip_addr:port if
+                                      the port is other than default (typically TCP
+                                      ports 860 and 3260).
+                                    type: string
+                                required:
+                                - iqn
+                                - lun
+                                - targetPortal
+                                type: object
+                              name:
+                                description: 'name of the volume. Must be a DNS_LABEL
+                                  and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              nfs:
+                                description: 'nfs represents an NFS mount on the host
+                                  that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                properties:
+                                  path:
+                                    description: 'path that is exported by the NFS
+                                      server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                    type: string
+                                  readOnly:
+                                    description: 'readOnly here will force the NFS
+                                      export to be mounted with read-only permissions.
+                                      Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                    type: boolean
+                                  server:
+                                    description: 'server is the hostname or IP address
+                                      of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                    type: string
+                                required:
+                                - path
+                                - server
+                                type: object
+                              persistentVolumeClaim:
+                                description: 'persistentVolumeClaimVolumeSource represents
+                                  a reference to a PersistentVolumeClaim in the same
+                                  namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                properties:
+                                  claimName:
+                                    description: 'claimName is the name of a PersistentVolumeClaim
+                                      in the same namespace as the pod using this
+                                      volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                    type: string
+                                  readOnly:
+                                    description: readOnly Will force the ReadOnly
+                                      setting in VolumeMounts. Default false.
+                                    type: boolean
+                                required:
+                                - claimName
+                                type: object
+                              photonPersistentDisk:
+                                description: photonPersistentDisk represents a PhotonController
+                                  persistent disk attached and mounted on kubelets
+                                  host machine
+                                properties:
+                                  fsType:
+                                    description: fsType is the filesystem type to
+                                      mount. Must be a filesystem type supported by
+                                      the host operating system. Ex. "ext4", "xfs",
+                                      "ntfs". Implicitly inferred to be "ext4" if
+                                      unspecified.
+                                    type: string
+                                  pdID:
+                                    description: pdID is the ID that identifies Photon
+                                      Controller persistent disk
+                                    type: string
+                                required:
+                                - pdID
+                                type: object
+                              portworxVolume:
+                                description: portworxVolume represents a portworx
+                                  volume attached and mounted on kubelets host machine
+                                properties:
+                                  fsType:
+                                    description: fSType represents the filesystem
+                                      type to mount Must be a filesystem type supported
+                                      by the host operating system. Ex. "ext4", "xfs".
+                                      Implicitly inferred to be "ext4" if unspecified.
+                                    type: string
+                                  readOnly:
+                                    description: readOnly defaults to false (read/write).
+                                      ReadOnly here will force the ReadOnly setting
+                                      in VolumeMounts.
+                                    type: boolean
+                                  volumeID:
+                                    description: volumeID uniquely identifies a Portworx
+                                      volume
+                                    type: string
+                                required:
+                                - volumeID
+                                type: object
+                              projected:
+                                description: projected items for all in one resources
+                                  secrets, configmaps, and downward API
+                                properties:
+                                  defaultMode:
+                                    description: defaultMode are the mode bits used
+                                      to set permissions on created files by default.
+                                      Must be an octal value between 0000 and 0777
+                                      or a decimal value between 0 and 511. YAML accepts
+                                      both octal and decimal values, JSON requires
+                                      decimal values for mode bits. Directories within
+                                      the path are not affected by this setting. This
+                                      might be in conflict with other options that
+                                      affect the file mode, like fsGroup, and the
+                                      result can be other mode bits set.
+                                    format: int32
+                                    type: integer
+                                  sources:
+                                    description: sources is the list of volume projections
+                                    items:
+                                      description: Projection that may be projected
+                                        along with other supported volume types
+                                      properties:
+                                        configMap:
+                                          description: configMap information about
+                                            the configMap data to project
+                                          properties:
+                                            items:
+                                              description: items if unspecified, each
+                                                key-value pair in the Data field of
+                                                the referenced ConfigMap will be projected
+                                                into the volume as a file whose name
+                                                is the key and content is the value.
+                                                If specified, the listed keys will
+                                                be projected into the specified paths,
+                                                and unlisted keys will not be present.
+                                                If a key is specified which is not
+                                                present in the ConfigMap, the volume
+                                                setup will error unless it is marked
+                                                optional. Paths must be relative and
+                                                may not contain the '..' path or start
+                                                with '..'.
+                                              items:
+                                                description: Maps a string key to
+                                                  a path within a volume.
+                                                properties:
+                                                  key:
+                                                    description: key is the key to
+                                                      project.
+                                                    type: string
+                                                  mode:
+                                                    description: 'mode is Optional:
+                                                      mode bits used to set permissions
+                                                      on this file. Must be an octal
+                                                      value between 0000 and 0777
+                                                      or a decimal value between 0
+                                                      and 511. YAML accepts both octal
+                                                      and decimal values, JSON requires
+                                                      decimal values for mode bits.
+                                                      If not specified, the volume
+                                                      defaultMode will be used. This
+                                                      might be in conflict with other
+                                                      options that affect the file
+                                                      mode, like fsGroup, and the
+                                                      result can be other mode bits
+                                                      set.'
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    description: path is the relative
+                                                      path of the file to map the
+                                                      key to. May not be an absolute
+                                                      path. May not contain the path
+                                                      element '..'. May not start
+                                                      with the string '..'.
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                type: object
+                                              type: array
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: optional specify whether
+                                                the ConfigMap or its keys must be
+                                                defined
+                                              type: boolean
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        downwardAPI:
+                                          description: downwardAPI information about
+                                            the downwardAPI data to project
+                                          properties:
+                                            items:
+                                              description: Items is a list of DownwardAPIVolume
+                                                file
+                                              items:
+                                                description: DownwardAPIVolumeFile
+                                                  represents information to create
+                                                  the file containing the pod field
+                                                properties:
+                                                  fieldRef:
+                                                    description: 'Required: Selects
+                                                      a field of the pod: only annotations,
+                                                      labels, name and namespace are
+                                                      supported.'
+                                                    properties:
+                                                      apiVersion:
+                                                        description: Version of the
+                                                          schema the FieldPath is
+                                                          written in terms of, defaults
+                                                          to "v1".
+                                                        type: string
+                                                      fieldPath:
+                                                        description: Path of the field
+                                                          to select in the specified
+                                                          API version.
+                                                        type: string
+                                                    required:
+                                                    - fieldPath
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  mode:
+                                                    description: 'Optional: mode bits
+                                                      used to set permissions on this
+                                                      file, must be an octal value
+                                                      between 0000 and 0777 or a decimal
+                                                      value between 0 and 511. YAML
+                                                      accepts both octal and decimal
+                                                      values, JSON requires decimal
+                                                      values for mode bits. If not
+                                                      specified, the volume defaultMode
+                                                      will be used. This might be
+                                                      in conflict with other options
+                                                      that affect the file mode, like
+                                                      fsGroup, and the result can
+                                                      be other mode bits set.'
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    description: 'Required: Path is  the
+                                                      relative path name of the file
+                                                      to be created. Must not be absolute
+                                                      or contain the ''..'' path.
+                                                      Must be utf-8 encoded. The first
+                                                      item of the relative path must
+                                                      not start with ''..'''
+                                                    type: string
+                                                  resourceFieldRef:
+                                                    description: 'Selects a resource
+                                                      of the container: only resources
+                                                      limits and requests (limits.cpu,
+                                                      limits.memory, requests.cpu
+                                                      and requests.memory) are currently
+                                                      supported.'
+                                                    properties:
+                                                      containerName:
+                                                        description: 'Container name:
+                                                          required for volumes, optional
+                                                          for env vars'
+                                                        type: string
+                                                      divisor:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        description: Specifies the
+                                                          output format of the exposed
+                                                          resources, defaults to "1"
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      resource:
+                                                        description: 'Required: resource
+                                                          to select'
+                                                        type: string
+                                                    required:
+                                                    - resource
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                required:
+                                                - path
+                                                type: object
+                                              type: array
+                                          type: object
+                                        secret:
+                                          description: secret information about the
+                                            secret data to project
+                                          properties:
+                                            items:
+                                              description: items if unspecified, each
+                                                key-value pair in the Data field of
+                                                the referenced Secret will be projected
+                                                into the volume as a file whose name
+                                                is the key and content is the value.
+                                                If specified, the listed keys will
+                                                be projected into the specified paths,
+                                                and unlisted keys will not be present.
+                                                If a key is specified which is not
+                                                present in the Secret, the volume
+                                                setup will error unless it is marked
+                                                optional. Paths must be relative and
+                                                may not contain the '..' path or start
+                                                with '..'.
+                                              items:
+                                                description: Maps a string key to
+                                                  a path within a volume.
+                                                properties:
+                                                  key:
+                                                    description: key is the key to
+                                                      project.
+                                                    type: string
+                                                  mode:
+                                                    description: 'mode is Optional:
+                                                      mode bits used to set permissions
+                                                      on this file. Must be an octal
+                                                      value between 0000 and 0777
+                                                      or a decimal value between 0
+                                                      and 511. YAML accepts both octal
+                                                      and decimal values, JSON requires
+                                                      decimal values for mode bits.
+                                                      If not specified, the volume
+                                                      defaultMode will be used. This
+                                                      might be in conflict with other
+                                                      options that affect the file
+                                                      mode, like fsGroup, and the
+                                                      result can be other mode bits
+                                                      set.'
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    description: path is the relative
+                                                      path of the file to map the
+                                                      key to. May not be an absolute
+                                                      path. May not contain the path
+                                                      element '..'. May not start
+                                                      with the string '..'.
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                type: object
+                                              type: array
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: optional field specify
+                                                whether the Secret or its key must
+                                                be defined
+                                              type: boolean
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        serviceAccountToken:
+                                          description: serviceAccountToken is information
+                                            about the serviceAccountToken data to
+                                            project
+                                          properties:
+                                            audience:
+                                              description: audience is the intended
+                                                audience of the token. A recipient
+                                                of a token must identify itself with
+                                                an identifier specified in the audience
+                                                of the token, and otherwise should
+                                                reject the token. The audience defaults
+                                                to the identifier of the apiserver.
+                                              type: string
+                                            expirationSeconds:
+                                              description: expirationSeconds is the
+                                                requested duration of validity of
+                                                the service account token. As the
+                                                token approaches expiration, the kubelet
+                                                volume plugin will proactively rotate
+                                                the service account token. The kubelet
+                                                will start trying to rotate the token
+                                                if the token is older than 80 percent
+                                                of its time to live or if the token
+                                                is older than 24 hours.Defaults to
+                                                1 hour and must be at least 10 minutes.
+                                              format: int64
+                                              type: integer
+                                            path:
+                                              description: path is the path relative
+                                                to the mount point of the file to
+                                                project the token into.
+                                              type: string
+                                          required:
+                                          - path
+                                          type: object
+                                      type: object
+                                    type: array
+                                type: object
+                              quobyte:
+                                description: quobyte represents a Quobyte mount on
+                                  the host that shares a pod's lifetime
+                                properties:
+                                  group:
+                                    description: group to map volume access to Default
+                                      is no group
+                                    type: string
+                                  readOnly:
+                                    description: readOnly here will force the Quobyte
+                                      volume to be mounted with read-only permissions.
+                                      Defaults to false.
+                                    type: boolean
+                                  registry:
+                                    description: registry represents a single or multiple
+                                      Quobyte Registry services specified as a string
+                                      as host:port pair (multiple entries are separated
+                                      with commas) which acts as the central registry
+                                      for volumes
+                                    type: string
+                                  tenant:
+                                    description: tenant owning the given Quobyte volume
+                                      in the Backend Used with dynamically provisioned
+                                      Quobyte volumes, value is set by the plugin
+                                    type: string
+                                  user:
+                                    description: user to map volume access to Defaults
+                                      to serivceaccount user
+                                    type: string
+                                  volume:
+                                    description: volume is a string that references
+                                      an already created Quobyte volume by name.
+                                    type: string
+                                required:
+                                - registry
+                                - volume
+                                type: object
+                              rbd:
+                                description: 'rbd represents a Rados Block Device
+                                  mount on the host that shares a pod''s lifetime.
+                                  More info: https://examples.k8s.io/volumes/rbd/README.md'
+                                properties:
+                                  fsType:
+                                    description: 'fsType is the filesystem type of
+                                      the volume that you want to mount. Tip: Ensure
+                                      that the filesystem type is supported by the
+                                      host operating system. Examples: "ext4", "xfs",
+                                      "ntfs". Implicitly inferred to be "ext4" if
+                                      unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                      TODO: how do we prevent errors in the filesystem
+                                      from compromising the machine'
+                                    type: string
+                                  image:
+                                    description: 'image is the rados image name. More
+                                      info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                    type: string
+                                  keyring:
+                                    description: 'keyring is the path to key ring
+                                      for RBDUser. Default is /etc/ceph/keyring. More
+                                      info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                    type: string
+                                  monitors:
+                                    description: 'monitors is a collection of Ceph
+                                      monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                    items:
+                                      type: string
+                                    type: array
+                                  pool:
+                                    description: 'pool is the rados pool name. Default
+                                      is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                    type: string
+                                  readOnly:
+                                    description: 'readOnly here will force the ReadOnly
+                                      setting in VolumeMounts. Defaults to false.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                    type: boolean
+                                  secretRef:
+                                    description: 'secretRef is name of the authentication
+                                      secret for RBDUser. If provided overrides keyring.
+                                      Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  user:
+                                    description: 'user is the rados user name. Default
+                                      is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                    type: string
+                                required:
+                                - image
+                                - monitors
+                                type: object
+                              scaleIO:
+                                description: scaleIO represents a ScaleIO persistent
+                                  volume attached and mounted on Kubernetes nodes.
+                                properties:
+                                  fsType:
+                                    description: fsType is the filesystem type to
+                                      mount. Must be a filesystem type supported by
+                                      the host operating system. Ex. "ext4", "xfs",
+                                      "ntfs". Default is "xfs".
+                                    type: string
+                                  gateway:
+                                    description: gateway is the host address of the
+                                      ScaleIO API Gateway.
+                                    type: string
+                                  protectionDomain:
+                                    description: protectionDomain is the name of the
+                                      ScaleIO Protection Domain for the configured
+                                      storage.
+                                    type: string
+                                  readOnly:
+                                    description: readOnly Defaults to false (read/write).
+                                      ReadOnly here will force the ReadOnly setting
+                                      in VolumeMounts.
+                                    type: boolean
+                                  secretRef:
+                                    description: secretRef references to the secret
+                                      for ScaleIO user and other sensitive information.
+                                      If this is not provided, Login operation will
+                                      fail.
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  sslEnabled:
+                                    description: sslEnabled Flag enable/disable SSL
+                                      communication with Gateway, default false
+                                    type: boolean
+                                  storageMode:
+                                    description: storageMode indicates whether the
+                                      storage for a volume should be ThickProvisioned
+                                      or ThinProvisioned. Default is ThinProvisioned.
+                                    type: string
+                                  storagePool:
+                                    description: storagePool is the ScaleIO Storage
+                                      Pool associated with the protection domain.
+                                    type: string
+                                  system:
+                                    description: system is the name of the storage
+                                      system as configured in ScaleIO.
+                                    type: string
+                                  volumeName:
+                                    description: volumeName is the name of a volume
+                                      already created in the ScaleIO system that is
+                                      associated with this volume source.
+                                    type: string
+                                required:
+                                - gateway
+                                - secretRef
+                                - system
+                                type: object
+                              secret:
+                                description: 'secret represents a secret that should
+                                  populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                properties:
+                                  defaultMode:
+                                    description: 'defaultMode is Optional: mode bits
+                                      used to set permissions on created files by
+                                      default. Must be an octal value between 0000
+                                      and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values,
+                                      JSON requires decimal values for mode bits.
+                                      Defaults to 0644. Directories within the path
+                                      are not affected by this setting. This might
+                                      be in conflict with other options that affect
+                                      the file mode, like fsGroup, and the result
+                                      can be other mode bits set.'
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    description: items If unspecified, each key-value
+                                      pair in the Data field of the referenced Secret
+                                      will be projected into the volume as a file
+                                      whose name is the key and content is the value.
+                                      If specified, the listed keys will be projected
+                                      into the specified paths, and unlisted keys
+                                      will not be present. If a key is specified which
+                                      is not present in the Secret, the volume setup
+                                      will error unless it is marked optional. Paths
+                                      must be relative and may not contain the '..'
+                                      path or start with '..'.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: 'mode is Optional: mode bits
+                                            used to set permissions on this file.
+                                            Must be an octal value between 0000 and
+                                            0777 or a decimal value between 0 and
+                                            511. YAML accepts both octal and decimal
+                                            values, JSON requires decimal values for
+                                            mode bits. If not specified, the volume
+                                            defaultMode will be used. This might be
+                                            in conflict with other options that affect
+                                            the file mode, like fsGroup, and the result
+                                            can be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: path is the relative path of
+                                            the file to map the key to. May not be
+                                            an absolute path. May not contain the
+                                            path element '..'. May not start with
+                                            the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                  optional:
+                                    description: optional field specify whether the
+                                      Secret or its keys must be defined
+                                    type: boolean
+                                  secretName:
+                                    description: 'secretName is the name of the secret
+                                      in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                    type: string
+                                type: object
+                              storageos:
+                                description: storageOS represents a StorageOS volume
+                                  attached and mounted on Kubernetes nodes.
+                                properties:
+                                  fsType:
+                                    description: fsType is the filesystem type to
+                                      mount. Must be a filesystem type supported by
+                                      the host operating system. Ex. "ext4", "xfs",
+                                      "ntfs". Implicitly inferred to be "ext4" if
+                                      unspecified.
+                                    type: string
+                                  readOnly:
+                                    description: readOnly defaults to false (read/write).
+                                      ReadOnly here will force the ReadOnly setting
+                                      in VolumeMounts.
+                                    type: boolean
+                                  secretRef:
+                                    description: secretRef specifies the secret to
+                                      use for obtaining the StorageOS API credentials.  If
+                                      not specified, default values will be attempted.
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  volumeName:
+                                    description: volumeName is the human-readable
+                                      name of the StorageOS volume.  Volume names
+                                      are only unique within a namespace.
+                                    type: string
+                                  volumeNamespace:
+                                    description: volumeNamespace specifies the scope
+                                      of the volume within StorageOS.  If no namespace
+                                      is specified then the Pod's namespace will be
+                                      used.  This allows the Kubernetes name scoping
+                                      to be mirrored within StorageOS for tighter
+                                      integration. Set VolumeName to any name to override
+                                      the default behaviour. Set to "default" if you
+                                      are not using namespaces within StorageOS. Namespaces
+                                      that do not pre-exist within StorageOS will
+                                      be created.
+                                    type: string
+                                type: object
+                              vsphereVolume:
+                                description: vsphereVolume represents a vSphere volume
+                                  attached and mounted on kubelets host machine
+                                properties:
+                                  fsType:
+                                    description: fsType is filesystem type to mount.
+                                      Must be a filesystem type supported by the host
+                                      operating system. Ex. "ext4", "xfs", "ntfs".
+                                      Implicitly inferred to be "ext4" if unspecified.
+                                    type: string
+                                  storagePolicyID:
+                                    description: storagePolicyID is the storage Policy
+                                      Based Management (SPBM) profile ID associated
+                                      with the StoragePolicyName.
+                                    type: string
+                                  storagePolicyName:
+                                    description: storagePolicyName is the storage
+                                      Policy Based Management (SPBM) profile name.
+                                    type: string
+                                  volumePath:
+                                    description: volumePath is the path that identifies
+                                      vSphere volume vmdk
+                                    type: string
+                                required:
+                                - volumePath
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                      required:
+                      - mounts
+                      - volumes
+                      type: object
+                    type: array
                   managed:
                     description: Managed - Whether the node is actually provisioned
                       (True) or should be treated as preprovisioned (False)

--- a/api/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
@@ -54,6 +54,1758 @@ spec:
                   ansibleVars:
                     description: AnsibleVars for configuring ansible
                     type: string
+                  extraMounts:
+                    description: ExtraMounts containing files which can be mounted
+                      into an Ansible Execution Pod
+                    items:
+                      description: VolMounts is the data structure used to expose
+                        Volumes and Mounts that can be added to a pod according to
+                        the defined Propagation policy
+                      properties:
+                        extraVolType:
+                          description: Label associated to a given extraMount
+                          type: string
+                        mounts:
+                          items:
+                            description: VolumeMount describes a mounting of a Volume
+                              within a container.
+                            properties:
+                              mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.  Must not contain ':'.
+                                type: string
+                              mountPropagation:
+                                description: mountPropagation determines how mounts
+                                  are propagated from the host to container and the
+                                  other way around. When not set, MountPropagationNone
+                                  is used. This field is beta in 1.10.
+                                type: string
+                              name:
+                                description: This must match the Name of a Volume.
+                                type: string
+                              readOnly:
+                                description: Mounted read-only if true, read-write
+                                  otherwise (false or unspecified). Defaults to false.
+                                type: boolean
+                              subPath:
+                                description: Path within the volume from which the
+                                  container's volume should be mounted. Defaults to
+                                  "" (volume's root).
+                                type: string
+                              subPathExpr:
+                                description: Expanded path within the volume from
+                                  which the container's volume should be mounted.
+                                  Behaves similarly to SubPath but environment variable
+                                  references $(VAR_NAME) are expanded using the container's
+                                  environment. Defaults to "" (volume's root). SubPathExpr
+                                  and SubPath are mutually exclusive.
+                                type: string
+                            required:
+                            - mountPath
+                            - name
+                            type: object
+                          type: array
+                        propagation:
+                          description: Propagation defines which pod should mount
+                            the volume
+                          items:
+                            description: PropagationType identifies the Service, Group
+                              or instance (e.g. the backend) that receives an Extra
+                              Volume that can potentially be mounted
+                            type: string
+                          type: array
+                        volumes:
+                          items:
+                            description: Volume represents a named volume in a pod
+                              that may be accessed by any container in the pod.
+                            properties:
+                              awsElasticBlockStore:
+                                description: 'awsElasticBlockStore represents an AWS
+                                  Disk resource that is attached to a kubelet''s host
+                                  machine and then exposed to the pod. More info:
+                                  https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                properties:
+                                  fsType:
+                                    description: 'fsType is the filesystem type of
+                                      the volume that you want to mount. Tip: Ensure
+                                      that the filesystem type is supported by the
+                                      host operating system. Examples: "ext4", "xfs",
+                                      "ntfs". Implicitly inferred to be "ext4" if
+                                      unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                      TODO: how do we prevent errors in the filesystem
+                                      from compromising the machine'
+                                    type: string
+                                  partition:
+                                    description: 'partition is the partition in the
+                                      volume that you want to mount. If omitted, the
+                                      default is to mount by volume name. Examples:
+                                      For volume /dev/sda1, you specify the partition
+                                      as "1". Similarly, the volume partition for
+                                      /dev/sda is "0" (or you can leave the property
+                                      empty).'
+                                    format: int32
+                                    type: integer
+                                  readOnly:
+                                    description: 'readOnly value true will force the
+                                      readOnly setting in VolumeMounts. More info:
+                                      https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                    type: boolean
+                                  volumeID:
+                                    description: 'volumeID is unique ID of the persistent
+                                      disk resource in AWS (Amazon EBS volume). More
+                                      info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                    type: string
+                                required:
+                                - volumeID
+                                type: object
+                              azureDisk:
+                                description: azureDisk represents an Azure Data Disk
+                                  mount on the host and bind mount to the pod.
+                                properties:
+                                  cachingMode:
+                                    description: 'cachingMode is the Host Caching
+                                      mode: None, Read Only, Read Write.'
+                                    type: string
+                                  diskName:
+                                    description: diskName is the Name of the data
+                                      disk in the blob storage
+                                    type: string
+                                  diskURI:
+                                    description: diskURI is the URI of data disk in
+                                      the blob storage
+                                    type: string
+                                  fsType:
+                                    description: fsType is Filesystem type to mount.
+                                      Must be a filesystem type supported by the host
+                                      operating system. Ex. "ext4", "xfs", "ntfs".
+                                      Implicitly inferred to be "ext4" if unspecified.
+                                    type: string
+                                  kind:
+                                    description: 'kind expected values are Shared:
+                                      multiple blob disks per storage account  Dedicated:
+                                      single blob disk per storage account  Managed:
+                                      azure managed data disk (only in managed availability
+                                      set). defaults to shared'
+                                    type: string
+                                  readOnly:
+                                    description: readOnly Defaults to false (read/write).
+                                      ReadOnly here will force the ReadOnly setting
+                                      in VolumeMounts.
+                                    type: boolean
+                                required:
+                                - diskName
+                                - diskURI
+                                type: object
+                              azureFile:
+                                description: azureFile represents an Azure File Service
+                                  mount on the host and bind mount to the pod.
+                                properties:
+                                  readOnly:
+                                    description: readOnly defaults to false (read/write).
+                                      ReadOnly here will force the ReadOnly setting
+                                      in VolumeMounts.
+                                    type: boolean
+                                  secretName:
+                                    description: secretName is the  name of secret
+                                      that contains Azure Storage Account Name and
+                                      Key
+                                    type: string
+                                  shareName:
+                                    description: shareName is the azure share Name
+                                    type: string
+                                required:
+                                - secretName
+                                - shareName
+                                type: object
+                              cephfs:
+                                description: cephFS represents a Ceph FS mount on
+                                  the host that shares a pod's lifetime
+                                properties:
+                                  monitors:
+                                    description: 'monitors is Required: Monitors is
+                                      a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                    items:
+                                      type: string
+                                    type: array
+                                  path:
+                                    description: 'path is Optional: Used as the mounted
+                                      root, rather than the full Ceph tree, default
+                                      is /'
+                                    type: string
+                                  readOnly:
+                                    description: 'readOnly is Optional: Defaults to
+                                      false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts. More info:
+                                      https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                    type: boolean
+                                  secretFile:
+                                    description: 'secretFile is Optional: SecretFile
+                                      is the path to key ring for User, default is
+                                      /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                    type: string
+                                  secretRef:
+                                    description: 'secretRef is Optional: SecretRef
+                                      is reference to the authentication secret for
+                                      User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  user:
+                                    description: 'user is optional: User is the rados
+                                      user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                    type: string
+                                required:
+                                - monitors
+                                type: object
+                              cinder:
+                                description: 'cinder represents a cinder volume attached
+                                  and mounted on kubelets host machine. More info:
+                                  https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                properties:
+                                  fsType:
+                                    description: 'fsType is the filesystem type to
+                                      mount. Must be a filesystem type supported by
+                                      the host operating system. Examples: "ext4",
+                                      "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                      if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                    type: string
+                                  readOnly:
+                                    description: 'readOnly defaults to false (read/write).
+                                      ReadOnly here will force the ReadOnly setting
+                                      in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                    type: boolean
+                                  secretRef:
+                                    description: 'secretRef is optional: points to
+                                      a secret object containing parameters used to
+                                      connect to OpenStack.'
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  volumeID:
+                                    description: 'volumeID used to identify the volume
+                                      in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                    type: string
+                                required:
+                                - volumeID
+                                type: object
+                              configMap:
+                                description: configMap represents a configMap that
+                                  should populate this volume
+                                properties:
+                                  defaultMode:
+                                    description: 'defaultMode is optional: mode bits
+                                      used to set permissions on created files by
+                                      default. Must be an octal value between 0000
+                                      and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values,
+                                      JSON requires decimal values for mode bits.
+                                      Defaults to 0644. Directories within the path
+                                      are not affected by this setting. This might
+                                      be in conflict with other options that affect
+                                      the file mode, like fsGroup, and the result
+                                      can be other mode bits set.'
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    description: items if unspecified, each key-value
+                                      pair in the Data field of the referenced ConfigMap
+                                      will be projected into the volume as a file
+                                      whose name is the key and content is the value.
+                                      If specified, the listed keys will be projected
+                                      into the specified paths, and unlisted keys
+                                      will not be present. If a key is specified which
+                                      is not present in the ConfigMap, the volume
+                                      setup will error unless it is marked optional.
+                                      Paths must be relative and may not contain the
+                                      '..' path or start with '..'.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: 'mode is Optional: mode bits
+                                            used to set permissions on this file.
+                                            Must be an octal value between 0000 and
+                                            0777 or a decimal value between 0 and
+                                            511. YAML accepts both octal and decimal
+                                            values, JSON requires decimal values for
+                                            mode bits. If not specified, the volume
+                                            defaultMode will be used. This might be
+                                            in conflict with other options that affect
+                                            the file mode, like fsGroup, and the result
+                                            can be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: path is the relative path of
+                                            the file to map the key to. May not be
+                                            an absolute path. May not contain the
+                                            path element '..'. May not start with
+                                            the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: optional specify whether the ConfigMap
+                                      or its keys must be defined
+                                    type: boolean
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              csi:
+                                description: csi (Container Storage Interface) represents
+                                  ephemeral storage that is handled by certain external
+                                  CSI drivers (Beta feature).
+                                properties:
+                                  driver:
+                                    description: driver is the name of the CSI driver
+                                      that handles this volume. Consult with your
+                                      admin for the correct name as registered in
+                                      the cluster.
+                                    type: string
+                                  fsType:
+                                    description: fsType to mount. Ex. "ext4", "xfs",
+                                      "ntfs". If not provided, the empty value is
+                                      passed to the associated CSI driver which will
+                                      determine the default filesystem to apply.
+                                    type: string
+                                  nodePublishSecretRef:
+                                    description: nodePublishSecretRef is a reference
+                                      to the secret object containing sensitive information
+                                      to pass to the CSI driver to complete the CSI
+                                      NodePublishVolume and NodeUnpublishVolume calls.
+                                      This field is optional, and  may be empty if
+                                      no secret is required. If the secret object
+                                      contains more than one secret, all secret references
+                                      are passed.
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  readOnly:
+                                    description: readOnly specifies a read-only configuration
+                                      for the volume. Defaults to false (read/write).
+                                    type: boolean
+                                  volumeAttributes:
+                                    additionalProperties:
+                                      type: string
+                                    description: volumeAttributes stores driver-specific
+                                      properties that are passed to the CSI driver.
+                                      Consult your driver's documentation for supported
+                                      values.
+                                    type: object
+                                required:
+                                - driver
+                                type: object
+                              downwardAPI:
+                                description: downwardAPI represents downward API about
+                                  the pod that should populate this volume
+                                properties:
+                                  defaultMode:
+                                    description: 'Optional: mode bits to use on created
+                                      files by default. Must be a Optional: mode bits
+                                      used to set permissions on created files by
+                                      default. Must be an octal value between 0000
+                                      and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values,
+                                      JSON requires decimal values for mode bits.
+                                      Defaults to 0644. Directories within the path
+                                      are not affected by this setting. This might
+                                      be in conflict with other options that affect
+                                      the file mode, like fsGroup, and the result
+                                      can be other mode bits set.'
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    description: Items is a list of downward API volume
+                                      file
+                                    items:
+                                      description: DownwardAPIVolumeFile represents
+                                        information to create the file containing
+                                        the pod field
+                                      properties:
+                                        fieldRef:
+                                          description: 'Required: Selects a field
+                                            of the pod: only annotations, labels,
+                                            name and namespace are supported.'
+                                          properties:
+                                            apiVersion:
+                                              description: Version of the schema the
+                                                FieldPath is written in terms of,
+                                                defaults to "v1".
+                                              type: string
+                                            fieldPath:
+                                              description: Path of the field to select
+                                                in the specified API version.
+                                              type: string
+                                          required:
+                                          - fieldPath
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        mode:
+                                          description: 'Optional: mode bits used to
+                                            set permissions on this file, must be
+                                            an octal value between 0000 and 0777 or
+                                            a decimal value between 0 and 511. YAML
+                                            accepts both octal and decimal values,
+                                            JSON requires decimal values for mode
+                                            bits. If not specified, the volume defaultMode
+                                            will be used. This might be in conflict
+                                            with other options that affect the file
+                                            mode, like fsGroup, and the result can
+                                            be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: 'Required: Path is  the relative
+                                            path name of the file to be created. Must
+                                            not be absolute or contain the ''..''
+                                            path. Must be utf-8 encoded. The first
+                                            item of the relative path must not start
+                                            with ''..'''
+                                          type: string
+                                        resourceFieldRef:
+                                          description: 'Selects a resource of the
+                                            container: only resources limits and requests
+                                            (limits.cpu, limits.memory, requests.cpu
+                                            and requests.memory) are currently supported.'
+                                          properties:
+                                            containerName:
+                                              description: 'Container name: required
+                                                for volumes, optional for env vars'
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Specifies the output format
+                                                of the exposed resources, defaults
+                                                to "1"
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              description: 'Required: resource to
+                                                select'
+                                              type: string
+                                          required:
+                                          - resource
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      required:
+                                      - path
+                                      type: object
+                                    type: array
+                                type: object
+                              emptyDir:
+                                description: 'emptyDir represents a temporary directory
+                                  that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                properties:
+                                  medium:
+                                    description: 'medium represents what type of storage
+                                      medium should back this directory. The default
+                                      is "" which means to use the node''s default
+                                      medium. Must be an empty string (default) or
+                                      Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                    type: string
+                                  sizeLimit:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: 'sizeLimit is the total amount of
+                                      local storage required for this EmptyDir volume.
+                                      The size limit is also applicable for memory
+                                      medium. The maximum usage on memory medium EmptyDir
+                                      would be the minimum value between the SizeLimit
+                                      specified here and the sum of memory limits
+                                      of all containers in a pod. The default is nil
+                                      which means that the limit is undefined. More
+                                      info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                type: object
+                              ephemeral:
+                                description: "ephemeral represents a volume that is
+                                  handled by a cluster storage driver. The volume's
+                                  lifecycle is tied to the pod that defines it - it
+                                  will be created before the pod starts, and deleted
+                                  when the pod is removed. \n Use this if: a) the
+                                  volume is only needed while the pod runs, b) features
+                                  of normal volumes like restoring from snapshot or
+                                  capacity tracking are needed, c) the storage driver
+                                  is specified through a storage class, and d) the
+                                  storage driver supports dynamic volume provisioning
+                                  through a PersistentVolumeClaim (see EphemeralVolumeSource
+                                  for more information on the connection between this
+                                  volume type and PersistentVolumeClaim). \n Use PersistentVolumeClaim
+                                  or one of the vendor-specific APIs for volumes that
+                                  persist for longer than the lifecycle of an individual
+                                  pod. \n Use CSI for light-weight local ephemeral
+                                  volumes if the CSI driver is meant to be used that
+                                  way - see the documentation of the driver for more
+                                  information. \n A pod can use both types of ephemeral
+                                  volumes and persistent volumes at the same time."
+                                properties:
+                                  volumeClaimTemplate:
+                                    description: "Will be used to create a stand-alone
+                                      PVC to provision the volume. The pod in which
+                                      this EphemeralVolumeSource is embedded will
+                                      be the owner of the PVC, i.e. the PVC will be
+                                      deleted together with the pod.  The name of
+                                      the PVC will be `<pod name>-<volume name>` where
+                                      `<volume name>` is the name from the `PodSpec.Volumes`
+                                      array entry. Pod validation will reject the
+                                      pod if the concatenated name is not valid for
+                                      a PVC (for example, too long). \n An existing
+                                      PVC with that name that is not owned by the
+                                      pod will *not* be used for the pod to avoid
+                                      using an unrelated volume by mistake. Starting
+                                      the pod is then blocked until the unrelated
+                                      PVC is removed. If such a pre-created PVC is
+                                      meant to be used by the pod, the PVC has to
+                                      updated with an owner reference to the pod once
+                                      the pod exists. Normally this should not be
+                                      necessary, but it may be useful when manually
+                                      reconstructing a broken cluster. \n This field
+                                      is read-only and no changes will be made by
+                                      Kubernetes to the PVC after it has been created.
+                                      \n Required, must not be nil."
+                                    properties:
+                                      metadata:
+                                        description: May contain labels and annotations
+                                          that will be copied into the PVC when creating
+                                          it. No other fields are allowed and will
+                                          be rejected during validation.
+                                        type: object
+                                      spec:
+                                        description: The specification for the PersistentVolumeClaim.
+                                          The entire content is copied unchanged into
+                                          the PVC that gets created from this template.
+                                          The same fields as in a PersistentVolumeClaim
+                                          are also valid here.
+                                        properties:
+                                          accessModes:
+                                            description: 'accessModes contains the
+                                              desired access modes the volume should
+                                              have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                            items:
+                                              type: string
+                                            type: array
+                                          dataSource:
+                                            description: 'dataSource field can be
+                                              used to specify either: * An existing
+                                              VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                              * An existing PVC (PersistentVolumeClaim)
+                                              If the provisioner or an external controller
+                                              can support the specified data source,
+                                              it will create a new volume based on
+                                              the contents of the specified data source.
+                                              If the AnyVolumeDataSource feature gate
+                                              is enabled, this field will always have
+                                              the same contents as the DataSourceRef
+                                              field.'
+                                            properties:
+                                              apiGroup:
+                                                description: APIGroup is the group
+                                                  for the resource being referenced.
+                                                  If APIGroup is not specified, the
+                                                  specified Kind must be in the core
+                                                  API group. For any other third-party
+                                                  types, APIGroup is required.
+                                                type: string
+                                              kind:
+                                                description: Kind is the type of resource
+                                                  being referenced
+                                                type: string
+                                              name:
+                                                description: Name is the name of resource
+                                                  being referenced
+                                                type: string
+                                            required:
+                                            - kind
+                                            - name
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          dataSourceRef:
+                                            description: 'dataSourceRef specifies
+                                              the object from which to populate the
+                                              volume with data, if a non-empty volume
+                                              is desired. This may be any local object
+                                              from a non-empty API group (non core
+                                              object) or a PersistentVolumeClaim object.
+                                              When this field is specified, volume
+                                              binding will only succeed if the type
+                                              of the specified object matches some
+                                              installed volume populator or dynamic
+                                              provisioner. This field will replace
+                                              the functionality of the DataSource
+                                              field and as such if both fields are
+                                              non-empty, they must have the same value.
+                                              For backwards compatibility, both fields
+                                              (DataSource and DataSourceRef) will
+                                              be set to the same value automatically
+                                              if one of them is empty and the other
+                                              is non-empty. There are two important
+                                              differences between DataSource and DataSourceRef:
+                                              * While DataSource only allows two specific
+                                              types of objects, DataSourceRef allows
+                                              any non-core object, as well as PersistentVolumeClaim
+                                              objects. * While DataSource ignores
+                                              disallowed values (dropping them), DataSourceRef
+                                              preserves all values, and generates
+                                              an error if a disallowed value is specified.
+                                              (Beta) Using this field requires the
+                                              AnyVolumeDataSource feature gate to
+                                              be enabled.'
+                                            properties:
+                                              apiGroup:
+                                                description: APIGroup is the group
+                                                  for the resource being referenced.
+                                                  If APIGroup is not specified, the
+                                                  specified Kind must be in the core
+                                                  API group. For any other third-party
+                                                  types, APIGroup is required.
+                                                type: string
+                                              kind:
+                                                description: Kind is the type of resource
+                                                  being referenced
+                                                type: string
+                                              name:
+                                                description: Name is the name of resource
+                                                  being referenced
+                                                type: string
+                                            required:
+                                            - kind
+                                            - name
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          resources:
+                                            description: 'resources represents the
+                                              minimum resources the volume should
+                                              have. If RecoverVolumeExpansionFailure
+                                              feature is enabled users are allowed
+                                              to specify resource requirements that
+                                              are lower than previous value but must
+                                              still be higher than capacity recorded
+                                              in the status field of the claim. More
+                                              info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                            properties:
+                                              limits:
+                                                additionalProperties:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                description: 'Limits describes the
+                                                  maximum amount of compute resources
+                                                  allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                type: object
+                                              requests:
+                                                additionalProperties:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                description: 'Requests describes the
+                                                  minimum amount of compute resources
+                                                  required. If Requests is omitted
+                                                  for a container, it defaults to
+                                                  Limits if that is explicitly specified,
+                                                  otherwise to an implementation-defined
+                                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                type: object
+                                            type: object
+                                          selector:
+                                            description: selector is a label query
+                                              over volumes to consider for binding.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents
+                                                        a key's relationship to a
+                                                        set of values. Valid operators
+                                                        are In, NotIn, Exists and
+                                                        DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array
+                                                        of string values. If the operator
+                                                        is In or NotIn, the values
+                                                        array must be non-empty. If
+                                                        the operator is Exists or
+                                                        DoesNotExist, the values array
+                                                        must be empty. This array
+                                                        is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs. A single {key,value}
+                                                  in the matchLabels map is equivalent
+                                                  to an element of matchExpressions,
+                                                  whose key field is "key", the operator
+                                                  is "In", and the values array contains
+                                                  only "value". The requirements are
+                                                  ANDed.
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          storageClassName:
+                                            description: 'storageClassName is the
+                                              name of the StorageClass required by
+                                              the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                            type: string
+                                          volumeMode:
+                                            description: volumeMode defines what type
+                                              of volume is required by the claim.
+                                              Value of Filesystem is implied when
+                                              not included in claim spec.
+                                            type: string
+                                          volumeName:
+                                            description: volumeName is the binding
+                                              reference to the PersistentVolume backing
+                                              this claim.
+                                            type: string
+                                        type: object
+                                    required:
+                                    - spec
+                                    type: object
+                                type: object
+                              fc:
+                                description: fc represents a Fibre Channel resource
+                                  that is attached to a kubelet's host machine and
+                                  then exposed to the pod.
+                                properties:
+                                  fsType:
+                                    description: 'fsType is the filesystem type to
+                                      mount. Must be a filesystem type supported by
+                                      the host operating system. Ex. "ext4", "xfs",
+                                      "ntfs". Implicitly inferred to be "ext4" if
+                                      unspecified. TODO: how do we prevent errors
+                                      in the filesystem from compromising the machine'
+                                    type: string
+                                  lun:
+                                    description: 'lun is Optional: FC target lun number'
+                                    format: int32
+                                    type: integer
+                                  readOnly:
+                                    description: 'readOnly is Optional: Defaults to
+                                      false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.'
+                                    type: boolean
+                                  targetWWNs:
+                                    description: 'targetWWNs is Optional: FC target
+                                      worldwide names (WWNs)'
+                                    items:
+                                      type: string
+                                    type: array
+                                  wwids:
+                                    description: 'wwids Optional: FC volume world
+                                      wide identifiers (wwids) Either wwids or combination
+                                      of targetWWNs and lun must be set, but not both
+                                      simultaneously.'
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              flexVolume:
+                                description: flexVolume represents a generic volume
+                                  resource that is provisioned/attached using an exec
+                                  based plugin.
+                                properties:
+                                  driver:
+                                    description: driver is the name of the driver
+                                      to use for this volume.
+                                    type: string
+                                  fsType:
+                                    description: fsType is the filesystem type to
+                                      mount. Must be a filesystem type supported by
+                                      the host operating system. Ex. "ext4", "xfs",
+                                      "ntfs". The default filesystem depends on FlexVolume
+                                      script.
+                                    type: string
+                                  options:
+                                    additionalProperties:
+                                      type: string
+                                    description: 'options is Optional: this field
+                                      holds extra command options if any.'
+                                    type: object
+                                  readOnly:
+                                    description: 'readOnly is Optional: defaults to
+                                      false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.'
+                                    type: boolean
+                                  secretRef:
+                                    description: 'secretRef is Optional: secretRef
+                                      is reference to the secret object containing
+                                      sensitive information to pass to the plugin
+                                      scripts. This may be empty if no secret object
+                                      is specified. If the secret object contains
+                                      more than one secret, all secrets are passed
+                                      to the plugin scripts.'
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                required:
+                                - driver
+                                type: object
+                              flocker:
+                                description: flocker represents a Flocker volume attached
+                                  to a kubelet's host machine. This depends on the
+                                  Flocker control service being running
+                                properties:
+                                  datasetName:
+                                    description: datasetName is Name of the dataset
+                                      stored as metadata -> name on the dataset for
+                                      Flocker should be considered as deprecated
+                                    type: string
+                                  datasetUUID:
+                                    description: datasetUUID is the UUID of the dataset.
+                                      This is unique identifier of a Flocker dataset
+                                    type: string
+                                type: object
+                              gcePersistentDisk:
+                                description: 'gcePersistentDisk represents a GCE Disk
+                                  resource that is attached to a kubelet''s host machine
+                                  and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                properties:
+                                  fsType:
+                                    description: 'fsType is filesystem type of the
+                                      volume that you want to mount. Tip: Ensure that
+                                      the filesystem type is supported by the host
+                                      operating system. Examples: "ext4", "xfs", "ntfs".
+                                      Implicitly inferred to be "ext4" if unspecified.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                      TODO: how do we prevent errors in the filesystem
+                                      from compromising the machine'
+                                    type: string
+                                  partition:
+                                    description: 'partition is the partition in the
+                                      volume that you want to mount. If omitted, the
+                                      default is to mount by volume name. Examples:
+                                      For volume /dev/sda1, you specify the partition
+                                      as "1". Similarly, the volume partition for
+                                      /dev/sda is "0" (or you can leave the property
+                                      empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                    format: int32
+                                    type: integer
+                                  pdName:
+                                    description: 'pdName is unique name of the PD
+                                      resource in GCE. Used to identify the disk in
+                                      GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                    type: string
+                                  readOnly:
+                                    description: 'readOnly here will force the ReadOnly
+                                      setting in VolumeMounts. Defaults to false.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                    type: boolean
+                                required:
+                                - pdName
+                                type: object
+                              gitRepo:
+                                description: 'gitRepo represents a git repository
+                                  at a particular revision. DEPRECATED: GitRepo is
+                                  deprecated. To provision a container with a git
+                                  repo, mount an EmptyDir into an InitContainer that
+                                  clones the repo using git, then mount the EmptyDir
+                                  into the Pod''s container.'
+                                properties:
+                                  directory:
+                                    description: directory is the target directory
+                                      name. Must not contain or start with '..'.  If
+                                      '.' is supplied, the volume directory will be
+                                      the git repository.  Otherwise, if specified,
+                                      the volume will contain the git repository in
+                                      the subdirectory with the given name.
+                                    type: string
+                                  repository:
+                                    description: repository is the URL
+                                    type: string
+                                  revision:
+                                    description: revision is the commit hash for the
+                                      specified revision.
+                                    type: string
+                                required:
+                                - repository
+                                type: object
+                              glusterfs:
+                                description: 'glusterfs represents a Glusterfs mount
+                                  on the host that shares a pod''s lifetime. More
+                                  info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                                properties:
+                                  endpoints:
+                                    description: 'endpoints is the endpoint name that
+                                      details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                    type: string
+                                  path:
+                                    description: 'path is the Glusterfs volume path.
+                                      More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                    type: string
+                                  readOnly:
+                                    description: 'readOnly here will force the Glusterfs
+                                      volume to be mounted with read-only permissions.
+                                      Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                    type: boolean
+                                required:
+                                - endpoints
+                                - path
+                                type: object
+                              hostPath:
+                                description: 'hostPath represents a pre-existing file
+                                  or directory on the host machine that is directly
+                                  exposed to the container. This is generally used
+                                  for system agents or other privileged things that
+                                  are allowed to see the host machine. Most containers
+                                  will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                  --- TODO(jonesdl) We need to restrict who can use
+                                  host directory mounts and who can/can not mount
+                                  host directories as read/write.'
+                                properties:
+                                  path:
+                                    description: 'path of the directory on the host.
+                                      If the path is a symlink, it will follow the
+                                      link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                    type: string
+                                  type:
+                                    description: 'type for HostPath Volume Defaults
+                                      to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                    type: string
+                                required:
+                                - path
+                                type: object
+                              iscsi:
+                                description: 'iscsi represents an ISCSI Disk resource
+                                  that is attached to a kubelet''s host machine and
+                                  then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                                properties:
+                                  chapAuthDiscovery:
+                                    description: chapAuthDiscovery defines whether
+                                      support iSCSI Discovery CHAP authentication
+                                    type: boolean
+                                  chapAuthSession:
+                                    description: chapAuthSession defines whether support
+                                      iSCSI Session CHAP authentication
+                                    type: boolean
+                                  fsType:
+                                    description: 'fsType is the filesystem type of
+                                      the volume that you want to mount. Tip: Ensure
+                                      that the filesystem type is supported by the
+                                      host operating system. Examples: "ext4", "xfs",
+                                      "ntfs". Implicitly inferred to be "ext4" if
+                                      unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                      TODO: how do we prevent errors in the filesystem
+                                      from compromising the machine'
+                                    type: string
+                                  initiatorName:
+                                    description: initiatorName is the custom iSCSI
+                                      Initiator Name. If initiatorName is specified
+                                      with iscsiInterface simultaneously, new iSCSI
+                                      interface <target portal>:<volume name> will
+                                      be created for the connection.
+                                    type: string
+                                  iqn:
+                                    description: iqn is the target iSCSI Qualified
+                                      Name.
+                                    type: string
+                                  iscsiInterface:
+                                    description: iscsiInterface is the interface Name
+                                      that uses an iSCSI transport. Defaults to 'default'
+                                      (tcp).
+                                    type: string
+                                  lun:
+                                    description: lun represents iSCSI Target Lun number.
+                                    format: int32
+                                    type: integer
+                                  portals:
+                                    description: portals is the iSCSI Target Portal
+                                      List. The portal is either an IP or ip_addr:port
+                                      if the port is other than default (typically
+                                      TCP ports 860 and 3260).
+                                    items:
+                                      type: string
+                                    type: array
+                                  readOnly:
+                                    description: readOnly here will force the ReadOnly
+                                      setting in VolumeMounts. Defaults to false.
+                                    type: boolean
+                                  secretRef:
+                                    description: secretRef is the CHAP Secret for
+                                      iSCSI target and initiator authentication
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  targetPortal:
+                                    description: targetPortal is iSCSI Target Portal.
+                                      The Portal is either an IP or ip_addr:port if
+                                      the port is other than default (typically TCP
+                                      ports 860 and 3260).
+                                    type: string
+                                required:
+                                - iqn
+                                - lun
+                                - targetPortal
+                                type: object
+                              name:
+                                description: 'name of the volume. Must be a DNS_LABEL
+                                  and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              nfs:
+                                description: 'nfs represents an NFS mount on the host
+                                  that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                properties:
+                                  path:
+                                    description: 'path that is exported by the NFS
+                                      server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                    type: string
+                                  readOnly:
+                                    description: 'readOnly here will force the NFS
+                                      export to be mounted with read-only permissions.
+                                      Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                    type: boolean
+                                  server:
+                                    description: 'server is the hostname or IP address
+                                      of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                    type: string
+                                required:
+                                - path
+                                - server
+                                type: object
+                              persistentVolumeClaim:
+                                description: 'persistentVolumeClaimVolumeSource represents
+                                  a reference to a PersistentVolumeClaim in the same
+                                  namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                properties:
+                                  claimName:
+                                    description: 'claimName is the name of a PersistentVolumeClaim
+                                      in the same namespace as the pod using this
+                                      volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                    type: string
+                                  readOnly:
+                                    description: readOnly Will force the ReadOnly
+                                      setting in VolumeMounts. Default false.
+                                    type: boolean
+                                required:
+                                - claimName
+                                type: object
+                              photonPersistentDisk:
+                                description: photonPersistentDisk represents a PhotonController
+                                  persistent disk attached and mounted on kubelets
+                                  host machine
+                                properties:
+                                  fsType:
+                                    description: fsType is the filesystem type to
+                                      mount. Must be a filesystem type supported by
+                                      the host operating system. Ex. "ext4", "xfs",
+                                      "ntfs". Implicitly inferred to be "ext4" if
+                                      unspecified.
+                                    type: string
+                                  pdID:
+                                    description: pdID is the ID that identifies Photon
+                                      Controller persistent disk
+                                    type: string
+                                required:
+                                - pdID
+                                type: object
+                              portworxVolume:
+                                description: portworxVolume represents a portworx
+                                  volume attached and mounted on kubelets host machine
+                                properties:
+                                  fsType:
+                                    description: fSType represents the filesystem
+                                      type to mount Must be a filesystem type supported
+                                      by the host operating system. Ex. "ext4", "xfs".
+                                      Implicitly inferred to be "ext4" if unspecified.
+                                    type: string
+                                  readOnly:
+                                    description: readOnly defaults to false (read/write).
+                                      ReadOnly here will force the ReadOnly setting
+                                      in VolumeMounts.
+                                    type: boolean
+                                  volumeID:
+                                    description: volumeID uniquely identifies a Portworx
+                                      volume
+                                    type: string
+                                required:
+                                - volumeID
+                                type: object
+                              projected:
+                                description: projected items for all in one resources
+                                  secrets, configmaps, and downward API
+                                properties:
+                                  defaultMode:
+                                    description: defaultMode are the mode bits used
+                                      to set permissions on created files by default.
+                                      Must be an octal value between 0000 and 0777
+                                      or a decimal value between 0 and 511. YAML accepts
+                                      both octal and decimal values, JSON requires
+                                      decimal values for mode bits. Directories within
+                                      the path are not affected by this setting. This
+                                      might be in conflict with other options that
+                                      affect the file mode, like fsGroup, and the
+                                      result can be other mode bits set.
+                                    format: int32
+                                    type: integer
+                                  sources:
+                                    description: sources is the list of volume projections
+                                    items:
+                                      description: Projection that may be projected
+                                        along with other supported volume types
+                                      properties:
+                                        configMap:
+                                          description: configMap information about
+                                            the configMap data to project
+                                          properties:
+                                            items:
+                                              description: items if unspecified, each
+                                                key-value pair in the Data field of
+                                                the referenced ConfigMap will be projected
+                                                into the volume as a file whose name
+                                                is the key and content is the value.
+                                                If specified, the listed keys will
+                                                be projected into the specified paths,
+                                                and unlisted keys will not be present.
+                                                If a key is specified which is not
+                                                present in the ConfigMap, the volume
+                                                setup will error unless it is marked
+                                                optional. Paths must be relative and
+                                                may not contain the '..' path or start
+                                                with '..'.
+                                              items:
+                                                description: Maps a string key to
+                                                  a path within a volume.
+                                                properties:
+                                                  key:
+                                                    description: key is the key to
+                                                      project.
+                                                    type: string
+                                                  mode:
+                                                    description: 'mode is Optional:
+                                                      mode bits used to set permissions
+                                                      on this file. Must be an octal
+                                                      value between 0000 and 0777
+                                                      or a decimal value between 0
+                                                      and 511. YAML accepts both octal
+                                                      and decimal values, JSON requires
+                                                      decimal values for mode bits.
+                                                      If not specified, the volume
+                                                      defaultMode will be used. This
+                                                      might be in conflict with other
+                                                      options that affect the file
+                                                      mode, like fsGroup, and the
+                                                      result can be other mode bits
+                                                      set.'
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    description: path is the relative
+                                                      path of the file to map the
+                                                      key to. May not be an absolute
+                                                      path. May not contain the path
+                                                      element '..'. May not start
+                                                      with the string '..'.
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                type: object
+                                              type: array
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: optional specify whether
+                                                the ConfigMap or its keys must be
+                                                defined
+                                              type: boolean
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        downwardAPI:
+                                          description: downwardAPI information about
+                                            the downwardAPI data to project
+                                          properties:
+                                            items:
+                                              description: Items is a list of DownwardAPIVolume
+                                                file
+                                              items:
+                                                description: DownwardAPIVolumeFile
+                                                  represents information to create
+                                                  the file containing the pod field
+                                                properties:
+                                                  fieldRef:
+                                                    description: 'Required: Selects
+                                                      a field of the pod: only annotations,
+                                                      labels, name and namespace are
+                                                      supported.'
+                                                    properties:
+                                                      apiVersion:
+                                                        description: Version of the
+                                                          schema the FieldPath is
+                                                          written in terms of, defaults
+                                                          to "v1".
+                                                        type: string
+                                                      fieldPath:
+                                                        description: Path of the field
+                                                          to select in the specified
+                                                          API version.
+                                                        type: string
+                                                    required:
+                                                    - fieldPath
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  mode:
+                                                    description: 'Optional: mode bits
+                                                      used to set permissions on this
+                                                      file, must be an octal value
+                                                      between 0000 and 0777 or a decimal
+                                                      value between 0 and 511. YAML
+                                                      accepts both octal and decimal
+                                                      values, JSON requires decimal
+                                                      values for mode bits. If not
+                                                      specified, the volume defaultMode
+                                                      will be used. This might be
+                                                      in conflict with other options
+                                                      that affect the file mode, like
+                                                      fsGroup, and the result can
+                                                      be other mode bits set.'
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    description: 'Required: Path is  the
+                                                      relative path name of the file
+                                                      to be created. Must not be absolute
+                                                      or contain the ''..'' path.
+                                                      Must be utf-8 encoded. The first
+                                                      item of the relative path must
+                                                      not start with ''..'''
+                                                    type: string
+                                                  resourceFieldRef:
+                                                    description: 'Selects a resource
+                                                      of the container: only resources
+                                                      limits and requests (limits.cpu,
+                                                      limits.memory, requests.cpu
+                                                      and requests.memory) are currently
+                                                      supported.'
+                                                    properties:
+                                                      containerName:
+                                                        description: 'Container name:
+                                                          required for volumes, optional
+                                                          for env vars'
+                                                        type: string
+                                                      divisor:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        description: Specifies the
+                                                          output format of the exposed
+                                                          resources, defaults to "1"
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      resource:
+                                                        description: 'Required: resource
+                                                          to select'
+                                                        type: string
+                                                    required:
+                                                    - resource
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                required:
+                                                - path
+                                                type: object
+                                              type: array
+                                          type: object
+                                        secret:
+                                          description: secret information about the
+                                            secret data to project
+                                          properties:
+                                            items:
+                                              description: items if unspecified, each
+                                                key-value pair in the Data field of
+                                                the referenced Secret will be projected
+                                                into the volume as a file whose name
+                                                is the key and content is the value.
+                                                If specified, the listed keys will
+                                                be projected into the specified paths,
+                                                and unlisted keys will not be present.
+                                                If a key is specified which is not
+                                                present in the Secret, the volume
+                                                setup will error unless it is marked
+                                                optional. Paths must be relative and
+                                                may not contain the '..' path or start
+                                                with '..'.
+                                              items:
+                                                description: Maps a string key to
+                                                  a path within a volume.
+                                                properties:
+                                                  key:
+                                                    description: key is the key to
+                                                      project.
+                                                    type: string
+                                                  mode:
+                                                    description: 'mode is Optional:
+                                                      mode bits used to set permissions
+                                                      on this file. Must be an octal
+                                                      value between 0000 and 0777
+                                                      or a decimal value between 0
+                                                      and 511. YAML accepts both octal
+                                                      and decimal values, JSON requires
+                                                      decimal values for mode bits.
+                                                      If not specified, the volume
+                                                      defaultMode will be used. This
+                                                      might be in conflict with other
+                                                      options that affect the file
+                                                      mode, like fsGroup, and the
+                                                      result can be other mode bits
+                                                      set.'
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    description: path is the relative
+                                                      path of the file to map the
+                                                      key to. May not be an absolute
+                                                      path. May not contain the path
+                                                      element '..'. May not start
+                                                      with the string '..'.
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                type: object
+                                              type: array
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: optional field specify
+                                                whether the Secret or its key must
+                                                be defined
+                                              type: boolean
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        serviceAccountToken:
+                                          description: serviceAccountToken is information
+                                            about the serviceAccountToken data to
+                                            project
+                                          properties:
+                                            audience:
+                                              description: audience is the intended
+                                                audience of the token. A recipient
+                                                of a token must identify itself with
+                                                an identifier specified in the audience
+                                                of the token, and otherwise should
+                                                reject the token. The audience defaults
+                                                to the identifier of the apiserver.
+                                              type: string
+                                            expirationSeconds:
+                                              description: expirationSeconds is the
+                                                requested duration of validity of
+                                                the service account token. As the
+                                                token approaches expiration, the kubelet
+                                                volume plugin will proactively rotate
+                                                the service account token. The kubelet
+                                                will start trying to rotate the token
+                                                if the token is older than 80 percent
+                                                of its time to live or if the token
+                                                is older than 24 hours.Defaults to
+                                                1 hour and must be at least 10 minutes.
+                                              format: int64
+                                              type: integer
+                                            path:
+                                              description: path is the path relative
+                                                to the mount point of the file to
+                                                project the token into.
+                                              type: string
+                                          required:
+                                          - path
+                                          type: object
+                                      type: object
+                                    type: array
+                                type: object
+                              quobyte:
+                                description: quobyte represents a Quobyte mount on
+                                  the host that shares a pod's lifetime
+                                properties:
+                                  group:
+                                    description: group to map volume access to Default
+                                      is no group
+                                    type: string
+                                  readOnly:
+                                    description: readOnly here will force the Quobyte
+                                      volume to be mounted with read-only permissions.
+                                      Defaults to false.
+                                    type: boolean
+                                  registry:
+                                    description: registry represents a single or multiple
+                                      Quobyte Registry services specified as a string
+                                      as host:port pair (multiple entries are separated
+                                      with commas) which acts as the central registry
+                                      for volumes
+                                    type: string
+                                  tenant:
+                                    description: tenant owning the given Quobyte volume
+                                      in the Backend Used with dynamically provisioned
+                                      Quobyte volumes, value is set by the plugin
+                                    type: string
+                                  user:
+                                    description: user to map volume access to Defaults
+                                      to serivceaccount user
+                                    type: string
+                                  volume:
+                                    description: volume is a string that references
+                                      an already created Quobyte volume by name.
+                                    type: string
+                                required:
+                                - registry
+                                - volume
+                                type: object
+                              rbd:
+                                description: 'rbd represents a Rados Block Device
+                                  mount on the host that shares a pod''s lifetime.
+                                  More info: https://examples.k8s.io/volumes/rbd/README.md'
+                                properties:
+                                  fsType:
+                                    description: 'fsType is the filesystem type of
+                                      the volume that you want to mount. Tip: Ensure
+                                      that the filesystem type is supported by the
+                                      host operating system. Examples: "ext4", "xfs",
+                                      "ntfs". Implicitly inferred to be "ext4" if
+                                      unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                      TODO: how do we prevent errors in the filesystem
+                                      from compromising the machine'
+                                    type: string
+                                  image:
+                                    description: 'image is the rados image name. More
+                                      info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                    type: string
+                                  keyring:
+                                    description: 'keyring is the path to key ring
+                                      for RBDUser. Default is /etc/ceph/keyring. More
+                                      info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                    type: string
+                                  monitors:
+                                    description: 'monitors is a collection of Ceph
+                                      monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                    items:
+                                      type: string
+                                    type: array
+                                  pool:
+                                    description: 'pool is the rados pool name. Default
+                                      is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                    type: string
+                                  readOnly:
+                                    description: 'readOnly here will force the ReadOnly
+                                      setting in VolumeMounts. Defaults to false.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                    type: boolean
+                                  secretRef:
+                                    description: 'secretRef is name of the authentication
+                                      secret for RBDUser. If provided overrides keyring.
+                                      Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  user:
+                                    description: 'user is the rados user name. Default
+                                      is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                    type: string
+                                required:
+                                - image
+                                - monitors
+                                type: object
+                              scaleIO:
+                                description: scaleIO represents a ScaleIO persistent
+                                  volume attached and mounted on Kubernetes nodes.
+                                properties:
+                                  fsType:
+                                    description: fsType is the filesystem type to
+                                      mount. Must be a filesystem type supported by
+                                      the host operating system. Ex. "ext4", "xfs",
+                                      "ntfs". Default is "xfs".
+                                    type: string
+                                  gateway:
+                                    description: gateway is the host address of the
+                                      ScaleIO API Gateway.
+                                    type: string
+                                  protectionDomain:
+                                    description: protectionDomain is the name of the
+                                      ScaleIO Protection Domain for the configured
+                                      storage.
+                                    type: string
+                                  readOnly:
+                                    description: readOnly Defaults to false (read/write).
+                                      ReadOnly here will force the ReadOnly setting
+                                      in VolumeMounts.
+                                    type: boolean
+                                  secretRef:
+                                    description: secretRef references to the secret
+                                      for ScaleIO user and other sensitive information.
+                                      If this is not provided, Login operation will
+                                      fail.
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  sslEnabled:
+                                    description: sslEnabled Flag enable/disable SSL
+                                      communication with Gateway, default false
+                                    type: boolean
+                                  storageMode:
+                                    description: storageMode indicates whether the
+                                      storage for a volume should be ThickProvisioned
+                                      or ThinProvisioned. Default is ThinProvisioned.
+                                    type: string
+                                  storagePool:
+                                    description: storagePool is the ScaleIO Storage
+                                      Pool associated with the protection domain.
+                                    type: string
+                                  system:
+                                    description: system is the name of the storage
+                                      system as configured in ScaleIO.
+                                    type: string
+                                  volumeName:
+                                    description: volumeName is the name of a volume
+                                      already created in the ScaleIO system that is
+                                      associated with this volume source.
+                                    type: string
+                                required:
+                                - gateway
+                                - secretRef
+                                - system
+                                type: object
+                              secret:
+                                description: 'secret represents a secret that should
+                                  populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                properties:
+                                  defaultMode:
+                                    description: 'defaultMode is Optional: mode bits
+                                      used to set permissions on created files by
+                                      default. Must be an octal value between 0000
+                                      and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values,
+                                      JSON requires decimal values for mode bits.
+                                      Defaults to 0644. Directories within the path
+                                      are not affected by this setting. This might
+                                      be in conflict with other options that affect
+                                      the file mode, like fsGroup, and the result
+                                      can be other mode bits set.'
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    description: items If unspecified, each key-value
+                                      pair in the Data field of the referenced Secret
+                                      will be projected into the volume as a file
+                                      whose name is the key and content is the value.
+                                      If specified, the listed keys will be projected
+                                      into the specified paths, and unlisted keys
+                                      will not be present. If a key is specified which
+                                      is not present in the Secret, the volume setup
+                                      will error unless it is marked optional. Paths
+                                      must be relative and may not contain the '..'
+                                      path or start with '..'.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: 'mode is Optional: mode bits
+                                            used to set permissions on this file.
+                                            Must be an octal value between 0000 and
+                                            0777 or a decimal value between 0 and
+                                            511. YAML accepts both octal and decimal
+                                            values, JSON requires decimal values for
+                                            mode bits. If not specified, the volume
+                                            defaultMode will be used. This might be
+                                            in conflict with other options that affect
+                                            the file mode, like fsGroup, and the result
+                                            can be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: path is the relative path of
+                                            the file to map the key to. May not be
+                                            an absolute path. May not contain the
+                                            path element '..'. May not start with
+                                            the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                  optional:
+                                    description: optional field specify whether the
+                                      Secret or its keys must be defined
+                                    type: boolean
+                                  secretName:
+                                    description: 'secretName is the name of the secret
+                                      in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                    type: string
+                                type: object
+                              storageos:
+                                description: storageOS represents a StorageOS volume
+                                  attached and mounted on Kubernetes nodes.
+                                properties:
+                                  fsType:
+                                    description: fsType is the filesystem type to
+                                      mount. Must be a filesystem type supported by
+                                      the host operating system. Ex. "ext4", "xfs",
+                                      "ntfs". Implicitly inferred to be "ext4" if
+                                      unspecified.
+                                    type: string
+                                  readOnly:
+                                    description: readOnly defaults to false (read/write).
+                                      ReadOnly here will force the ReadOnly setting
+                                      in VolumeMounts.
+                                    type: boolean
+                                  secretRef:
+                                    description: secretRef specifies the secret to
+                                      use for obtaining the StorageOS API credentials.  If
+                                      not specified, default values will be attempted.
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  volumeName:
+                                    description: volumeName is the human-readable
+                                      name of the StorageOS volume.  Volume names
+                                      are only unique within a namespace.
+                                    type: string
+                                  volumeNamespace:
+                                    description: volumeNamespace specifies the scope
+                                      of the volume within StorageOS.  If no namespace
+                                      is specified then the Pod's namespace will be
+                                      used.  This allows the Kubernetes name scoping
+                                      to be mirrored within StorageOS for tighter
+                                      integration. Set VolumeName to any name to override
+                                      the default behaviour. Set to "default" if you
+                                      are not using namespaces within StorageOS. Namespaces
+                                      that do not pre-exist within StorageOS will
+                                      be created.
+                                    type: string
+                                type: object
+                              vsphereVolume:
+                                description: vsphereVolume represents a vSphere volume
+                                  attached and mounted on kubelets host machine
+                                properties:
+                                  fsType:
+                                    description: fsType is filesystem type to mount.
+                                      Must be a filesystem type supported by the host
+                                      operating system. Ex. "ext4", "xfs", "ntfs".
+                                      Implicitly inferred to be "ext4" if unspecified.
+                                    type: string
+                                  storagePolicyID:
+                                    description: storagePolicyID is the storage Policy
+                                      Based Management (SPBM) profile ID associated
+                                      with the StoragePolicyName.
+                                    type: string
+                                  storagePolicyName:
+                                    description: storagePolicyName is the storage
+                                      Policy Based Management (SPBM) profile name.
+                                    type: string
+                                  volumePath:
+                                    description: volumePath is the path that identifies
+                                      vSphere volume vmdk
+                                    type: string
+                                required:
+                                - volumePath
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                      required:
+                      - mounts
+                      - volumes
+                      type: object
+                    type: array
                   managed:
                     description: Managed - Whether the node is actually provisioned
                       (True) or should be treated as preprovisioned (False)

--- a/api/bases/dataplane.openstack.org_openstackdataplanes.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplanes.yaml
@@ -61,6 +61,1903 @@ spec:
                         ansibleVars:
                           description: AnsibleVars for configuring ansible
                           type: string
+                        extraMounts:
+                          description: ExtraMounts containing files which can be mounted
+                            into an Ansible Execution Pod
+                          items:
+                            description: VolMounts is the data structure used to expose
+                              Volumes and Mounts that can be added to a pod according
+                              to the defined Propagation policy
+                            properties:
+                              extraVolType:
+                                description: Label associated to a given extraMount
+                                type: string
+                              mounts:
+                                items:
+                                  description: VolumeMount describes a mounting of
+                                    a Volume within a container.
+                                  properties:
+                                    mountPath:
+                                      description: Path within the container at which
+                                        the volume should be mounted.  Must not contain
+                                        ':'.
+                                      type: string
+                                    mountPropagation:
+                                      description: mountPropagation determines how
+                                        mounts are propagated from the host to container
+                                        and the other way around. When not set, MountPropagationNone
+                                        is used. This field is beta in 1.10.
+                                      type: string
+                                    name:
+                                      description: This must match the Name of a Volume.
+                                      type: string
+                                    readOnly:
+                                      description: Mounted read-only if true, read-write
+                                        otherwise (false or unspecified). Defaults
+                                        to false.
+                                      type: boolean
+                                    subPath:
+                                      description: Path within the volume from which
+                                        the container's volume should be mounted.
+                                        Defaults to "" (volume's root).
+                                      type: string
+                                    subPathExpr:
+                                      description: Expanded path within the volume
+                                        from which the container's volume should be
+                                        mounted. Behaves similarly to SubPath but
+                                        environment variable references $(VAR_NAME)
+                                        are expanded using the container's environment.
+                                        Defaults to "" (volume's root). SubPathExpr
+                                        and SubPath are mutually exclusive.
+                                      type: string
+                                  required:
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                              propagation:
+                                description: Propagation defines which pod should
+                                  mount the volume
+                                items:
+                                  description: PropagationType identifies the Service,
+                                    Group or instance (e.g. the backend) that receives
+                                    an Extra Volume that can potentially be mounted
+                                  type: string
+                                type: array
+                              volumes:
+                                items:
+                                  description: Volume represents a named volume in
+                                    a pod that may be accessed by any container in
+                                    the pod.
+                                  properties:
+                                    awsElasticBlockStore:
+                                      description: 'awsElasticBlockStore represents
+                                        an AWS Disk resource that is attached to a
+                                        kubelet''s host machine and then exposed to
+                                        the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                      properties:
+                                        fsType:
+                                          description: 'fsType is the filesystem type
+                                            of the volume that you want to mount.
+                                            Tip: Ensure that the filesystem type is
+                                            supported by the host operating system.
+                                            Examples: "ext4", "xfs", "ntfs". Implicitly
+                                            inferred to be "ext4" if unspecified.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                            TODO: how do we prevent errors in the
+                                            filesystem from compromising the machine'
+                                          type: string
+                                        partition:
+                                          description: 'partition is the partition
+                                            in the volume that you want to mount.
+                                            If omitted, the default is to mount by
+                                            volume name. Examples: For volume /dev/sda1,
+                                            you specify the partition as "1". Similarly,
+                                            the volume partition for /dev/sda is "0"
+                                            (or you can leave the property empty).'
+                                          format: int32
+                                          type: integer
+                                        readOnly:
+                                          description: 'readOnly value true will force
+                                            the readOnly setting in VolumeMounts.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                          type: boolean
+                                        volumeID:
+                                          description: 'volumeID is unique ID of the
+                                            persistent disk resource in AWS (Amazon
+                                            EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                          type: string
+                                      required:
+                                      - volumeID
+                                      type: object
+                                    azureDisk:
+                                      description: azureDisk represents an Azure Data
+                                        Disk mount on the host and bind mount to the
+                                        pod.
+                                      properties:
+                                        cachingMode:
+                                          description: 'cachingMode is the Host Caching
+                                            mode: None, Read Only, Read Write.'
+                                          type: string
+                                        diskName:
+                                          description: diskName is the Name of the
+                                            data disk in the blob storage
+                                          type: string
+                                        diskURI:
+                                          description: diskURI is the URI of data
+                                            disk in the blob storage
+                                          type: string
+                                        fsType:
+                                          description: fsType is Filesystem type to
+                                            mount. Must be a filesystem type supported
+                                            by the host operating system. Ex. "ext4",
+                                            "xfs", "ntfs". Implicitly inferred to
+                                            be "ext4" if unspecified.
+                                          type: string
+                                        kind:
+                                          description: 'kind expected values are Shared:
+                                            multiple blob disks per storage account  Dedicated:
+                                            single blob disk per storage account  Managed:
+                                            azure managed data disk (only in managed
+                                            availability set). defaults to shared'
+                                          type: string
+                                        readOnly:
+                                          description: readOnly Defaults to false
+                                            (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
+                                          type: boolean
+                                      required:
+                                      - diskName
+                                      - diskURI
+                                      type: object
+                                    azureFile:
+                                      description: azureFile represents an Azure File
+                                        Service mount on the host and bind mount to
+                                        the pod.
+                                      properties:
+                                        readOnly:
+                                          description: readOnly defaults to false
+                                            (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
+                                          type: boolean
+                                        secretName:
+                                          description: secretName is the  name of
+                                            secret that contains Azure Storage Account
+                                            Name and Key
+                                          type: string
+                                        shareName:
+                                          description: shareName is the azure share
+                                            Name
+                                          type: string
+                                      required:
+                                      - secretName
+                                      - shareName
+                                      type: object
+                                    cephfs:
+                                      description: cephFS represents a Ceph FS mount
+                                        on the host that shares a pod's lifetime
+                                      properties:
+                                        monitors:
+                                          description: 'monitors is Required: Monitors
+                                            is a collection of Ceph monitors More
+                                            info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          items:
+                                            type: string
+                                          type: array
+                                        path:
+                                          description: 'path is Optional: Used as
+                                            the mounted root, rather than the full
+                                            Ceph tree, default is /'
+                                          type: string
+                                        readOnly:
+                                          description: 'readOnly is Optional: Defaults
+                                            to false (read/write). ReadOnly here will
+                                            force the ReadOnly setting in VolumeMounts.
+                                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          type: boolean
+                                        secretFile:
+                                          description: 'secretFile is Optional: SecretFile
+                                            is the path to key ring for User, default
+                                            is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          type: string
+                                        secretRef:
+                                          description: 'secretRef is Optional: SecretRef
+                                            is reference to the authentication secret
+                                            for User, default is empty. More info:
+                                            https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        user:
+                                          description: 'user is optional: User is
+                                            the rados user name, default is admin
+                                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          type: string
+                                      required:
+                                      - monitors
+                                      type: object
+                                    cinder:
+                                      description: 'cinder represents a cinder volume
+                                        attached and mounted on kubelets host machine.
+                                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                      properties:
+                                        fsType:
+                                          description: 'fsType is the filesystem type
+                                            to mount. Must be a filesystem type supported
+                                            by the host operating system. Examples:
+                                            "ext4", "xfs", "ntfs". Implicitly inferred
+                                            to be "ext4" if unspecified. More info:
+                                            https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                          type: string
+                                        readOnly:
+                                          description: 'readOnly defaults to false
+                                            (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
+                                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                          type: boolean
+                                        secretRef:
+                                          description: 'secretRef is optional: points
+                                            to a secret object containing parameters
+                                            used to connect to OpenStack.'
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        volumeID:
+                                          description: 'volumeID used to identify
+                                            the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                          type: string
+                                      required:
+                                      - volumeID
+                                      type: object
+                                    configMap:
+                                      description: configMap represents a configMap
+                                        that should populate this volume
+                                      properties:
+                                        defaultMode:
+                                          description: 'defaultMode is optional: mode
+                                            bits used to set permissions on created
+                                            files by default. Must be an octal value
+                                            between 0000 and 0777 or a decimal value
+                                            between 0 and 511. YAML accepts both octal
+                                            and decimal values, JSON requires decimal
+                                            values for mode bits. Defaults to 0644.
+                                            Directories within the path are not affected
+                                            by this setting. This might be in conflict
+                                            with other options that affect the file
+                                            mode, like fsGroup, and the result can
+                                            be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          description: items if unspecified, each
+                                            key-value pair in the Data field of the
+                                            referenced ConfigMap will be projected
+                                            into the volume as a file whose name is
+                                            the key and content is the value. If specified,
+                                            the listed keys will be projected into
+                                            the specified paths, and unlisted keys
+                                            will not be present. If a key is specified
+                                            which is not present in the ConfigMap,
+                                            the volume setup will error unless it
+                                            is marked optional. Paths must be relative
+                                            and may not contain the '..' path or start
+                                            with '..'.
+                                          items:
+                                            description: Maps a string key to a path
+                                              within a volume.
+                                            properties:
+                                              key:
+                                                description: key is the key to project.
+                                                type: string
+                                              mode:
+                                                description: 'mode is Optional: mode
+                                                  bits used to set permissions on
+                                                  this file. Must be an octal value
+                                                  between 0000 and 0777 or a decimal
+                                                  value between 0 and 511. YAML accepts
+                                                  both octal and decimal values, JSON
+                                                  requires decimal values for mode
+                                                  bits. If not specified, the volume
+                                                  defaultMode will be used. This might
+                                                  be in conflict with other options
+                                                  that affect the file mode, like
+                                                  fsGroup, and the result can be other
+                                                  mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: path is the relative
+                                                  path of the file to map the key
+                                                  to. May not be an absolute path.
+                                                  May not contain the path element
+                                                  '..'. May not start with the string
+                                                  '..'.
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: optional specify whether the
+                                            ConfigMap or its keys must be defined
+                                          type: boolean
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    csi:
+                                      description: csi (Container Storage Interface)
+                                        represents ephemeral storage that is handled
+                                        by certain external CSI drivers (Beta feature).
+                                      properties:
+                                        driver:
+                                          description: driver is the name of the CSI
+                                            driver that handles this volume. Consult
+                                            with your admin for the correct name as
+                                            registered in the cluster.
+                                          type: string
+                                        fsType:
+                                          description: fsType to mount. Ex. "ext4",
+                                            "xfs", "ntfs". If not provided, the empty
+                                            value is passed to the associated CSI
+                                            driver which will determine the default
+                                            filesystem to apply.
+                                          type: string
+                                        nodePublishSecretRef:
+                                          description: nodePublishSecretRef is a reference
+                                            to the secret object containing sensitive
+                                            information to pass to the CSI driver
+                                            to complete the CSI NodePublishVolume
+                                            and NodeUnpublishVolume calls. This field
+                                            is optional, and  may be empty if no secret
+                                            is required. If the secret object contains
+                                            more than one secret, all secret references
+                                            are passed.
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        readOnly:
+                                          description: readOnly specifies a read-only
+                                            configuration for the volume. Defaults
+                                            to false (read/write).
+                                          type: boolean
+                                        volumeAttributes:
+                                          additionalProperties:
+                                            type: string
+                                          description: volumeAttributes stores driver-specific
+                                            properties that are passed to the CSI
+                                            driver. Consult your driver's documentation
+                                            for supported values.
+                                          type: object
+                                      required:
+                                      - driver
+                                      type: object
+                                    downwardAPI:
+                                      description: downwardAPI represents downward
+                                        API about the pod that should populate this
+                                        volume
+                                      properties:
+                                        defaultMode:
+                                          description: 'Optional: mode bits to use
+                                            on created files by default. Must be a
+                                            Optional: mode bits used to set permissions
+                                            on created files by default. Must be an
+                                            octal value between 0000 and 0777 or a
+                                            decimal value between 0 and 511. YAML
+                                            accepts both octal and decimal values,
+                                            JSON requires decimal values for mode
+                                            bits. Defaults to 0644. Directories within
+                                            the path are not affected by this setting.
+                                            This might be in conflict with other options
+                                            that affect the file mode, like fsGroup,
+                                            and the result can be other mode bits
+                                            set.'
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          description: Items is a list of downward
+                                            API volume file
+                                          items:
+                                            description: DownwardAPIVolumeFile represents
+                                              information to create the file containing
+                                              the pod field
+                                            properties:
+                                              fieldRef:
+                                                description: 'Required: Selects a
+                                                  field of the pod: only annotations,
+                                                  labels, name and namespace are supported.'
+                                                properties:
+                                                  apiVersion:
+                                                    description: Version of the schema
+                                                      the FieldPath is written in
+                                                      terms of, defaults to "v1".
+                                                    type: string
+                                                  fieldPath:
+                                                    description: Path of the field
+                                                      to select in the specified API
+                                                      version.
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              mode:
+                                                description: 'Optional: mode bits
+                                                  used to set permissions on this
+                                                  file, must be an octal value between
+                                                  0000 and 0777 or a decimal value
+                                                  between 0 and 511. YAML accepts
+                                                  both octal and decimal values, JSON
+                                                  requires decimal values for mode
+                                                  bits. If not specified, the volume
+                                                  defaultMode will be used. This might
+                                                  be in conflict with other options
+                                                  that affect the file mode, like
+                                                  fsGroup, and the result can be other
+                                                  mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: 'Required: Path is  the
+                                                  relative path name of the file to
+                                                  be created. Must not be absolute
+                                                  or contain the ''..'' path. Must
+                                                  be utf-8 encoded. The first item
+                                                  of the relative path must not start
+                                                  with ''..'''
+                                                type: string
+                                              resourceFieldRef:
+                                                description: 'Selects a resource of
+                                                  the container: only resources limits
+                                                  and requests (limits.cpu, limits.memory,
+                                                  requests.cpu and requests.memory)
+                                                  are currently supported.'
+                                                properties:
+                                                  containerName:
+                                                    description: 'Container name:
+                                                      required for volumes, optional
+                                                      for env vars'
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: Specifies the output
+                                                      format of the exposed resources,
+                                                      defaults to "1"
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    description: 'Required: resource
+                                                      to select'
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            required:
+                                            - path
+                                            type: object
+                                          type: array
+                                      type: object
+                                    emptyDir:
+                                      description: 'emptyDir represents a temporary
+                                        directory that shares a pod''s lifetime. More
+                                        info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                      properties:
+                                        medium:
+                                          description: 'medium represents what type
+                                            of storage medium should back this directory.
+                                            The default is "" which means to use the
+                                            node''s default medium. Must be an empty
+                                            string (default) or Memory. More info:
+                                            https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                          type: string
+                                        sizeLimit:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: 'sizeLimit is the total amount
+                                            of local storage required for this EmptyDir
+                                            volume. The size limit is also applicable
+                                            for memory medium. The maximum usage on
+                                            memory medium EmptyDir would be the minimum
+                                            value between the SizeLimit specified
+                                            here and the sum of memory limits of all
+                                            containers in a pod. The default is nil
+                                            which means that the limit is undefined.
+                                            More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                      type: object
+                                    ephemeral:
+                                      description: "ephemeral represents a volume
+                                        that is handled by a cluster storage driver.
+                                        The volume's lifecycle is tied to the pod
+                                        that defines it - it will be created before
+                                        the pod starts, and deleted when the pod is
+                                        removed. \n Use this if: a) the volume is
+                                        only needed while the pod runs, b) features
+                                        of normal volumes like restoring from snapshot
+                                        or capacity tracking are needed, c) the storage
+                                        driver is specified through a storage class,
+                                        and d) the storage driver supports dynamic
+                                        volume provisioning through a PersistentVolumeClaim
+                                        (see EphemeralVolumeSource for more information
+                                        on the connection between this volume type
+                                        and PersistentVolumeClaim). \n Use PersistentVolumeClaim
+                                        or one of the vendor-specific APIs for volumes
+                                        that persist for longer than the lifecycle
+                                        of an individual pod. \n Use CSI for light-weight
+                                        local ephemeral volumes if the CSI driver
+                                        is meant to be used that way - see the documentation
+                                        of the driver for more information. \n A pod
+                                        can use both types of ephemeral volumes and
+                                        persistent volumes at the same time."
+                                      properties:
+                                        volumeClaimTemplate:
+                                          description: "Will be used to create a stand-alone
+                                            PVC to provision the volume. The pod in
+                                            which this EphemeralVolumeSource is embedded
+                                            will be the owner of the PVC, i.e. the
+                                            PVC will be deleted together with the
+                                            pod.  The name of the PVC will be `<pod
+                                            name>-<volume name>` where `<volume name>`
+                                            is the name from the `PodSpec.Volumes`
+                                            array entry. Pod validation will reject
+                                            the pod if the concatenated name is not
+                                            valid for a PVC (for example, too long).
+                                            \n An existing PVC with that name that
+                                            is not owned by the pod will *not* be
+                                            used for the pod to avoid using an unrelated
+                                            volume by mistake. Starting the pod is
+                                            then blocked until the unrelated PVC is
+                                            removed. If such a pre-created PVC is
+                                            meant to be used by the pod, the PVC has
+                                            to updated with an owner reference to
+                                            the pod once the pod exists. Normally
+                                            this should not be necessary, but it may
+                                            be useful when manually reconstructing
+                                            a broken cluster. \n This field is read-only
+                                            and no changes will be made by Kubernetes
+                                            to the PVC after it has been created.
+                                            \n Required, must not be nil."
+                                          properties:
+                                            metadata:
+                                              description: May contain labels and
+                                                annotations that will be copied into
+                                                the PVC when creating it. No other
+                                                fields are allowed and will be rejected
+                                                during validation.
+                                              type: object
+                                            spec:
+                                              description: The specification for the
+                                                PersistentVolumeClaim. The entire
+                                                content is copied unchanged into the
+                                                PVC that gets created from this template.
+                                                The same fields as in a PersistentVolumeClaim
+                                                are also valid here.
+                                              properties:
+                                                accessModes:
+                                                  description: 'accessModes contains
+                                                    the desired access modes the volume
+                                                    should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                dataSource:
+                                                  description: 'dataSource field can
+                                                    be used to specify either: * An
+                                                    existing VolumeSnapshot object
+                                                    (snapshot.storage.k8s.io/VolumeSnapshot)
+                                                    * An existing PVC (PersistentVolumeClaim)
+                                                    If the provisioner or an external
+                                                    controller can support the specified
+                                                    data source, it will create a
+                                                    new volume based on the contents
+                                                    of the specified data source.
+                                                    If the AnyVolumeDataSource feature
+                                                    gate is enabled, this field will
+                                                    always have the same contents
+                                                    as the DataSourceRef field.'
+                                                  properties:
+                                                    apiGroup:
+                                                      description: APIGroup is the
+                                                        group for the resource being
+                                                        referenced. If APIGroup is
+                                                        not specified, the specified
+                                                        Kind must be in the core API
+                                                        group. For any other third-party
+                                                        types, APIGroup is required.
+                                                      type: string
+                                                    kind:
+                                                      description: Kind is the type
+                                                        of resource being referenced
+                                                      type: string
+                                                    name:
+                                                      description: Name is the name
+                                                        of resource being referenced
+                                                      type: string
+                                                  required:
+                                                  - kind
+                                                  - name
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                dataSourceRef:
+                                                  description: 'dataSourceRef specifies
+                                                    the object from which to populate
+                                                    the volume with data, if a non-empty
+                                                    volume is desired. This may be
+                                                    any local object from a non-empty
+                                                    API group (non core object) or
+                                                    a PersistentVolumeClaim object.
+                                                    When this field is specified,
+                                                    volume binding will only succeed
+                                                    if the type of the specified object
+                                                    matches some installed volume
+                                                    populator or dynamic provisioner.
+                                                    This field will replace the functionality
+                                                    of the DataSource field and as
+                                                    such if both fields are non-empty,
+                                                    they must have the same value.
+                                                    For backwards compatibility, both
+                                                    fields (DataSource and DataSourceRef)
+                                                    will be set to the same value
+                                                    automatically if one of them is
+                                                    empty and the other is non-empty.
+                                                    There are two important differences
+                                                    between DataSource and DataSourceRef:
+                                                    * While DataSource only allows
+                                                    two specific types of objects,
+                                                    DataSourceRef allows any non-core
+                                                    object, as well as PersistentVolumeClaim
+                                                    objects. * While DataSource ignores
+                                                    disallowed values (dropping them),
+                                                    DataSourceRef preserves all values,
+                                                    and generates an error if a disallowed
+                                                    value is specified. (Beta) Using
+                                                    this field requires the AnyVolumeDataSource
+                                                    feature gate to be enabled.'
+                                                  properties:
+                                                    apiGroup:
+                                                      description: APIGroup is the
+                                                        group for the resource being
+                                                        referenced. If APIGroup is
+                                                        not specified, the specified
+                                                        Kind must be in the core API
+                                                        group. For any other third-party
+                                                        types, APIGroup is required.
+                                                      type: string
+                                                    kind:
+                                                      description: Kind is the type
+                                                        of resource being referenced
+                                                      type: string
+                                                    name:
+                                                      description: Name is the name
+                                                        of resource being referenced
+                                                      type: string
+                                                  required:
+                                                  - kind
+                                                  - name
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                resources:
+                                                  description: 'resources represents
+                                                    the minimum resources the volume
+                                                    should have. If RecoverVolumeExpansionFailure
+                                                    feature is enabled users are allowed
+                                                    to specify resource requirements
+                                                    that are lower than previous value
+                                                    but must still be higher than
+                                                    capacity recorded in the status
+                                                    field of the claim. More info:
+                                                    https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                                  properties:
+                                                    limits:
+                                                      additionalProperties:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      description: 'Limits describes
+                                                        the maximum amount of compute
+                                                        resources allowed. More info:
+                                                        https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                      type: object
+                                                    requests:
+                                                      additionalProperties:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      description: 'Requests describes
+                                                        the minimum amount of compute
+                                                        resources required. If Requests
+                                                        is omitted for a container,
+                                                        it defaults to Limits if that
+                                                        is explicitly specified, otherwise
+                                                        to an implementation-defined
+                                                        value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                      type: object
+                                                  type: object
+                                                selector:
+                                                  description: selector is a label
+                                                    query over volumes to consider
+                                                    for binding.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                storageClassName:
+                                                  description: 'storageClassName is
+                                                    the name of the StorageClass required
+                                                    by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                                  type: string
+                                                volumeMode:
+                                                  description: volumeMode defines
+                                                    what type of volume is required
+                                                    by the claim. Value of Filesystem
+                                                    is implied when not included in
+                                                    claim spec.
+                                                  type: string
+                                                volumeName:
+                                                  description: volumeName is the binding
+                                                    reference to the PersistentVolume
+                                                    backing this claim.
+                                                  type: string
+                                              type: object
+                                          required:
+                                          - spec
+                                          type: object
+                                      type: object
+                                    fc:
+                                      description: fc represents a Fibre Channel resource
+                                        that is attached to a kubelet's host machine
+                                        and then exposed to the pod.
+                                      properties:
+                                        fsType:
+                                          description: 'fsType is the filesystem type
+                                            to mount. Must be a filesystem type supported
+                                            by the host operating system. Ex. "ext4",
+                                            "xfs", "ntfs". Implicitly inferred to
+                                            be "ext4" if unspecified. TODO: how do
+                                            we prevent errors in the filesystem from
+                                            compromising the machine'
+                                          type: string
+                                        lun:
+                                          description: 'lun is Optional: FC target
+                                            lun number'
+                                          format: int32
+                                          type: integer
+                                        readOnly:
+                                          description: 'readOnly is Optional: Defaults
+                                            to false (read/write). ReadOnly here will
+                                            force the ReadOnly setting in VolumeMounts.'
+                                          type: boolean
+                                        targetWWNs:
+                                          description: 'targetWWNs is Optional: FC
+                                            target worldwide names (WWNs)'
+                                          items:
+                                            type: string
+                                          type: array
+                                        wwids:
+                                          description: 'wwids Optional: FC volume
+                                            world wide identifiers (wwids) Either
+                                            wwids or combination of targetWWNs and
+                                            lun must be set, but not both simultaneously.'
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    flexVolume:
+                                      description: flexVolume represents a generic
+                                        volume resource that is provisioned/attached
+                                        using an exec based plugin.
+                                      properties:
+                                        driver:
+                                          description: driver is the name of the driver
+                                            to use for this volume.
+                                          type: string
+                                        fsType:
+                                          description: fsType is the filesystem type
+                                            to mount. Must be a filesystem type supported
+                                            by the host operating system. Ex. "ext4",
+                                            "xfs", "ntfs". The default filesystem
+                                            depends on FlexVolume script.
+                                          type: string
+                                        options:
+                                          additionalProperties:
+                                            type: string
+                                          description: 'options is Optional: this
+                                            field holds extra command options if any.'
+                                          type: object
+                                        readOnly:
+                                          description: 'readOnly is Optional: defaults
+                                            to false (read/write). ReadOnly here will
+                                            force the ReadOnly setting in VolumeMounts.'
+                                          type: boolean
+                                        secretRef:
+                                          description: 'secretRef is Optional: secretRef
+                                            is reference to the secret object containing
+                                            sensitive information to pass to the plugin
+                                            scripts. This may be empty if no secret
+                                            object is specified. If the secret object
+                                            contains more than one secret, all secrets
+                                            are passed to the plugin scripts.'
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      required:
+                                      - driver
+                                      type: object
+                                    flocker:
+                                      description: flocker represents a Flocker volume
+                                        attached to a kubelet's host machine. This
+                                        depends on the Flocker control service being
+                                        running
+                                      properties:
+                                        datasetName:
+                                          description: datasetName is Name of the
+                                            dataset stored as metadata -> name on
+                                            the dataset for Flocker should be considered
+                                            as deprecated
+                                          type: string
+                                        datasetUUID:
+                                          description: datasetUUID is the UUID of
+                                            the dataset. This is unique identifier
+                                            of a Flocker dataset
+                                          type: string
+                                      type: object
+                                    gcePersistentDisk:
+                                      description: 'gcePersistentDisk represents a
+                                        GCE Disk resource that is attached to a kubelet''s
+                                        host machine and then exposed to the pod.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                      properties:
+                                        fsType:
+                                          description: 'fsType is filesystem type
+                                            of the volume that you want to mount.
+                                            Tip: Ensure that the filesystem type is
+                                            supported by the host operating system.
+                                            Examples: "ext4", "xfs", "ntfs". Implicitly
+                                            inferred to be "ext4" if unspecified.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                            TODO: how do we prevent errors in the
+                                            filesystem from compromising the machine'
+                                          type: string
+                                        partition:
+                                          description: 'partition is the partition
+                                            in the volume that you want to mount.
+                                            If omitted, the default is to mount by
+                                            volume name. Examples: For volume /dev/sda1,
+                                            you specify the partition as "1". Similarly,
+                                            the volume partition for /dev/sda is "0"
+                                            (or you can leave the property empty).
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                          format: int32
+                                          type: integer
+                                        pdName:
+                                          description: 'pdName is unique name of the
+                                            PD resource in GCE. Used to identify the
+                                            disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                          type: string
+                                        readOnly:
+                                          description: 'readOnly here will force the
+                                            ReadOnly setting in VolumeMounts. Defaults
+                                            to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                          type: boolean
+                                      required:
+                                      - pdName
+                                      type: object
+                                    gitRepo:
+                                      description: 'gitRepo represents a git repository
+                                        at a particular revision. DEPRECATED: GitRepo
+                                        is deprecated. To provision a container with
+                                        a git repo, mount an EmptyDir into an InitContainer
+                                        that clones the repo using git, then mount
+                                        the EmptyDir into the Pod''s container.'
+                                      properties:
+                                        directory:
+                                          description: directory is the target directory
+                                            name. Must not contain or start with '..'.  If
+                                            '.' is supplied, the volume directory
+                                            will be the git repository.  Otherwise,
+                                            if specified, the volume will contain
+                                            the git repository in the subdirectory
+                                            with the given name.
+                                          type: string
+                                        repository:
+                                          description: repository is the URL
+                                          type: string
+                                        revision:
+                                          description: revision is the commit hash
+                                            for the specified revision.
+                                          type: string
+                                      required:
+                                      - repository
+                                      type: object
+                                    glusterfs:
+                                      description: 'glusterfs represents a Glusterfs
+                                        mount on the host that shares a pod''s lifetime.
+                                        More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                                      properties:
+                                        endpoints:
+                                          description: 'endpoints is the endpoint
+                                            name that details Glusterfs topology.
+                                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                          type: string
+                                        path:
+                                          description: 'path is the Glusterfs volume
+                                            path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                          type: string
+                                        readOnly:
+                                          description: 'readOnly here will force the
+                                            Glusterfs volume to be mounted with read-only
+                                            permissions. Defaults to false. More info:
+                                            https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                          type: boolean
+                                      required:
+                                      - endpoints
+                                      - path
+                                      type: object
+                                    hostPath:
+                                      description: 'hostPath represents a pre-existing
+                                        file or directory on the host machine that
+                                        is directly exposed to the container. This
+                                        is generally used for system agents or other
+                                        privileged things that are allowed to see
+                                        the host machine. Most containers will NOT
+                                        need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                        --- TODO(jonesdl) We need to restrict who
+                                        can use host directory mounts and who can/can
+                                        not mount host directories as read/write.'
+                                      properties:
+                                        path:
+                                          description: 'path of the directory on the
+                                            host. If the path is a symlink, it will
+                                            follow the link to the real path. More
+                                            info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                          type: string
+                                        type:
+                                          description: 'type for HostPath Volume Defaults
+                                            to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                          type: string
+                                      required:
+                                      - path
+                                      type: object
+                                    iscsi:
+                                      description: 'iscsi represents an ISCSI Disk
+                                        resource that is attached to a kubelet''s
+                                        host machine and then exposed to the pod.
+                                        More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                                      properties:
+                                        chapAuthDiscovery:
+                                          description: chapAuthDiscovery defines whether
+                                            support iSCSI Discovery CHAP authentication
+                                          type: boolean
+                                        chapAuthSession:
+                                          description: chapAuthSession defines whether
+                                            support iSCSI Session CHAP authentication
+                                          type: boolean
+                                        fsType:
+                                          description: 'fsType is the filesystem type
+                                            of the volume that you want to mount.
+                                            Tip: Ensure that the filesystem type is
+                                            supported by the host operating system.
+                                            Examples: "ext4", "xfs", "ntfs". Implicitly
+                                            inferred to be "ext4" if unspecified.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                            TODO: how do we prevent errors in the
+                                            filesystem from compromising the machine'
+                                          type: string
+                                        initiatorName:
+                                          description: initiatorName is the custom
+                                            iSCSI Initiator Name. If initiatorName
+                                            is specified with iscsiInterface simultaneously,
+                                            new iSCSI interface <target portal>:<volume
+                                            name> will be created for the connection.
+                                          type: string
+                                        iqn:
+                                          description: iqn is the target iSCSI Qualified
+                                            Name.
+                                          type: string
+                                        iscsiInterface:
+                                          description: iscsiInterface is the interface
+                                            Name that uses an iSCSI transport. Defaults
+                                            to 'default' (tcp).
+                                          type: string
+                                        lun:
+                                          description: lun represents iSCSI Target
+                                            Lun number.
+                                          format: int32
+                                          type: integer
+                                        portals:
+                                          description: portals is the iSCSI Target
+                                            Portal List. The portal is either an IP
+                                            or ip_addr:port if the port is other than
+                                            default (typically TCP ports 860 and 3260).
+                                          items:
+                                            type: string
+                                          type: array
+                                        readOnly:
+                                          description: readOnly here will force the
+                                            ReadOnly setting in VolumeMounts. Defaults
+                                            to false.
+                                          type: boolean
+                                        secretRef:
+                                          description: secretRef is the CHAP Secret
+                                            for iSCSI target and initiator authentication
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        targetPortal:
+                                          description: targetPortal is iSCSI Target
+                                            Portal. The Portal is either an IP or
+                                            ip_addr:port if the port is other than
+                                            default (typically TCP ports 860 and 3260).
+                                          type: string
+                                      required:
+                                      - iqn
+                                      - lun
+                                      - targetPortal
+                                      type: object
+                                    name:
+                                      description: 'name of the volume. Must be a
+                                        DNS_LABEL and unique within the pod. More
+                                        info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    nfs:
+                                      description: 'nfs represents an NFS mount on
+                                        the host that shares a pod''s lifetime More
+                                        info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                      properties:
+                                        path:
+                                          description: 'path that is exported by the
+                                            NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                          type: string
+                                        readOnly:
+                                          description: 'readOnly here will force the
+                                            NFS export to be mounted with read-only
+                                            permissions. Defaults to false. More info:
+                                            https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                          type: boolean
+                                        server:
+                                          description: 'server is the hostname or
+                                            IP address of the NFS server. More info:
+                                            https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                          type: string
+                                      required:
+                                      - path
+                                      - server
+                                      type: object
+                                    persistentVolumeClaim:
+                                      description: 'persistentVolumeClaimVolumeSource
+                                        represents a reference to a PersistentVolumeClaim
+                                        in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                      properties:
+                                        claimName:
+                                          description: 'claimName is the name of a
+                                            PersistentVolumeClaim in the same namespace
+                                            as the pod using this volume. More info:
+                                            https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                          type: string
+                                        readOnly:
+                                          description: readOnly Will force the ReadOnly
+                                            setting in VolumeMounts. Default false.
+                                          type: boolean
+                                      required:
+                                      - claimName
+                                      type: object
+                                    photonPersistentDisk:
+                                      description: photonPersistentDisk represents
+                                        a PhotonController persistent disk attached
+                                        and mounted on kubelets host machine
+                                      properties:
+                                        fsType:
+                                          description: fsType is the filesystem type
+                                            to mount. Must be a filesystem type supported
+                                            by the host operating system. Ex. "ext4",
+                                            "xfs", "ntfs". Implicitly inferred to
+                                            be "ext4" if unspecified.
+                                          type: string
+                                        pdID:
+                                          description: pdID is the ID that identifies
+                                            Photon Controller persistent disk
+                                          type: string
+                                      required:
+                                      - pdID
+                                      type: object
+                                    portworxVolume:
+                                      description: portworxVolume represents a portworx
+                                        volume attached and mounted on kubelets host
+                                        machine
+                                      properties:
+                                        fsType:
+                                          description: fSType represents the filesystem
+                                            type to mount Must be a filesystem type
+                                            supported by the host operating system.
+                                            Ex. "ext4", "xfs". Implicitly inferred
+                                            to be "ext4" if unspecified.
+                                          type: string
+                                        readOnly:
+                                          description: readOnly defaults to false
+                                            (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
+                                          type: boolean
+                                        volumeID:
+                                          description: volumeID uniquely identifies
+                                            a Portworx volume
+                                          type: string
+                                      required:
+                                      - volumeID
+                                      type: object
+                                    projected:
+                                      description: projected items for all in one
+                                        resources secrets, configmaps, and downward
+                                        API
+                                      properties:
+                                        defaultMode:
+                                          description: defaultMode are the mode bits
+                                            used to set permissions on created files
+                                            by default. Must be an octal value between
+                                            0000 and 0777 or a decimal value between
+                                            0 and 511. YAML accepts both octal and
+                                            decimal values, JSON requires decimal
+                                            values for mode bits. Directories within
+                                            the path are not affected by this setting.
+                                            This might be in conflict with other options
+                                            that affect the file mode, like fsGroup,
+                                            and the result can be other mode bits
+                                            set.
+                                          format: int32
+                                          type: integer
+                                        sources:
+                                          description: sources is the list of volume
+                                            projections
+                                          items:
+                                            description: Projection that may be projected
+                                              along with other supported volume types
+                                            properties:
+                                              configMap:
+                                                description: configMap information
+                                                  about the configMap data to project
+                                                properties:
+                                                  items:
+                                                    description: items if unspecified,
+                                                      each key-value pair in the Data
+                                                      field of the referenced ConfigMap
+                                                      will be projected into the volume
+                                                      as a file whose name is the
+                                                      key and content is the value.
+                                                      If specified, the listed keys
+                                                      will be projected into the specified
+                                                      paths, and unlisted keys will
+                                                      not be present. If a key is
+                                                      specified which is not present
+                                                      in the ConfigMap, the volume
+                                                      setup will error unless it is
+                                                      marked optional. Paths must
+                                                      be relative and may not contain
+                                                      the '..' path or start with
+                                                      '..'.
+                                                    items:
+                                                      description: Maps a string key
+                                                        to a path within a volume.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            key to project.
+                                                          type: string
+                                                        mode:
+                                                          description: 'mode is Optional:
+                                                            mode bits used to set
+                                                            permissions on this file.
+                                                            Must be an octal value
+                                                            between 0000 and 0777
+                                                            or a decimal value between
+                                                            0 and 511. YAML accepts
+                                                            both octal and decimal
+                                                            values, JSON requires
+                                                            decimal values for mode
+                                                            bits. If not specified,
+                                                            the volume defaultMode
+                                                            will be used. This might
+                                                            be in conflict with other
+                                                            options that affect the
+                                                            file mode, like fsGroup,
+                                                            and the result can be
+                                                            other mode bits set.'
+                                                          format: int32
+                                                          type: integer
+                                                        path:
+                                                          description: path is the
+                                                            relative path of the file
+                                                            to map the key to. May
+                                                            not be an absolute path.
+                                                            May not contain the path
+                                                            element '..'. May not
+                                                            start with the string
+                                                            '..'.
+                                                          type: string
+                                                      required:
+                                                      - key
+                                                      - path
+                                                      type: object
+                                                    type: array
+                                                  name:
+                                                    description: 'Name of the referent.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                      TODO: Add other useful fields.
+                                                      apiVersion, kind, uid?'
+                                                    type: string
+                                                  optional:
+                                                    description: optional specify
+                                                      whether the ConfigMap or its
+                                                      keys must be defined
+                                                    type: boolean
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              downwardAPI:
+                                                description: downwardAPI information
+                                                  about the downwardAPI data to project
+                                                properties:
+                                                  items:
+                                                    description: Items is a list of
+                                                      DownwardAPIVolume file
+                                                    items:
+                                                      description: DownwardAPIVolumeFile
+                                                        represents information to
+                                                        create the file containing
+                                                        the pod field
+                                                      properties:
+                                                        fieldRef:
+                                                          description: 'Required:
+                                                            Selects a field of the
+                                                            pod: only annotations,
+                                                            labels, name and namespace
+                                                            are supported.'
+                                                          properties:
+                                                            apiVersion:
+                                                              description: Version
+                                                                of the schema the
+                                                                FieldPath is written
+                                                                in terms of, defaults
+                                                                to "v1".
+                                                              type: string
+                                                            fieldPath:
+                                                              description: Path of
+                                                                the field to select
+                                                                in the specified API
+                                                                version.
+                                                              type: string
+                                                          required:
+                                                          - fieldPath
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        mode:
+                                                          description: 'Optional:
+                                                            mode bits used to set
+                                                            permissions on this file,
+                                                            must be an octal value
+                                                            between 0000 and 0777
+                                                            or a decimal value between
+                                                            0 and 511. YAML accepts
+                                                            both octal and decimal
+                                                            values, JSON requires
+                                                            decimal values for mode
+                                                            bits. If not specified,
+                                                            the volume defaultMode
+                                                            will be used. This might
+                                                            be in conflict with other
+                                                            options that affect the
+                                                            file mode, like fsGroup,
+                                                            and the result can be
+                                                            other mode bits set.'
+                                                          format: int32
+                                                          type: integer
+                                                        path:
+                                                          description: 'Required:
+                                                            Path is  the relative
+                                                            path name of the file
+                                                            to be created. Must not
+                                                            be absolute or contain
+                                                            the ''..'' path. Must
+                                                            be utf-8 encoded. The
+                                                            first item of the relative
+                                                            path must not start with
+                                                            ''..'''
+                                                          type: string
+                                                        resourceFieldRef:
+                                                          description: 'Selects a
+                                                            resource of the container:
+                                                            only resources limits
+                                                            and requests (limits.cpu,
+                                                            limits.memory, requests.cpu
+                                                            and requests.memory) are
+                                                            currently supported.'
+                                                          properties:
+                                                            containerName:
+                                                              description: 'Container
+                                                                name: required for
+                                                                volumes, optional
+                                                                for env vars'
+                                                              type: string
+                                                            divisor:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              description: Specifies
+                                                                the output format
+                                                                of the exposed resources,
+                                                                defaults to "1"
+                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                              x-kubernetes-int-or-string: true
+                                                            resource:
+                                                              description: 'Required:
+                                                                resource to select'
+                                                              type: string
+                                                          required:
+                                                          - resource
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                      required:
+                                                      - path
+                                                      type: object
+                                                    type: array
+                                                type: object
+                                              secret:
+                                                description: secret information about
+                                                  the secret data to project
+                                                properties:
+                                                  items:
+                                                    description: items if unspecified,
+                                                      each key-value pair in the Data
+                                                      field of the referenced Secret
+                                                      will be projected into the volume
+                                                      as a file whose name is the
+                                                      key and content is the value.
+                                                      If specified, the listed keys
+                                                      will be projected into the specified
+                                                      paths, and unlisted keys will
+                                                      not be present. If a key is
+                                                      specified which is not present
+                                                      in the Secret, the volume setup
+                                                      will error unless it is marked
+                                                      optional. Paths must be relative
+                                                      and may not contain the '..'
+                                                      path or start with '..'.
+                                                    items:
+                                                      description: Maps a string key
+                                                        to a path within a volume.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            key to project.
+                                                          type: string
+                                                        mode:
+                                                          description: 'mode is Optional:
+                                                            mode bits used to set
+                                                            permissions on this file.
+                                                            Must be an octal value
+                                                            between 0000 and 0777
+                                                            or a decimal value between
+                                                            0 and 511. YAML accepts
+                                                            both octal and decimal
+                                                            values, JSON requires
+                                                            decimal values for mode
+                                                            bits. If not specified,
+                                                            the volume defaultMode
+                                                            will be used. This might
+                                                            be in conflict with other
+                                                            options that affect the
+                                                            file mode, like fsGroup,
+                                                            and the result can be
+                                                            other mode bits set.'
+                                                          format: int32
+                                                          type: integer
+                                                        path:
+                                                          description: path is the
+                                                            relative path of the file
+                                                            to map the key to. May
+                                                            not be an absolute path.
+                                                            May not contain the path
+                                                            element '..'. May not
+                                                            start with the string
+                                                            '..'.
+                                                          type: string
+                                                      required:
+                                                      - key
+                                                      - path
+                                                      type: object
+                                                    type: array
+                                                  name:
+                                                    description: 'Name of the referent.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                      TODO: Add other useful fields.
+                                                      apiVersion, kind, uid?'
+                                                    type: string
+                                                  optional:
+                                                    description: optional field specify
+                                                      whether the Secret or its key
+                                                      must be defined
+                                                    type: boolean
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              serviceAccountToken:
+                                                description: serviceAccountToken is
+                                                  information about the serviceAccountToken
+                                                  data to project
+                                                properties:
+                                                  audience:
+                                                    description: audience is the intended
+                                                      audience of the token. A recipient
+                                                      of a token must identify itself
+                                                      with an identifier specified
+                                                      in the audience of the token,
+                                                      and otherwise should reject
+                                                      the token. The audience defaults
+                                                      to the identifier of the apiserver.
+                                                    type: string
+                                                  expirationSeconds:
+                                                    description: expirationSeconds
+                                                      is the requested duration of
+                                                      validity of the service account
+                                                      token. As the token approaches
+                                                      expiration, the kubelet volume
+                                                      plugin will proactively rotate
+                                                      the service account token. The
+                                                      kubelet will start trying to
+                                                      rotate the token if the token
+                                                      is older than 80 percent of
+                                                      its time to live or if the token
+                                                      is older than 24 hours.Defaults
+                                                      to 1 hour and must be at least
+                                                      10 minutes.
+                                                    format: int64
+                                                    type: integer
+                                                  path:
+                                                    description: path is the path
+                                                      relative to the mount point
+                                                      of the file to project the token
+                                                      into.
+                                                    type: string
+                                                required:
+                                                - path
+                                                type: object
+                                            type: object
+                                          type: array
+                                      type: object
+                                    quobyte:
+                                      description: quobyte represents a Quobyte mount
+                                        on the host that shares a pod's lifetime
+                                      properties:
+                                        group:
+                                          description: group to map volume access
+                                            to Default is no group
+                                          type: string
+                                        readOnly:
+                                          description: readOnly here will force the
+                                            Quobyte volume to be mounted with read-only
+                                            permissions. Defaults to false.
+                                          type: boolean
+                                        registry:
+                                          description: registry represents a single
+                                            or multiple Quobyte Registry services
+                                            specified as a string as host:port pair
+                                            (multiple entries are separated with commas)
+                                            which acts as the central registry for
+                                            volumes
+                                          type: string
+                                        tenant:
+                                          description: tenant owning the given Quobyte
+                                            volume in the Backend Used with dynamically
+                                            provisioned Quobyte volumes, value is
+                                            set by the plugin
+                                          type: string
+                                        user:
+                                          description: user to map volume access to
+                                            Defaults to serivceaccount user
+                                          type: string
+                                        volume:
+                                          description: volume is a string that references
+                                            an already created Quobyte volume by name.
+                                          type: string
+                                      required:
+                                      - registry
+                                      - volume
+                                      type: object
+                                    rbd:
+                                      description: 'rbd represents a Rados Block Device
+                                        mount on the host that shares a pod''s lifetime.
+                                        More info: https://examples.k8s.io/volumes/rbd/README.md'
+                                      properties:
+                                        fsType:
+                                          description: 'fsType is the filesystem type
+                                            of the volume that you want to mount.
+                                            Tip: Ensure that the filesystem type is
+                                            supported by the host operating system.
+                                            Examples: "ext4", "xfs", "ntfs". Implicitly
+                                            inferred to be "ext4" if unspecified.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                            TODO: how do we prevent errors in the
+                                            filesystem from compromising the machine'
+                                          type: string
+                                        image:
+                                          description: 'image is the rados image name.
+                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          type: string
+                                        keyring:
+                                          description: 'keyring is the path to key
+                                            ring for RBDUser. Default is /etc/ceph/keyring.
+                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          type: string
+                                        monitors:
+                                          description: 'monitors is a collection of
+                                            Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          items:
+                                            type: string
+                                          type: array
+                                        pool:
+                                          description: 'pool is the rados pool name.
+                                            Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          type: string
+                                        readOnly:
+                                          description: 'readOnly here will force the
+                                            ReadOnly setting in VolumeMounts. Defaults
+                                            to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          type: boolean
+                                        secretRef:
+                                          description: 'secretRef is name of the authentication
+                                            secret for RBDUser. If provided overrides
+                                            keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        user:
+                                          description: 'user is the rados user name.
+                                            Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          type: string
+                                      required:
+                                      - image
+                                      - monitors
+                                      type: object
+                                    scaleIO:
+                                      description: scaleIO represents a ScaleIO persistent
+                                        volume attached and mounted on Kubernetes
+                                        nodes.
+                                      properties:
+                                        fsType:
+                                          description: fsType is the filesystem type
+                                            to mount. Must be a filesystem type supported
+                                            by the host operating system. Ex. "ext4",
+                                            "xfs", "ntfs". Default is "xfs".
+                                          type: string
+                                        gateway:
+                                          description: gateway is the host address
+                                            of the ScaleIO API Gateway.
+                                          type: string
+                                        protectionDomain:
+                                          description: protectionDomain is the name
+                                            of the ScaleIO Protection Domain for the
+                                            configured storage.
+                                          type: string
+                                        readOnly:
+                                          description: readOnly Defaults to false
+                                            (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
+                                          type: boolean
+                                        secretRef:
+                                          description: secretRef references to the
+                                            secret for ScaleIO user and other sensitive
+                                            information. If this is not provided,
+                                            Login operation will fail.
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        sslEnabled:
+                                          description: sslEnabled Flag enable/disable
+                                            SSL communication with Gateway, default
+                                            false
+                                          type: boolean
+                                        storageMode:
+                                          description: storageMode indicates whether
+                                            the storage for a volume should be ThickProvisioned
+                                            or ThinProvisioned. Default is ThinProvisioned.
+                                          type: string
+                                        storagePool:
+                                          description: storagePool is the ScaleIO
+                                            Storage Pool associated with the protection
+                                            domain.
+                                          type: string
+                                        system:
+                                          description: system is the name of the storage
+                                            system as configured in ScaleIO.
+                                          type: string
+                                        volumeName:
+                                          description: volumeName is the name of a
+                                            volume already created in the ScaleIO
+                                            system that is associated with this volume
+                                            source.
+                                          type: string
+                                      required:
+                                      - gateway
+                                      - secretRef
+                                      - system
+                                      type: object
+                                    secret:
+                                      description: 'secret represents a secret that
+                                        should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                      properties:
+                                        defaultMode:
+                                          description: 'defaultMode is Optional: mode
+                                            bits used to set permissions on created
+                                            files by default. Must be an octal value
+                                            between 0000 and 0777 or a decimal value
+                                            between 0 and 511. YAML accepts both octal
+                                            and decimal values, JSON requires decimal
+                                            values for mode bits. Defaults to 0644.
+                                            Directories within the path are not affected
+                                            by this setting. This might be in conflict
+                                            with other options that affect the file
+                                            mode, like fsGroup, and the result can
+                                            be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          description: items If unspecified, each
+                                            key-value pair in the Data field of the
+                                            referenced Secret will be projected into
+                                            the volume as a file whose name is the
+                                            key and content is the value. If specified,
+                                            the listed keys will be projected into
+                                            the specified paths, and unlisted keys
+                                            will not be present. If a key is specified
+                                            which is not present in the Secret, the
+                                            volume setup will error unless it is marked
+                                            optional. Paths must be relative and may
+                                            not contain the '..' path or start with
+                                            '..'.
+                                          items:
+                                            description: Maps a string key to a path
+                                              within a volume.
+                                            properties:
+                                              key:
+                                                description: key is the key to project.
+                                                type: string
+                                              mode:
+                                                description: 'mode is Optional: mode
+                                                  bits used to set permissions on
+                                                  this file. Must be an octal value
+                                                  between 0000 and 0777 or a decimal
+                                                  value between 0 and 511. YAML accepts
+                                                  both octal and decimal values, JSON
+                                                  requires decimal values for mode
+                                                  bits. If not specified, the volume
+                                                  defaultMode will be used. This might
+                                                  be in conflict with other options
+                                                  that affect the file mode, like
+                                                  fsGroup, and the result can be other
+                                                  mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: path is the relative
+                                                  path of the file to map the key
+                                                  to. May not be an absolute path.
+                                                  May not contain the path element
+                                                  '..'. May not start with the string
+                                                  '..'.
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                        optional:
+                                          description: optional field specify whether
+                                            the Secret or its keys must be defined
+                                          type: boolean
+                                        secretName:
+                                          description: 'secretName is the name of
+                                            the secret in the pod''s namespace to
+                                            use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                          type: string
+                                      type: object
+                                    storageos:
+                                      description: storageOS represents a StorageOS
+                                        volume attached and mounted on Kubernetes
+                                        nodes.
+                                      properties:
+                                        fsType:
+                                          description: fsType is the filesystem type
+                                            to mount. Must be a filesystem type supported
+                                            by the host operating system. Ex. "ext4",
+                                            "xfs", "ntfs". Implicitly inferred to
+                                            be "ext4" if unspecified.
+                                          type: string
+                                        readOnly:
+                                          description: readOnly defaults to false
+                                            (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
+                                          type: boolean
+                                        secretRef:
+                                          description: secretRef specifies the secret
+                                            to use for obtaining the StorageOS API
+                                            credentials.  If not specified, default
+                                            values will be attempted.
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        volumeName:
+                                          description: volumeName is the human-readable
+                                            name of the StorageOS volume.  Volume
+                                            names are only unique within a namespace.
+                                          type: string
+                                        volumeNamespace:
+                                          description: volumeNamespace specifies the
+                                            scope of the volume within StorageOS.  If
+                                            no namespace is specified then the Pod's
+                                            namespace will be used.  This allows the
+                                            Kubernetes name scoping to be mirrored
+                                            within StorageOS for tighter integration.
+                                            Set VolumeName to any name to override
+                                            the default behaviour. Set to "default"
+                                            if you are not using namespaces within
+                                            StorageOS. Namespaces that do not pre-exist
+                                            within StorageOS will be created.
+                                          type: string
+                                      type: object
+                                    vsphereVolume:
+                                      description: vsphereVolume represents a vSphere
+                                        volume attached and mounted on kubelets host
+                                        machine
+                                      properties:
+                                        fsType:
+                                          description: fsType is filesystem type to
+                                            mount. Must be a filesystem type supported
+                                            by the host operating system. Ex. "ext4",
+                                            "xfs", "ntfs". Implicitly inferred to
+                                            be "ext4" if unspecified.
+                                          type: string
+                                        storagePolicyID:
+                                          description: storagePolicyID is the storage
+                                            Policy Based Management (SPBM) profile
+                                            ID associated with the StoragePolicyName.
+                                          type: string
+                                        storagePolicyName:
+                                          description: storagePolicyName is the storage
+                                            Policy Based Management (SPBM) profile
+                                            name.
+                                          type: string
+                                        volumePath:
+                                          description: volumePath is the path that
+                                            identifies vSphere volume vmdk
+                                          type: string
+                                      required:
+                                      - volumePath
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                            required:
+                            - mounts
+                            - volumes
+                            type: object
+                          type: array
                         managed:
                           description: Managed - Whether the node is actually provisioned
                             (True) or should be treated as preprovisioned (False)

--- a/api/go.mod
+++ b/api/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20230307144813-39ed0da90b23
+	github.com/openstack-k8s-operators/lib-common/modules/storage v0.0.0-20230208113903-f7b52e2a2ccb
 	k8s.io/apimachinery v0.25.4
 	sigs.k8s.io/controller-runtime v0.13.1
 )

--- a/api/go.sum
+++ b/api/go.sum
@@ -28,6 +28,7 @@ github.com/onsi/gomega v1.26.0 h1:03cDLK28U6hWvCAns6NeydX3zIm4SF3ci69ulidS32Q=
 github.com/onsi/gomega v1.26.0/go.mod h1:r+zV744Re+DiYCIPRlYOTxn0YkOLcAnW8k1xXdMPGhM=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20230307144813-39ed0da90b23 h1:XPgJD+Z6iXzb4EmM/k3GtHBlCLEFM/ci8pGDyyZePRM=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20230307144813-39ed0da90b23/go.mod h1:wDUzrnAhtC0O99PYR8qQWQoGJzVQwGnfGepKzExCVk8=
+github.com/openstack-k8s-operators/lib-common/modules/storage v0.0.0-20230208113903-f7b52e2a2ccb h1:ryKoUXxe7kfpfCJoYd0wj9JkYcO6HmLgM+d3+L4AStM=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/api/v1beta1/openstackdataplanenode_types.go
+++ b/api/v1beta1/openstackdataplanenode_types.go
@@ -18,6 +18,7 @@ package v1beta1
 
 import (
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
+	"github.com/openstack-k8s-operators/lib-common/modules/storage"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -97,6 +98,11 @@ type NodeSection struct {
 	// Secret.data.ssh-privatekey: <base64 encoded private key contents>
 	// https://kubernetes.io/docs/concepts/configuration/secret/#ssh-authentication-secrets
 	AnsibleSSHPrivateKeySecret string `json:"ansibleSSHPrivateKeySecret"`
+
+	// ExtraMounts containing files which can be mounted into an Ansible Execution Pod
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default={}
+	ExtraMounts []storage.VolMounts `json:"extraMounts,omitempty"`
 }
 
 // DeployStrategySection for fields controlling the deployment

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -23,6 +23,7 @@ package v1beta1
 
 import (
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
+	"github.com/openstack-k8s-operators/lib-common/modules/storage"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -79,6 +80,13 @@ func (in *NodeSection) DeepCopyInto(out *NodeSection) {
 		in, out := &in.Networks, &out.Networks
 		*out = make([]NetworksSection, len(*in))
 		copy(*out, *in)
+	}
+	if in.ExtraMounts != nil {
+		in, out := &in.ExtraMounts, &out.ExtraMounts
+		*out = make([]storage.VolMounts, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 }
 

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
@@ -89,6 +89,1758 @@ spec:
                   ansibleVars:
                     description: AnsibleVars for configuring ansible
                     type: string
+                  extraMounts:
+                    description: ExtraMounts containing files which can be mounted
+                      into an Ansible Execution Pod
+                    items:
+                      description: VolMounts is the data structure used to expose
+                        Volumes and Mounts that can be added to a pod according to
+                        the defined Propagation policy
+                      properties:
+                        extraVolType:
+                          description: Label associated to a given extraMount
+                          type: string
+                        mounts:
+                          items:
+                            description: VolumeMount describes a mounting of a Volume
+                              within a container.
+                            properties:
+                              mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.  Must not contain ':'.
+                                type: string
+                              mountPropagation:
+                                description: mountPropagation determines how mounts
+                                  are propagated from the host to container and the
+                                  other way around. When not set, MountPropagationNone
+                                  is used. This field is beta in 1.10.
+                                type: string
+                              name:
+                                description: This must match the Name of a Volume.
+                                type: string
+                              readOnly:
+                                description: Mounted read-only if true, read-write
+                                  otherwise (false or unspecified). Defaults to false.
+                                type: boolean
+                              subPath:
+                                description: Path within the volume from which the
+                                  container's volume should be mounted. Defaults to
+                                  "" (volume's root).
+                                type: string
+                              subPathExpr:
+                                description: Expanded path within the volume from
+                                  which the container's volume should be mounted.
+                                  Behaves similarly to SubPath but environment variable
+                                  references $(VAR_NAME) are expanded using the container's
+                                  environment. Defaults to "" (volume's root). SubPathExpr
+                                  and SubPath are mutually exclusive.
+                                type: string
+                            required:
+                            - mountPath
+                            - name
+                            type: object
+                          type: array
+                        propagation:
+                          description: Propagation defines which pod should mount
+                            the volume
+                          items:
+                            description: PropagationType identifies the Service, Group
+                              or instance (e.g. the backend) that receives an Extra
+                              Volume that can potentially be mounted
+                            type: string
+                          type: array
+                        volumes:
+                          items:
+                            description: Volume represents a named volume in a pod
+                              that may be accessed by any container in the pod.
+                            properties:
+                              awsElasticBlockStore:
+                                description: 'awsElasticBlockStore represents an AWS
+                                  Disk resource that is attached to a kubelet''s host
+                                  machine and then exposed to the pod. More info:
+                                  https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                properties:
+                                  fsType:
+                                    description: 'fsType is the filesystem type of
+                                      the volume that you want to mount. Tip: Ensure
+                                      that the filesystem type is supported by the
+                                      host operating system. Examples: "ext4", "xfs",
+                                      "ntfs". Implicitly inferred to be "ext4" if
+                                      unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                      TODO: how do we prevent errors in the filesystem
+                                      from compromising the machine'
+                                    type: string
+                                  partition:
+                                    description: 'partition is the partition in the
+                                      volume that you want to mount. If omitted, the
+                                      default is to mount by volume name. Examples:
+                                      For volume /dev/sda1, you specify the partition
+                                      as "1". Similarly, the volume partition for
+                                      /dev/sda is "0" (or you can leave the property
+                                      empty).'
+                                    format: int32
+                                    type: integer
+                                  readOnly:
+                                    description: 'readOnly value true will force the
+                                      readOnly setting in VolumeMounts. More info:
+                                      https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                    type: boolean
+                                  volumeID:
+                                    description: 'volumeID is unique ID of the persistent
+                                      disk resource in AWS (Amazon EBS volume). More
+                                      info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                    type: string
+                                required:
+                                - volumeID
+                                type: object
+                              azureDisk:
+                                description: azureDisk represents an Azure Data Disk
+                                  mount on the host and bind mount to the pod.
+                                properties:
+                                  cachingMode:
+                                    description: 'cachingMode is the Host Caching
+                                      mode: None, Read Only, Read Write.'
+                                    type: string
+                                  diskName:
+                                    description: diskName is the Name of the data
+                                      disk in the blob storage
+                                    type: string
+                                  diskURI:
+                                    description: diskURI is the URI of data disk in
+                                      the blob storage
+                                    type: string
+                                  fsType:
+                                    description: fsType is Filesystem type to mount.
+                                      Must be a filesystem type supported by the host
+                                      operating system. Ex. "ext4", "xfs", "ntfs".
+                                      Implicitly inferred to be "ext4" if unspecified.
+                                    type: string
+                                  kind:
+                                    description: 'kind expected values are Shared:
+                                      multiple blob disks per storage account  Dedicated:
+                                      single blob disk per storage account  Managed:
+                                      azure managed data disk (only in managed availability
+                                      set). defaults to shared'
+                                    type: string
+                                  readOnly:
+                                    description: readOnly Defaults to false (read/write).
+                                      ReadOnly here will force the ReadOnly setting
+                                      in VolumeMounts.
+                                    type: boolean
+                                required:
+                                - diskName
+                                - diskURI
+                                type: object
+                              azureFile:
+                                description: azureFile represents an Azure File Service
+                                  mount on the host and bind mount to the pod.
+                                properties:
+                                  readOnly:
+                                    description: readOnly defaults to false (read/write).
+                                      ReadOnly here will force the ReadOnly setting
+                                      in VolumeMounts.
+                                    type: boolean
+                                  secretName:
+                                    description: secretName is the  name of secret
+                                      that contains Azure Storage Account Name and
+                                      Key
+                                    type: string
+                                  shareName:
+                                    description: shareName is the azure share Name
+                                    type: string
+                                required:
+                                - secretName
+                                - shareName
+                                type: object
+                              cephfs:
+                                description: cephFS represents a Ceph FS mount on
+                                  the host that shares a pod's lifetime
+                                properties:
+                                  monitors:
+                                    description: 'monitors is Required: Monitors is
+                                      a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                    items:
+                                      type: string
+                                    type: array
+                                  path:
+                                    description: 'path is Optional: Used as the mounted
+                                      root, rather than the full Ceph tree, default
+                                      is /'
+                                    type: string
+                                  readOnly:
+                                    description: 'readOnly is Optional: Defaults to
+                                      false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts. More info:
+                                      https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                    type: boolean
+                                  secretFile:
+                                    description: 'secretFile is Optional: SecretFile
+                                      is the path to key ring for User, default is
+                                      /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                    type: string
+                                  secretRef:
+                                    description: 'secretRef is Optional: SecretRef
+                                      is reference to the authentication secret for
+                                      User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  user:
+                                    description: 'user is optional: User is the rados
+                                      user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                    type: string
+                                required:
+                                - monitors
+                                type: object
+                              cinder:
+                                description: 'cinder represents a cinder volume attached
+                                  and mounted on kubelets host machine. More info:
+                                  https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                properties:
+                                  fsType:
+                                    description: 'fsType is the filesystem type to
+                                      mount. Must be a filesystem type supported by
+                                      the host operating system. Examples: "ext4",
+                                      "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                      if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                    type: string
+                                  readOnly:
+                                    description: 'readOnly defaults to false (read/write).
+                                      ReadOnly here will force the ReadOnly setting
+                                      in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                    type: boolean
+                                  secretRef:
+                                    description: 'secretRef is optional: points to
+                                      a secret object containing parameters used to
+                                      connect to OpenStack.'
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  volumeID:
+                                    description: 'volumeID used to identify the volume
+                                      in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                    type: string
+                                required:
+                                - volumeID
+                                type: object
+                              configMap:
+                                description: configMap represents a configMap that
+                                  should populate this volume
+                                properties:
+                                  defaultMode:
+                                    description: 'defaultMode is optional: mode bits
+                                      used to set permissions on created files by
+                                      default. Must be an octal value between 0000
+                                      and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values,
+                                      JSON requires decimal values for mode bits.
+                                      Defaults to 0644. Directories within the path
+                                      are not affected by this setting. This might
+                                      be in conflict with other options that affect
+                                      the file mode, like fsGroup, and the result
+                                      can be other mode bits set.'
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    description: items if unspecified, each key-value
+                                      pair in the Data field of the referenced ConfigMap
+                                      will be projected into the volume as a file
+                                      whose name is the key and content is the value.
+                                      If specified, the listed keys will be projected
+                                      into the specified paths, and unlisted keys
+                                      will not be present. If a key is specified which
+                                      is not present in the ConfigMap, the volume
+                                      setup will error unless it is marked optional.
+                                      Paths must be relative and may not contain the
+                                      '..' path or start with '..'.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: 'mode is Optional: mode bits
+                                            used to set permissions on this file.
+                                            Must be an octal value between 0000 and
+                                            0777 or a decimal value between 0 and
+                                            511. YAML accepts both octal and decimal
+                                            values, JSON requires decimal values for
+                                            mode bits. If not specified, the volume
+                                            defaultMode will be used. This might be
+                                            in conflict with other options that affect
+                                            the file mode, like fsGroup, and the result
+                                            can be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: path is the relative path of
+                                            the file to map the key to. May not be
+                                            an absolute path. May not contain the
+                                            path element '..'. May not start with
+                                            the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: optional specify whether the ConfigMap
+                                      or its keys must be defined
+                                    type: boolean
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              csi:
+                                description: csi (Container Storage Interface) represents
+                                  ephemeral storage that is handled by certain external
+                                  CSI drivers (Beta feature).
+                                properties:
+                                  driver:
+                                    description: driver is the name of the CSI driver
+                                      that handles this volume. Consult with your
+                                      admin for the correct name as registered in
+                                      the cluster.
+                                    type: string
+                                  fsType:
+                                    description: fsType to mount. Ex. "ext4", "xfs",
+                                      "ntfs". If not provided, the empty value is
+                                      passed to the associated CSI driver which will
+                                      determine the default filesystem to apply.
+                                    type: string
+                                  nodePublishSecretRef:
+                                    description: nodePublishSecretRef is a reference
+                                      to the secret object containing sensitive information
+                                      to pass to the CSI driver to complete the CSI
+                                      NodePublishVolume and NodeUnpublishVolume calls.
+                                      This field is optional, and  may be empty if
+                                      no secret is required. If the secret object
+                                      contains more than one secret, all secret references
+                                      are passed.
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  readOnly:
+                                    description: readOnly specifies a read-only configuration
+                                      for the volume. Defaults to false (read/write).
+                                    type: boolean
+                                  volumeAttributes:
+                                    additionalProperties:
+                                      type: string
+                                    description: volumeAttributes stores driver-specific
+                                      properties that are passed to the CSI driver.
+                                      Consult your driver's documentation for supported
+                                      values.
+                                    type: object
+                                required:
+                                - driver
+                                type: object
+                              downwardAPI:
+                                description: downwardAPI represents downward API about
+                                  the pod that should populate this volume
+                                properties:
+                                  defaultMode:
+                                    description: 'Optional: mode bits to use on created
+                                      files by default. Must be a Optional: mode bits
+                                      used to set permissions on created files by
+                                      default. Must be an octal value between 0000
+                                      and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values,
+                                      JSON requires decimal values for mode bits.
+                                      Defaults to 0644. Directories within the path
+                                      are not affected by this setting. This might
+                                      be in conflict with other options that affect
+                                      the file mode, like fsGroup, and the result
+                                      can be other mode bits set.'
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    description: Items is a list of downward API volume
+                                      file
+                                    items:
+                                      description: DownwardAPIVolumeFile represents
+                                        information to create the file containing
+                                        the pod field
+                                      properties:
+                                        fieldRef:
+                                          description: 'Required: Selects a field
+                                            of the pod: only annotations, labels,
+                                            name and namespace are supported.'
+                                          properties:
+                                            apiVersion:
+                                              description: Version of the schema the
+                                                FieldPath is written in terms of,
+                                                defaults to "v1".
+                                              type: string
+                                            fieldPath:
+                                              description: Path of the field to select
+                                                in the specified API version.
+                                              type: string
+                                          required:
+                                          - fieldPath
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        mode:
+                                          description: 'Optional: mode bits used to
+                                            set permissions on this file, must be
+                                            an octal value between 0000 and 0777 or
+                                            a decimal value between 0 and 511. YAML
+                                            accepts both octal and decimal values,
+                                            JSON requires decimal values for mode
+                                            bits. If not specified, the volume defaultMode
+                                            will be used. This might be in conflict
+                                            with other options that affect the file
+                                            mode, like fsGroup, and the result can
+                                            be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: 'Required: Path is  the relative
+                                            path name of the file to be created. Must
+                                            not be absolute or contain the ''..''
+                                            path. Must be utf-8 encoded. The first
+                                            item of the relative path must not start
+                                            with ''..'''
+                                          type: string
+                                        resourceFieldRef:
+                                          description: 'Selects a resource of the
+                                            container: only resources limits and requests
+                                            (limits.cpu, limits.memory, requests.cpu
+                                            and requests.memory) are currently supported.'
+                                          properties:
+                                            containerName:
+                                              description: 'Container name: required
+                                                for volumes, optional for env vars'
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Specifies the output format
+                                                of the exposed resources, defaults
+                                                to "1"
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              description: 'Required: resource to
+                                                select'
+                                              type: string
+                                          required:
+                                          - resource
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      required:
+                                      - path
+                                      type: object
+                                    type: array
+                                type: object
+                              emptyDir:
+                                description: 'emptyDir represents a temporary directory
+                                  that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                properties:
+                                  medium:
+                                    description: 'medium represents what type of storage
+                                      medium should back this directory. The default
+                                      is "" which means to use the node''s default
+                                      medium. Must be an empty string (default) or
+                                      Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                    type: string
+                                  sizeLimit:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: 'sizeLimit is the total amount of
+                                      local storage required for this EmptyDir volume.
+                                      The size limit is also applicable for memory
+                                      medium. The maximum usage on memory medium EmptyDir
+                                      would be the minimum value between the SizeLimit
+                                      specified here and the sum of memory limits
+                                      of all containers in a pod. The default is nil
+                                      which means that the limit is undefined. More
+                                      info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                type: object
+                              ephemeral:
+                                description: "ephemeral represents a volume that is
+                                  handled by a cluster storage driver. The volume's
+                                  lifecycle is tied to the pod that defines it - it
+                                  will be created before the pod starts, and deleted
+                                  when the pod is removed. \n Use this if: a) the
+                                  volume is only needed while the pod runs, b) features
+                                  of normal volumes like restoring from snapshot or
+                                  capacity tracking are needed, c) the storage driver
+                                  is specified through a storage class, and d) the
+                                  storage driver supports dynamic volume provisioning
+                                  through a PersistentVolumeClaim (see EphemeralVolumeSource
+                                  for more information on the connection between this
+                                  volume type and PersistentVolumeClaim). \n Use PersistentVolumeClaim
+                                  or one of the vendor-specific APIs for volumes that
+                                  persist for longer than the lifecycle of an individual
+                                  pod. \n Use CSI for light-weight local ephemeral
+                                  volumes if the CSI driver is meant to be used that
+                                  way - see the documentation of the driver for more
+                                  information. \n A pod can use both types of ephemeral
+                                  volumes and persistent volumes at the same time."
+                                properties:
+                                  volumeClaimTemplate:
+                                    description: "Will be used to create a stand-alone
+                                      PVC to provision the volume. The pod in which
+                                      this EphemeralVolumeSource is embedded will
+                                      be the owner of the PVC, i.e. the PVC will be
+                                      deleted together with the pod.  The name of
+                                      the PVC will be `<pod name>-<volume name>` where
+                                      `<volume name>` is the name from the `PodSpec.Volumes`
+                                      array entry. Pod validation will reject the
+                                      pod if the concatenated name is not valid for
+                                      a PVC (for example, too long). \n An existing
+                                      PVC with that name that is not owned by the
+                                      pod will *not* be used for the pod to avoid
+                                      using an unrelated volume by mistake. Starting
+                                      the pod is then blocked until the unrelated
+                                      PVC is removed. If such a pre-created PVC is
+                                      meant to be used by the pod, the PVC has to
+                                      updated with an owner reference to the pod once
+                                      the pod exists. Normally this should not be
+                                      necessary, but it may be useful when manually
+                                      reconstructing a broken cluster. \n This field
+                                      is read-only and no changes will be made by
+                                      Kubernetes to the PVC after it has been created.
+                                      \n Required, must not be nil."
+                                    properties:
+                                      metadata:
+                                        description: May contain labels and annotations
+                                          that will be copied into the PVC when creating
+                                          it. No other fields are allowed and will
+                                          be rejected during validation.
+                                        type: object
+                                      spec:
+                                        description: The specification for the PersistentVolumeClaim.
+                                          The entire content is copied unchanged into
+                                          the PVC that gets created from this template.
+                                          The same fields as in a PersistentVolumeClaim
+                                          are also valid here.
+                                        properties:
+                                          accessModes:
+                                            description: 'accessModes contains the
+                                              desired access modes the volume should
+                                              have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                            items:
+                                              type: string
+                                            type: array
+                                          dataSource:
+                                            description: 'dataSource field can be
+                                              used to specify either: * An existing
+                                              VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                              * An existing PVC (PersistentVolumeClaim)
+                                              If the provisioner or an external controller
+                                              can support the specified data source,
+                                              it will create a new volume based on
+                                              the contents of the specified data source.
+                                              If the AnyVolumeDataSource feature gate
+                                              is enabled, this field will always have
+                                              the same contents as the DataSourceRef
+                                              field.'
+                                            properties:
+                                              apiGroup:
+                                                description: APIGroup is the group
+                                                  for the resource being referenced.
+                                                  If APIGroup is not specified, the
+                                                  specified Kind must be in the core
+                                                  API group. For any other third-party
+                                                  types, APIGroup is required.
+                                                type: string
+                                              kind:
+                                                description: Kind is the type of resource
+                                                  being referenced
+                                                type: string
+                                              name:
+                                                description: Name is the name of resource
+                                                  being referenced
+                                                type: string
+                                            required:
+                                            - kind
+                                            - name
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          dataSourceRef:
+                                            description: 'dataSourceRef specifies
+                                              the object from which to populate the
+                                              volume with data, if a non-empty volume
+                                              is desired. This may be any local object
+                                              from a non-empty API group (non core
+                                              object) or a PersistentVolumeClaim object.
+                                              When this field is specified, volume
+                                              binding will only succeed if the type
+                                              of the specified object matches some
+                                              installed volume populator or dynamic
+                                              provisioner. This field will replace
+                                              the functionality of the DataSource
+                                              field and as such if both fields are
+                                              non-empty, they must have the same value.
+                                              For backwards compatibility, both fields
+                                              (DataSource and DataSourceRef) will
+                                              be set to the same value automatically
+                                              if one of them is empty and the other
+                                              is non-empty. There are two important
+                                              differences between DataSource and DataSourceRef:
+                                              * While DataSource only allows two specific
+                                              types of objects, DataSourceRef allows
+                                              any non-core object, as well as PersistentVolumeClaim
+                                              objects. * While DataSource ignores
+                                              disallowed values (dropping them), DataSourceRef
+                                              preserves all values, and generates
+                                              an error if a disallowed value is specified.
+                                              (Beta) Using this field requires the
+                                              AnyVolumeDataSource feature gate to
+                                              be enabled.'
+                                            properties:
+                                              apiGroup:
+                                                description: APIGroup is the group
+                                                  for the resource being referenced.
+                                                  If APIGroup is not specified, the
+                                                  specified Kind must be in the core
+                                                  API group. For any other third-party
+                                                  types, APIGroup is required.
+                                                type: string
+                                              kind:
+                                                description: Kind is the type of resource
+                                                  being referenced
+                                                type: string
+                                              name:
+                                                description: Name is the name of resource
+                                                  being referenced
+                                                type: string
+                                            required:
+                                            - kind
+                                            - name
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          resources:
+                                            description: 'resources represents the
+                                              minimum resources the volume should
+                                              have. If RecoverVolumeExpansionFailure
+                                              feature is enabled users are allowed
+                                              to specify resource requirements that
+                                              are lower than previous value but must
+                                              still be higher than capacity recorded
+                                              in the status field of the claim. More
+                                              info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                            properties:
+                                              limits:
+                                                additionalProperties:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                description: 'Limits describes the
+                                                  maximum amount of compute resources
+                                                  allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                type: object
+                                              requests:
+                                                additionalProperties:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                description: 'Requests describes the
+                                                  minimum amount of compute resources
+                                                  required. If Requests is omitted
+                                                  for a container, it defaults to
+                                                  Limits if that is explicitly specified,
+                                                  otherwise to an implementation-defined
+                                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                type: object
+                                            type: object
+                                          selector:
+                                            description: selector is a label query
+                                              over volumes to consider for binding.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents
+                                                        a key's relationship to a
+                                                        set of values. Valid operators
+                                                        are In, NotIn, Exists and
+                                                        DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array
+                                                        of string values. If the operator
+                                                        is In or NotIn, the values
+                                                        array must be non-empty. If
+                                                        the operator is Exists or
+                                                        DoesNotExist, the values array
+                                                        must be empty. This array
+                                                        is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs. A single {key,value}
+                                                  in the matchLabels map is equivalent
+                                                  to an element of matchExpressions,
+                                                  whose key field is "key", the operator
+                                                  is "In", and the values array contains
+                                                  only "value". The requirements are
+                                                  ANDed.
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          storageClassName:
+                                            description: 'storageClassName is the
+                                              name of the StorageClass required by
+                                              the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                            type: string
+                                          volumeMode:
+                                            description: volumeMode defines what type
+                                              of volume is required by the claim.
+                                              Value of Filesystem is implied when
+                                              not included in claim spec.
+                                            type: string
+                                          volumeName:
+                                            description: volumeName is the binding
+                                              reference to the PersistentVolume backing
+                                              this claim.
+                                            type: string
+                                        type: object
+                                    required:
+                                    - spec
+                                    type: object
+                                type: object
+                              fc:
+                                description: fc represents a Fibre Channel resource
+                                  that is attached to a kubelet's host machine and
+                                  then exposed to the pod.
+                                properties:
+                                  fsType:
+                                    description: 'fsType is the filesystem type to
+                                      mount. Must be a filesystem type supported by
+                                      the host operating system. Ex. "ext4", "xfs",
+                                      "ntfs". Implicitly inferred to be "ext4" if
+                                      unspecified. TODO: how do we prevent errors
+                                      in the filesystem from compromising the machine'
+                                    type: string
+                                  lun:
+                                    description: 'lun is Optional: FC target lun number'
+                                    format: int32
+                                    type: integer
+                                  readOnly:
+                                    description: 'readOnly is Optional: Defaults to
+                                      false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.'
+                                    type: boolean
+                                  targetWWNs:
+                                    description: 'targetWWNs is Optional: FC target
+                                      worldwide names (WWNs)'
+                                    items:
+                                      type: string
+                                    type: array
+                                  wwids:
+                                    description: 'wwids Optional: FC volume world
+                                      wide identifiers (wwids) Either wwids or combination
+                                      of targetWWNs and lun must be set, but not both
+                                      simultaneously.'
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              flexVolume:
+                                description: flexVolume represents a generic volume
+                                  resource that is provisioned/attached using an exec
+                                  based plugin.
+                                properties:
+                                  driver:
+                                    description: driver is the name of the driver
+                                      to use for this volume.
+                                    type: string
+                                  fsType:
+                                    description: fsType is the filesystem type to
+                                      mount. Must be a filesystem type supported by
+                                      the host operating system. Ex. "ext4", "xfs",
+                                      "ntfs". The default filesystem depends on FlexVolume
+                                      script.
+                                    type: string
+                                  options:
+                                    additionalProperties:
+                                      type: string
+                                    description: 'options is Optional: this field
+                                      holds extra command options if any.'
+                                    type: object
+                                  readOnly:
+                                    description: 'readOnly is Optional: defaults to
+                                      false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.'
+                                    type: boolean
+                                  secretRef:
+                                    description: 'secretRef is Optional: secretRef
+                                      is reference to the secret object containing
+                                      sensitive information to pass to the plugin
+                                      scripts. This may be empty if no secret object
+                                      is specified. If the secret object contains
+                                      more than one secret, all secrets are passed
+                                      to the plugin scripts.'
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                required:
+                                - driver
+                                type: object
+                              flocker:
+                                description: flocker represents a Flocker volume attached
+                                  to a kubelet's host machine. This depends on the
+                                  Flocker control service being running
+                                properties:
+                                  datasetName:
+                                    description: datasetName is Name of the dataset
+                                      stored as metadata -> name on the dataset for
+                                      Flocker should be considered as deprecated
+                                    type: string
+                                  datasetUUID:
+                                    description: datasetUUID is the UUID of the dataset.
+                                      This is unique identifier of a Flocker dataset
+                                    type: string
+                                type: object
+                              gcePersistentDisk:
+                                description: 'gcePersistentDisk represents a GCE Disk
+                                  resource that is attached to a kubelet''s host machine
+                                  and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                properties:
+                                  fsType:
+                                    description: 'fsType is filesystem type of the
+                                      volume that you want to mount. Tip: Ensure that
+                                      the filesystem type is supported by the host
+                                      operating system. Examples: "ext4", "xfs", "ntfs".
+                                      Implicitly inferred to be "ext4" if unspecified.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                      TODO: how do we prevent errors in the filesystem
+                                      from compromising the machine'
+                                    type: string
+                                  partition:
+                                    description: 'partition is the partition in the
+                                      volume that you want to mount. If omitted, the
+                                      default is to mount by volume name. Examples:
+                                      For volume /dev/sda1, you specify the partition
+                                      as "1". Similarly, the volume partition for
+                                      /dev/sda is "0" (or you can leave the property
+                                      empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                    format: int32
+                                    type: integer
+                                  pdName:
+                                    description: 'pdName is unique name of the PD
+                                      resource in GCE. Used to identify the disk in
+                                      GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                    type: string
+                                  readOnly:
+                                    description: 'readOnly here will force the ReadOnly
+                                      setting in VolumeMounts. Defaults to false.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                    type: boolean
+                                required:
+                                - pdName
+                                type: object
+                              gitRepo:
+                                description: 'gitRepo represents a git repository
+                                  at a particular revision. DEPRECATED: GitRepo is
+                                  deprecated. To provision a container with a git
+                                  repo, mount an EmptyDir into an InitContainer that
+                                  clones the repo using git, then mount the EmptyDir
+                                  into the Pod''s container.'
+                                properties:
+                                  directory:
+                                    description: directory is the target directory
+                                      name. Must not contain or start with '..'.  If
+                                      '.' is supplied, the volume directory will be
+                                      the git repository.  Otherwise, if specified,
+                                      the volume will contain the git repository in
+                                      the subdirectory with the given name.
+                                    type: string
+                                  repository:
+                                    description: repository is the URL
+                                    type: string
+                                  revision:
+                                    description: revision is the commit hash for the
+                                      specified revision.
+                                    type: string
+                                required:
+                                - repository
+                                type: object
+                              glusterfs:
+                                description: 'glusterfs represents a Glusterfs mount
+                                  on the host that shares a pod''s lifetime. More
+                                  info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                                properties:
+                                  endpoints:
+                                    description: 'endpoints is the endpoint name that
+                                      details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                    type: string
+                                  path:
+                                    description: 'path is the Glusterfs volume path.
+                                      More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                    type: string
+                                  readOnly:
+                                    description: 'readOnly here will force the Glusterfs
+                                      volume to be mounted with read-only permissions.
+                                      Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                    type: boolean
+                                required:
+                                - endpoints
+                                - path
+                                type: object
+                              hostPath:
+                                description: 'hostPath represents a pre-existing file
+                                  or directory on the host machine that is directly
+                                  exposed to the container. This is generally used
+                                  for system agents or other privileged things that
+                                  are allowed to see the host machine. Most containers
+                                  will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                  --- TODO(jonesdl) We need to restrict who can use
+                                  host directory mounts and who can/can not mount
+                                  host directories as read/write.'
+                                properties:
+                                  path:
+                                    description: 'path of the directory on the host.
+                                      If the path is a symlink, it will follow the
+                                      link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                    type: string
+                                  type:
+                                    description: 'type for HostPath Volume Defaults
+                                      to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                    type: string
+                                required:
+                                - path
+                                type: object
+                              iscsi:
+                                description: 'iscsi represents an ISCSI Disk resource
+                                  that is attached to a kubelet''s host machine and
+                                  then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                                properties:
+                                  chapAuthDiscovery:
+                                    description: chapAuthDiscovery defines whether
+                                      support iSCSI Discovery CHAP authentication
+                                    type: boolean
+                                  chapAuthSession:
+                                    description: chapAuthSession defines whether support
+                                      iSCSI Session CHAP authentication
+                                    type: boolean
+                                  fsType:
+                                    description: 'fsType is the filesystem type of
+                                      the volume that you want to mount. Tip: Ensure
+                                      that the filesystem type is supported by the
+                                      host operating system. Examples: "ext4", "xfs",
+                                      "ntfs". Implicitly inferred to be "ext4" if
+                                      unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                      TODO: how do we prevent errors in the filesystem
+                                      from compromising the machine'
+                                    type: string
+                                  initiatorName:
+                                    description: initiatorName is the custom iSCSI
+                                      Initiator Name. If initiatorName is specified
+                                      with iscsiInterface simultaneously, new iSCSI
+                                      interface <target portal>:<volume name> will
+                                      be created for the connection.
+                                    type: string
+                                  iqn:
+                                    description: iqn is the target iSCSI Qualified
+                                      Name.
+                                    type: string
+                                  iscsiInterface:
+                                    description: iscsiInterface is the interface Name
+                                      that uses an iSCSI transport. Defaults to 'default'
+                                      (tcp).
+                                    type: string
+                                  lun:
+                                    description: lun represents iSCSI Target Lun number.
+                                    format: int32
+                                    type: integer
+                                  portals:
+                                    description: portals is the iSCSI Target Portal
+                                      List. The portal is either an IP or ip_addr:port
+                                      if the port is other than default (typically
+                                      TCP ports 860 and 3260).
+                                    items:
+                                      type: string
+                                    type: array
+                                  readOnly:
+                                    description: readOnly here will force the ReadOnly
+                                      setting in VolumeMounts. Defaults to false.
+                                    type: boolean
+                                  secretRef:
+                                    description: secretRef is the CHAP Secret for
+                                      iSCSI target and initiator authentication
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  targetPortal:
+                                    description: targetPortal is iSCSI Target Portal.
+                                      The Portal is either an IP or ip_addr:port if
+                                      the port is other than default (typically TCP
+                                      ports 860 and 3260).
+                                    type: string
+                                required:
+                                - iqn
+                                - lun
+                                - targetPortal
+                                type: object
+                              name:
+                                description: 'name of the volume. Must be a DNS_LABEL
+                                  and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              nfs:
+                                description: 'nfs represents an NFS mount on the host
+                                  that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                properties:
+                                  path:
+                                    description: 'path that is exported by the NFS
+                                      server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                    type: string
+                                  readOnly:
+                                    description: 'readOnly here will force the NFS
+                                      export to be mounted with read-only permissions.
+                                      Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                    type: boolean
+                                  server:
+                                    description: 'server is the hostname or IP address
+                                      of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                    type: string
+                                required:
+                                - path
+                                - server
+                                type: object
+                              persistentVolumeClaim:
+                                description: 'persistentVolumeClaimVolumeSource represents
+                                  a reference to a PersistentVolumeClaim in the same
+                                  namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                properties:
+                                  claimName:
+                                    description: 'claimName is the name of a PersistentVolumeClaim
+                                      in the same namespace as the pod using this
+                                      volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                    type: string
+                                  readOnly:
+                                    description: readOnly Will force the ReadOnly
+                                      setting in VolumeMounts. Default false.
+                                    type: boolean
+                                required:
+                                - claimName
+                                type: object
+                              photonPersistentDisk:
+                                description: photonPersistentDisk represents a PhotonController
+                                  persistent disk attached and mounted on kubelets
+                                  host machine
+                                properties:
+                                  fsType:
+                                    description: fsType is the filesystem type to
+                                      mount. Must be a filesystem type supported by
+                                      the host operating system. Ex. "ext4", "xfs",
+                                      "ntfs". Implicitly inferred to be "ext4" if
+                                      unspecified.
+                                    type: string
+                                  pdID:
+                                    description: pdID is the ID that identifies Photon
+                                      Controller persistent disk
+                                    type: string
+                                required:
+                                - pdID
+                                type: object
+                              portworxVolume:
+                                description: portworxVolume represents a portworx
+                                  volume attached and mounted on kubelets host machine
+                                properties:
+                                  fsType:
+                                    description: fSType represents the filesystem
+                                      type to mount Must be a filesystem type supported
+                                      by the host operating system. Ex. "ext4", "xfs".
+                                      Implicitly inferred to be "ext4" if unspecified.
+                                    type: string
+                                  readOnly:
+                                    description: readOnly defaults to false (read/write).
+                                      ReadOnly here will force the ReadOnly setting
+                                      in VolumeMounts.
+                                    type: boolean
+                                  volumeID:
+                                    description: volumeID uniquely identifies a Portworx
+                                      volume
+                                    type: string
+                                required:
+                                - volumeID
+                                type: object
+                              projected:
+                                description: projected items for all in one resources
+                                  secrets, configmaps, and downward API
+                                properties:
+                                  defaultMode:
+                                    description: defaultMode are the mode bits used
+                                      to set permissions on created files by default.
+                                      Must be an octal value between 0000 and 0777
+                                      or a decimal value between 0 and 511. YAML accepts
+                                      both octal and decimal values, JSON requires
+                                      decimal values for mode bits. Directories within
+                                      the path are not affected by this setting. This
+                                      might be in conflict with other options that
+                                      affect the file mode, like fsGroup, and the
+                                      result can be other mode bits set.
+                                    format: int32
+                                    type: integer
+                                  sources:
+                                    description: sources is the list of volume projections
+                                    items:
+                                      description: Projection that may be projected
+                                        along with other supported volume types
+                                      properties:
+                                        configMap:
+                                          description: configMap information about
+                                            the configMap data to project
+                                          properties:
+                                            items:
+                                              description: items if unspecified, each
+                                                key-value pair in the Data field of
+                                                the referenced ConfigMap will be projected
+                                                into the volume as a file whose name
+                                                is the key and content is the value.
+                                                If specified, the listed keys will
+                                                be projected into the specified paths,
+                                                and unlisted keys will not be present.
+                                                If a key is specified which is not
+                                                present in the ConfigMap, the volume
+                                                setup will error unless it is marked
+                                                optional. Paths must be relative and
+                                                may not contain the '..' path or start
+                                                with '..'.
+                                              items:
+                                                description: Maps a string key to
+                                                  a path within a volume.
+                                                properties:
+                                                  key:
+                                                    description: key is the key to
+                                                      project.
+                                                    type: string
+                                                  mode:
+                                                    description: 'mode is Optional:
+                                                      mode bits used to set permissions
+                                                      on this file. Must be an octal
+                                                      value between 0000 and 0777
+                                                      or a decimal value between 0
+                                                      and 511. YAML accepts both octal
+                                                      and decimal values, JSON requires
+                                                      decimal values for mode bits.
+                                                      If not specified, the volume
+                                                      defaultMode will be used. This
+                                                      might be in conflict with other
+                                                      options that affect the file
+                                                      mode, like fsGroup, and the
+                                                      result can be other mode bits
+                                                      set.'
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    description: path is the relative
+                                                      path of the file to map the
+                                                      key to. May not be an absolute
+                                                      path. May not contain the path
+                                                      element '..'. May not start
+                                                      with the string '..'.
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                type: object
+                                              type: array
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: optional specify whether
+                                                the ConfigMap or its keys must be
+                                                defined
+                                              type: boolean
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        downwardAPI:
+                                          description: downwardAPI information about
+                                            the downwardAPI data to project
+                                          properties:
+                                            items:
+                                              description: Items is a list of DownwardAPIVolume
+                                                file
+                                              items:
+                                                description: DownwardAPIVolumeFile
+                                                  represents information to create
+                                                  the file containing the pod field
+                                                properties:
+                                                  fieldRef:
+                                                    description: 'Required: Selects
+                                                      a field of the pod: only annotations,
+                                                      labels, name and namespace are
+                                                      supported.'
+                                                    properties:
+                                                      apiVersion:
+                                                        description: Version of the
+                                                          schema the FieldPath is
+                                                          written in terms of, defaults
+                                                          to "v1".
+                                                        type: string
+                                                      fieldPath:
+                                                        description: Path of the field
+                                                          to select in the specified
+                                                          API version.
+                                                        type: string
+                                                    required:
+                                                    - fieldPath
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  mode:
+                                                    description: 'Optional: mode bits
+                                                      used to set permissions on this
+                                                      file, must be an octal value
+                                                      between 0000 and 0777 or a decimal
+                                                      value between 0 and 511. YAML
+                                                      accepts both octal and decimal
+                                                      values, JSON requires decimal
+                                                      values for mode bits. If not
+                                                      specified, the volume defaultMode
+                                                      will be used. This might be
+                                                      in conflict with other options
+                                                      that affect the file mode, like
+                                                      fsGroup, and the result can
+                                                      be other mode bits set.'
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    description: 'Required: Path is  the
+                                                      relative path name of the file
+                                                      to be created. Must not be absolute
+                                                      or contain the ''..'' path.
+                                                      Must be utf-8 encoded. The first
+                                                      item of the relative path must
+                                                      not start with ''..'''
+                                                    type: string
+                                                  resourceFieldRef:
+                                                    description: 'Selects a resource
+                                                      of the container: only resources
+                                                      limits and requests (limits.cpu,
+                                                      limits.memory, requests.cpu
+                                                      and requests.memory) are currently
+                                                      supported.'
+                                                    properties:
+                                                      containerName:
+                                                        description: 'Container name:
+                                                          required for volumes, optional
+                                                          for env vars'
+                                                        type: string
+                                                      divisor:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        description: Specifies the
+                                                          output format of the exposed
+                                                          resources, defaults to "1"
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      resource:
+                                                        description: 'Required: resource
+                                                          to select'
+                                                        type: string
+                                                    required:
+                                                    - resource
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                required:
+                                                - path
+                                                type: object
+                                              type: array
+                                          type: object
+                                        secret:
+                                          description: secret information about the
+                                            secret data to project
+                                          properties:
+                                            items:
+                                              description: items if unspecified, each
+                                                key-value pair in the Data field of
+                                                the referenced Secret will be projected
+                                                into the volume as a file whose name
+                                                is the key and content is the value.
+                                                If specified, the listed keys will
+                                                be projected into the specified paths,
+                                                and unlisted keys will not be present.
+                                                If a key is specified which is not
+                                                present in the Secret, the volume
+                                                setup will error unless it is marked
+                                                optional. Paths must be relative and
+                                                may not contain the '..' path or start
+                                                with '..'.
+                                              items:
+                                                description: Maps a string key to
+                                                  a path within a volume.
+                                                properties:
+                                                  key:
+                                                    description: key is the key to
+                                                      project.
+                                                    type: string
+                                                  mode:
+                                                    description: 'mode is Optional:
+                                                      mode bits used to set permissions
+                                                      on this file. Must be an octal
+                                                      value between 0000 and 0777
+                                                      or a decimal value between 0
+                                                      and 511. YAML accepts both octal
+                                                      and decimal values, JSON requires
+                                                      decimal values for mode bits.
+                                                      If not specified, the volume
+                                                      defaultMode will be used. This
+                                                      might be in conflict with other
+                                                      options that affect the file
+                                                      mode, like fsGroup, and the
+                                                      result can be other mode bits
+                                                      set.'
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    description: path is the relative
+                                                      path of the file to map the
+                                                      key to. May not be an absolute
+                                                      path. May not contain the path
+                                                      element '..'. May not start
+                                                      with the string '..'.
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                type: object
+                                              type: array
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: optional field specify
+                                                whether the Secret or its key must
+                                                be defined
+                                              type: boolean
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        serviceAccountToken:
+                                          description: serviceAccountToken is information
+                                            about the serviceAccountToken data to
+                                            project
+                                          properties:
+                                            audience:
+                                              description: audience is the intended
+                                                audience of the token. A recipient
+                                                of a token must identify itself with
+                                                an identifier specified in the audience
+                                                of the token, and otherwise should
+                                                reject the token. The audience defaults
+                                                to the identifier of the apiserver.
+                                              type: string
+                                            expirationSeconds:
+                                              description: expirationSeconds is the
+                                                requested duration of validity of
+                                                the service account token. As the
+                                                token approaches expiration, the kubelet
+                                                volume plugin will proactively rotate
+                                                the service account token. The kubelet
+                                                will start trying to rotate the token
+                                                if the token is older than 80 percent
+                                                of its time to live or if the token
+                                                is older than 24 hours.Defaults to
+                                                1 hour and must be at least 10 minutes.
+                                              format: int64
+                                              type: integer
+                                            path:
+                                              description: path is the path relative
+                                                to the mount point of the file to
+                                                project the token into.
+                                              type: string
+                                          required:
+                                          - path
+                                          type: object
+                                      type: object
+                                    type: array
+                                type: object
+                              quobyte:
+                                description: quobyte represents a Quobyte mount on
+                                  the host that shares a pod's lifetime
+                                properties:
+                                  group:
+                                    description: group to map volume access to Default
+                                      is no group
+                                    type: string
+                                  readOnly:
+                                    description: readOnly here will force the Quobyte
+                                      volume to be mounted with read-only permissions.
+                                      Defaults to false.
+                                    type: boolean
+                                  registry:
+                                    description: registry represents a single or multiple
+                                      Quobyte Registry services specified as a string
+                                      as host:port pair (multiple entries are separated
+                                      with commas) which acts as the central registry
+                                      for volumes
+                                    type: string
+                                  tenant:
+                                    description: tenant owning the given Quobyte volume
+                                      in the Backend Used with dynamically provisioned
+                                      Quobyte volumes, value is set by the plugin
+                                    type: string
+                                  user:
+                                    description: user to map volume access to Defaults
+                                      to serivceaccount user
+                                    type: string
+                                  volume:
+                                    description: volume is a string that references
+                                      an already created Quobyte volume by name.
+                                    type: string
+                                required:
+                                - registry
+                                - volume
+                                type: object
+                              rbd:
+                                description: 'rbd represents a Rados Block Device
+                                  mount on the host that shares a pod''s lifetime.
+                                  More info: https://examples.k8s.io/volumes/rbd/README.md'
+                                properties:
+                                  fsType:
+                                    description: 'fsType is the filesystem type of
+                                      the volume that you want to mount. Tip: Ensure
+                                      that the filesystem type is supported by the
+                                      host operating system. Examples: "ext4", "xfs",
+                                      "ntfs". Implicitly inferred to be "ext4" if
+                                      unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                      TODO: how do we prevent errors in the filesystem
+                                      from compromising the machine'
+                                    type: string
+                                  image:
+                                    description: 'image is the rados image name. More
+                                      info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                    type: string
+                                  keyring:
+                                    description: 'keyring is the path to key ring
+                                      for RBDUser. Default is /etc/ceph/keyring. More
+                                      info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                    type: string
+                                  monitors:
+                                    description: 'monitors is a collection of Ceph
+                                      monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                    items:
+                                      type: string
+                                    type: array
+                                  pool:
+                                    description: 'pool is the rados pool name. Default
+                                      is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                    type: string
+                                  readOnly:
+                                    description: 'readOnly here will force the ReadOnly
+                                      setting in VolumeMounts. Defaults to false.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                    type: boolean
+                                  secretRef:
+                                    description: 'secretRef is name of the authentication
+                                      secret for RBDUser. If provided overrides keyring.
+                                      Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  user:
+                                    description: 'user is the rados user name. Default
+                                      is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                    type: string
+                                required:
+                                - image
+                                - monitors
+                                type: object
+                              scaleIO:
+                                description: scaleIO represents a ScaleIO persistent
+                                  volume attached and mounted on Kubernetes nodes.
+                                properties:
+                                  fsType:
+                                    description: fsType is the filesystem type to
+                                      mount. Must be a filesystem type supported by
+                                      the host operating system. Ex. "ext4", "xfs",
+                                      "ntfs". Default is "xfs".
+                                    type: string
+                                  gateway:
+                                    description: gateway is the host address of the
+                                      ScaleIO API Gateway.
+                                    type: string
+                                  protectionDomain:
+                                    description: protectionDomain is the name of the
+                                      ScaleIO Protection Domain for the configured
+                                      storage.
+                                    type: string
+                                  readOnly:
+                                    description: readOnly Defaults to false (read/write).
+                                      ReadOnly here will force the ReadOnly setting
+                                      in VolumeMounts.
+                                    type: boolean
+                                  secretRef:
+                                    description: secretRef references to the secret
+                                      for ScaleIO user and other sensitive information.
+                                      If this is not provided, Login operation will
+                                      fail.
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  sslEnabled:
+                                    description: sslEnabled Flag enable/disable SSL
+                                      communication with Gateway, default false
+                                    type: boolean
+                                  storageMode:
+                                    description: storageMode indicates whether the
+                                      storage for a volume should be ThickProvisioned
+                                      or ThinProvisioned. Default is ThinProvisioned.
+                                    type: string
+                                  storagePool:
+                                    description: storagePool is the ScaleIO Storage
+                                      Pool associated with the protection domain.
+                                    type: string
+                                  system:
+                                    description: system is the name of the storage
+                                      system as configured in ScaleIO.
+                                    type: string
+                                  volumeName:
+                                    description: volumeName is the name of a volume
+                                      already created in the ScaleIO system that is
+                                      associated with this volume source.
+                                    type: string
+                                required:
+                                - gateway
+                                - secretRef
+                                - system
+                                type: object
+                              secret:
+                                description: 'secret represents a secret that should
+                                  populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                properties:
+                                  defaultMode:
+                                    description: 'defaultMode is Optional: mode bits
+                                      used to set permissions on created files by
+                                      default. Must be an octal value between 0000
+                                      and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values,
+                                      JSON requires decimal values for mode bits.
+                                      Defaults to 0644. Directories within the path
+                                      are not affected by this setting. This might
+                                      be in conflict with other options that affect
+                                      the file mode, like fsGroup, and the result
+                                      can be other mode bits set.'
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    description: items If unspecified, each key-value
+                                      pair in the Data field of the referenced Secret
+                                      will be projected into the volume as a file
+                                      whose name is the key and content is the value.
+                                      If specified, the listed keys will be projected
+                                      into the specified paths, and unlisted keys
+                                      will not be present. If a key is specified which
+                                      is not present in the Secret, the volume setup
+                                      will error unless it is marked optional. Paths
+                                      must be relative and may not contain the '..'
+                                      path or start with '..'.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: 'mode is Optional: mode bits
+                                            used to set permissions on this file.
+                                            Must be an octal value between 0000 and
+                                            0777 or a decimal value between 0 and
+                                            511. YAML accepts both octal and decimal
+                                            values, JSON requires decimal values for
+                                            mode bits. If not specified, the volume
+                                            defaultMode will be used. This might be
+                                            in conflict with other options that affect
+                                            the file mode, like fsGroup, and the result
+                                            can be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: path is the relative path of
+                                            the file to map the key to. May not be
+                                            an absolute path. May not contain the
+                                            path element '..'. May not start with
+                                            the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                  optional:
+                                    description: optional field specify whether the
+                                      Secret or its keys must be defined
+                                    type: boolean
+                                  secretName:
+                                    description: 'secretName is the name of the secret
+                                      in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                    type: string
+                                type: object
+                              storageos:
+                                description: storageOS represents a StorageOS volume
+                                  attached and mounted on Kubernetes nodes.
+                                properties:
+                                  fsType:
+                                    description: fsType is the filesystem type to
+                                      mount. Must be a filesystem type supported by
+                                      the host operating system. Ex. "ext4", "xfs",
+                                      "ntfs". Implicitly inferred to be "ext4" if
+                                      unspecified.
+                                    type: string
+                                  readOnly:
+                                    description: readOnly defaults to false (read/write).
+                                      ReadOnly here will force the ReadOnly setting
+                                      in VolumeMounts.
+                                    type: boolean
+                                  secretRef:
+                                    description: secretRef specifies the secret to
+                                      use for obtaining the StorageOS API credentials.  If
+                                      not specified, default values will be attempted.
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  volumeName:
+                                    description: volumeName is the human-readable
+                                      name of the StorageOS volume.  Volume names
+                                      are only unique within a namespace.
+                                    type: string
+                                  volumeNamespace:
+                                    description: volumeNamespace specifies the scope
+                                      of the volume within StorageOS.  If no namespace
+                                      is specified then the Pod's namespace will be
+                                      used.  This allows the Kubernetes name scoping
+                                      to be mirrored within StorageOS for tighter
+                                      integration. Set VolumeName to any name to override
+                                      the default behaviour. Set to "default" if you
+                                      are not using namespaces within StorageOS. Namespaces
+                                      that do not pre-exist within StorageOS will
+                                      be created.
+                                    type: string
+                                type: object
+                              vsphereVolume:
+                                description: vsphereVolume represents a vSphere volume
+                                  attached and mounted on kubelets host machine
+                                properties:
+                                  fsType:
+                                    description: fsType is filesystem type to mount.
+                                      Must be a filesystem type supported by the host
+                                      operating system. Ex. "ext4", "xfs", "ntfs".
+                                      Implicitly inferred to be "ext4" if unspecified.
+                                    type: string
+                                  storagePolicyID:
+                                    description: storagePolicyID is the storage Policy
+                                      Based Management (SPBM) profile ID associated
+                                      with the StoragePolicyName.
+                                    type: string
+                                  storagePolicyName:
+                                    description: storagePolicyName is the storage
+                                      Policy Based Management (SPBM) profile name.
+                                    type: string
+                                  volumePath:
+                                    description: volumePath is the path that identifies
+                                      vSphere volume vmdk
+                                    type: string
+                                required:
+                                - volumePath
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                      required:
+                      - mounts
+                      - volumes
+                      type: object
+                    type: array
                   managed:
                     description: Managed - Whether the node is actually provisioned
                       (True) or should be treated as preprovisioned (False)

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
@@ -54,6 +54,1758 @@ spec:
                   ansibleVars:
                     description: AnsibleVars for configuring ansible
                     type: string
+                  extraMounts:
+                    description: ExtraMounts containing files which can be mounted
+                      into an Ansible Execution Pod
+                    items:
+                      description: VolMounts is the data structure used to expose
+                        Volumes and Mounts that can be added to a pod according to
+                        the defined Propagation policy
+                      properties:
+                        extraVolType:
+                          description: Label associated to a given extraMount
+                          type: string
+                        mounts:
+                          items:
+                            description: VolumeMount describes a mounting of a Volume
+                              within a container.
+                            properties:
+                              mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.  Must not contain ':'.
+                                type: string
+                              mountPropagation:
+                                description: mountPropagation determines how mounts
+                                  are propagated from the host to container and the
+                                  other way around. When not set, MountPropagationNone
+                                  is used. This field is beta in 1.10.
+                                type: string
+                              name:
+                                description: This must match the Name of a Volume.
+                                type: string
+                              readOnly:
+                                description: Mounted read-only if true, read-write
+                                  otherwise (false or unspecified). Defaults to false.
+                                type: boolean
+                              subPath:
+                                description: Path within the volume from which the
+                                  container's volume should be mounted. Defaults to
+                                  "" (volume's root).
+                                type: string
+                              subPathExpr:
+                                description: Expanded path within the volume from
+                                  which the container's volume should be mounted.
+                                  Behaves similarly to SubPath but environment variable
+                                  references $(VAR_NAME) are expanded using the container's
+                                  environment. Defaults to "" (volume's root). SubPathExpr
+                                  and SubPath are mutually exclusive.
+                                type: string
+                            required:
+                            - mountPath
+                            - name
+                            type: object
+                          type: array
+                        propagation:
+                          description: Propagation defines which pod should mount
+                            the volume
+                          items:
+                            description: PropagationType identifies the Service, Group
+                              or instance (e.g. the backend) that receives an Extra
+                              Volume that can potentially be mounted
+                            type: string
+                          type: array
+                        volumes:
+                          items:
+                            description: Volume represents a named volume in a pod
+                              that may be accessed by any container in the pod.
+                            properties:
+                              awsElasticBlockStore:
+                                description: 'awsElasticBlockStore represents an AWS
+                                  Disk resource that is attached to a kubelet''s host
+                                  machine and then exposed to the pod. More info:
+                                  https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                properties:
+                                  fsType:
+                                    description: 'fsType is the filesystem type of
+                                      the volume that you want to mount. Tip: Ensure
+                                      that the filesystem type is supported by the
+                                      host operating system. Examples: "ext4", "xfs",
+                                      "ntfs". Implicitly inferred to be "ext4" if
+                                      unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                      TODO: how do we prevent errors in the filesystem
+                                      from compromising the machine'
+                                    type: string
+                                  partition:
+                                    description: 'partition is the partition in the
+                                      volume that you want to mount. If omitted, the
+                                      default is to mount by volume name. Examples:
+                                      For volume /dev/sda1, you specify the partition
+                                      as "1". Similarly, the volume partition for
+                                      /dev/sda is "0" (or you can leave the property
+                                      empty).'
+                                    format: int32
+                                    type: integer
+                                  readOnly:
+                                    description: 'readOnly value true will force the
+                                      readOnly setting in VolumeMounts. More info:
+                                      https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                    type: boolean
+                                  volumeID:
+                                    description: 'volumeID is unique ID of the persistent
+                                      disk resource in AWS (Amazon EBS volume). More
+                                      info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                    type: string
+                                required:
+                                - volumeID
+                                type: object
+                              azureDisk:
+                                description: azureDisk represents an Azure Data Disk
+                                  mount on the host and bind mount to the pod.
+                                properties:
+                                  cachingMode:
+                                    description: 'cachingMode is the Host Caching
+                                      mode: None, Read Only, Read Write.'
+                                    type: string
+                                  diskName:
+                                    description: diskName is the Name of the data
+                                      disk in the blob storage
+                                    type: string
+                                  diskURI:
+                                    description: diskURI is the URI of data disk in
+                                      the blob storage
+                                    type: string
+                                  fsType:
+                                    description: fsType is Filesystem type to mount.
+                                      Must be a filesystem type supported by the host
+                                      operating system. Ex. "ext4", "xfs", "ntfs".
+                                      Implicitly inferred to be "ext4" if unspecified.
+                                    type: string
+                                  kind:
+                                    description: 'kind expected values are Shared:
+                                      multiple blob disks per storage account  Dedicated:
+                                      single blob disk per storage account  Managed:
+                                      azure managed data disk (only in managed availability
+                                      set). defaults to shared'
+                                    type: string
+                                  readOnly:
+                                    description: readOnly Defaults to false (read/write).
+                                      ReadOnly here will force the ReadOnly setting
+                                      in VolumeMounts.
+                                    type: boolean
+                                required:
+                                - diskName
+                                - diskURI
+                                type: object
+                              azureFile:
+                                description: azureFile represents an Azure File Service
+                                  mount on the host and bind mount to the pod.
+                                properties:
+                                  readOnly:
+                                    description: readOnly defaults to false (read/write).
+                                      ReadOnly here will force the ReadOnly setting
+                                      in VolumeMounts.
+                                    type: boolean
+                                  secretName:
+                                    description: secretName is the  name of secret
+                                      that contains Azure Storage Account Name and
+                                      Key
+                                    type: string
+                                  shareName:
+                                    description: shareName is the azure share Name
+                                    type: string
+                                required:
+                                - secretName
+                                - shareName
+                                type: object
+                              cephfs:
+                                description: cephFS represents a Ceph FS mount on
+                                  the host that shares a pod's lifetime
+                                properties:
+                                  monitors:
+                                    description: 'monitors is Required: Monitors is
+                                      a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                    items:
+                                      type: string
+                                    type: array
+                                  path:
+                                    description: 'path is Optional: Used as the mounted
+                                      root, rather than the full Ceph tree, default
+                                      is /'
+                                    type: string
+                                  readOnly:
+                                    description: 'readOnly is Optional: Defaults to
+                                      false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts. More info:
+                                      https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                    type: boolean
+                                  secretFile:
+                                    description: 'secretFile is Optional: SecretFile
+                                      is the path to key ring for User, default is
+                                      /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                    type: string
+                                  secretRef:
+                                    description: 'secretRef is Optional: SecretRef
+                                      is reference to the authentication secret for
+                                      User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  user:
+                                    description: 'user is optional: User is the rados
+                                      user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                    type: string
+                                required:
+                                - monitors
+                                type: object
+                              cinder:
+                                description: 'cinder represents a cinder volume attached
+                                  and mounted on kubelets host machine. More info:
+                                  https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                properties:
+                                  fsType:
+                                    description: 'fsType is the filesystem type to
+                                      mount. Must be a filesystem type supported by
+                                      the host operating system. Examples: "ext4",
+                                      "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                      if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                    type: string
+                                  readOnly:
+                                    description: 'readOnly defaults to false (read/write).
+                                      ReadOnly here will force the ReadOnly setting
+                                      in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                    type: boolean
+                                  secretRef:
+                                    description: 'secretRef is optional: points to
+                                      a secret object containing parameters used to
+                                      connect to OpenStack.'
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  volumeID:
+                                    description: 'volumeID used to identify the volume
+                                      in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                    type: string
+                                required:
+                                - volumeID
+                                type: object
+                              configMap:
+                                description: configMap represents a configMap that
+                                  should populate this volume
+                                properties:
+                                  defaultMode:
+                                    description: 'defaultMode is optional: mode bits
+                                      used to set permissions on created files by
+                                      default. Must be an octal value between 0000
+                                      and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values,
+                                      JSON requires decimal values for mode bits.
+                                      Defaults to 0644. Directories within the path
+                                      are not affected by this setting. This might
+                                      be in conflict with other options that affect
+                                      the file mode, like fsGroup, and the result
+                                      can be other mode bits set.'
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    description: items if unspecified, each key-value
+                                      pair in the Data field of the referenced ConfigMap
+                                      will be projected into the volume as a file
+                                      whose name is the key and content is the value.
+                                      If specified, the listed keys will be projected
+                                      into the specified paths, and unlisted keys
+                                      will not be present. If a key is specified which
+                                      is not present in the ConfigMap, the volume
+                                      setup will error unless it is marked optional.
+                                      Paths must be relative and may not contain the
+                                      '..' path or start with '..'.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: 'mode is Optional: mode bits
+                                            used to set permissions on this file.
+                                            Must be an octal value between 0000 and
+                                            0777 or a decimal value between 0 and
+                                            511. YAML accepts both octal and decimal
+                                            values, JSON requires decimal values for
+                                            mode bits. If not specified, the volume
+                                            defaultMode will be used. This might be
+                                            in conflict with other options that affect
+                                            the file mode, like fsGroup, and the result
+                                            can be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: path is the relative path of
+                                            the file to map the key to. May not be
+                                            an absolute path. May not contain the
+                                            path element '..'. May not start with
+                                            the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: optional specify whether the ConfigMap
+                                      or its keys must be defined
+                                    type: boolean
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              csi:
+                                description: csi (Container Storage Interface) represents
+                                  ephemeral storage that is handled by certain external
+                                  CSI drivers (Beta feature).
+                                properties:
+                                  driver:
+                                    description: driver is the name of the CSI driver
+                                      that handles this volume. Consult with your
+                                      admin for the correct name as registered in
+                                      the cluster.
+                                    type: string
+                                  fsType:
+                                    description: fsType to mount. Ex. "ext4", "xfs",
+                                      "ntfs". If not provided, the empty value is
+                                      passed to the associated CSI driver which will
+                                      determine the default filesystem to apply.
+                                    type: string
+                                  nodePublishSecretRef:
+                                    description: nodePublishSecretRef is a reference
+                                      to the secret object containing sensitive information
+                                      to pass to the CSI driver to complete the CSI
+                                      NodePublishVolume and NodeUnpublishVolume calls.
+                                      This field is optional, and  may be empty if
+                                      no secret is required. If the secret object
+                                      contains more than one secret, all secret references
+                                      are passed.
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  readOnly:
+                                    description: readOnly specifies a read-only configuration
+                                      for the volume. Defaults to false (read/write).
+                                    type: boolean
+                                  volumeAttributes:
+                                    additionalProperties:
+                                      type: string
+                                    description: volumeAttributes stores driver-specific
+                                      properties that are passed to the CSI driver.
+                                      Consult your driver's documentation for supported
+                                      values.
+                                    type: object
+                                required:
+                                - driver
+                                type: object
+                              downwardAPI:
+                                description: downwardAPI represents downward API about
+                                  the pod that should populate this volume
+                                properties:
+                                  defaultMode:
+                                    description: 'Optional: mode bits to use on created
+                                      files by default. Must be a Optional: mode bits
+                                      used to set permissions on created files by
+                                      default. Must be an octal value between 0000
+                                      and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values,
+                                      JSON requires decimal values for mode bits.
+                                      Defaults to 0644. Directories within the path
+                                      are not affected by this setting. This might
+                                      be in conflict with other options that affect
+                                      the file mode, like fsGroup, and the result
+                                      can be other mode bits set.'
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    description: Items is a list of downward API volume
+                                      file
+                                    items:
+                                      description: DownwardAPIVolumeFile represents
+                                        information to create the file containing
+                                        the pod field
+                                      properties:
+                                        fieldRef:
+                                          description: 'Required: Selects a field
+                                            of the pod: only annotations, labels,
+                                            name and namespace are supported.'
+                                          properties:
+                                            apiVersion:
+                                              description: Version of the schema the
+                                                FieldPath is written in terms of,
+                                                defaults to "v1".
+                                              type: string
+                                            fieldPath:
+                                              description: Path of the field to select
+                                                in the specified API version.
+                                              type: string
+                                          required:
+                                          - fieldPath
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        mode:
+                                          description: 'Optional: mode bits used to
+                                            set permissions on this file, must be
+                                            an octal value between 0000 and 0777 or
+                                            a decimal value between 0 and 511. YAML
+                                            accepts both octal and decimal values,
+                                            JSON requires decimal values for mode
+                                            bits. If not specified, the volume defaultMode
+                                            will be used. This might be in conflict
+                                            with other options that affect the file
+                                            mode, like fsGroup, and the result can
+                                            be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: 'Required: Path is  the relative
+                                            path name of the file to be created. Must
+                                            not be absolute or contain the ''..''
+                                            path. Must be utf-8 encoded. The first
+                                            item of the relative path must not start
+                                            with ''..'''
+                                          type: string
+                                        resourceFieldRef:
+                                          description: 'Selects a resource of the
+                                            container: only resources limits and requests
+                                            (limits.cpu, limits.memory, requests.cpu
+                                            and requests.memory) are currently supported.'
+                                          properties:
+                                            containerName:
+                                              description: 'Container name: required
+                                                for volumes, optional for env vars'
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Specifies the output format
+                                                of the exposed resources, defaults
+                                                to "1"
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              description: 'Required: resource to
+                                                select'
+                                              type: string
+                                          required:
+                                          - resource
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      required:
+                                      - path
+                                      type: object
+                                    type: array
+                                type: object
+                              emptyDir:
+                                description: 'emptyDir represents a temporary directory
+                                  that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                properties:
+                                  medium:
+                                    description: 'medium represents what type of storage
+                                      medium should back this directory. The default
+                                      is "" which means to use the node''s default
+                                      medium. Must be an empty string (default) or
+                                      Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                    type: string
+                                  sizeLimit:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: 'sizeLimit is the total amount of
+                                      local storage required for this EmptyDir volume.
+                                      The size limit is also applicable for memory
+                                      medium. The maximum usage on memory medium EmptyDir
+                                      would be the minimum value between the SizeLimit
+                                      specified here and the sum of memory limits
+                                      of all containers in a pod. The default is nil
+                                      which means that the limit is undefined. More
+                                      info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                type: object
+                              ephemeral:
+                                description: "ephemeral represents a volume that is
+                                  handled by a cluster storage driver. The volume's
+                                  lifecycle is tied to the pod that defines it - it
+                                  will be created before the pod starts, and deleted
+                                  when the pod is removed. \n Use this if: a) the
+                                  volume is only needed while the pod runs, b) features
+                                  of normal volumes like restoring from snapshot or
+                                  capacity tracking are needed, c) the storage driver
+                                  is specified through a storage class, and d) the
+                                  storage driver supports dynamic volume provisioning
+                                  through a PersistentVolumeClaim (see EphemeralVolumeSource
+                                  for more information on the connection between this
+                                  volume type and PersistentVolumeClaim). \n Use PersistentVolumeClaim
+                                  or one of the vendor-specific APIs for volumes that
+                                  persist for longer than the lifecycle of an individual
+                                  pod. \n Use CSI for light-weight local ephemeral
+                                  volumes if the CSI driver is meant to be used that
+                                  way - see the documentation of the driver for more
+                                  information. \n A pod can use both types of ephemeral
+                                  volumes and persistent volumes at the same time."
+                                properties:
+                                  volumeClaimTemplate:
+                                    description: "Will be used to create a stand-alone
+                                      PVC to provision the volume. The pod in which
+                                      this EphemeralVolumeSource is embedded will
+                                      be the owner of the PVC, i.e. the PVC will be
+                                      deleted together with the pod.  The name of
+                                      the PVC will be `<pod name>-<volume name>` where
+                                      `<volume name>` is the name from the `PodSpec.Volumes`
+                                      array entry. Pod validation will reject the
+                                      pod if the concatenated name is not valid for
+                                      a PVC (for example, too long). \n An existing
+                                      PVC with that name that is not owned by the
+                                      pod will *not* be used for the pod to avoid
+                                      using an unrelated volume by mistake. Starting
+                                      the pod is then blocked until the unrelated
+                                      PVC is removed. If such a pre-created PVC is
+                                      meant to be used by the pod, the PVC has to
+                                      updated with an owner reference to the pod once
+                                      the pod exists. Normally this should not be
+                                      necessary, but it may be useful when manually
+                                      reconstructing a broken cluster. \n This field
+                                      is read-only and no changes will be made by
+                                      Kubernetes to the PVC after it has been created.
+                                      \n Required, must not be nil."
+                                    properties:
+                                      metadata:
+                                        description: May contain labels and annotations
+                                          that will be copied into the PVC when creating
+                                          it. No other fields are allowed and will
+                                          be rejected during validation.
+                                        type: object
+                                      spec:
+                                        description: The specification for the PersistentVolumeClaim.
+                                          The entire content is copied unchanged into
+                                          the PVC that gets created from this template.
+                                          The same fields as in a PersistentVolumeClaim
+                                          are also valid here.
+                                        properties:
+                                          accessModes:
+                                            description: 'accessModes contains the
+                                              desired access modes the volume should
+                                              have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                            items:
+                                              type: string
+                                            type: array
+                                          dataSource:
+                                            description: 'dataSource field can be
+                                              used to specify either: * An existing
+                                              VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                              * An existing PVC (PersistentVolumeClaim)
+                                              If the provisioner or an external controller
+                                              can support the specified data source,
+                                              it will create a new volume based on
+                                              the contents of the specified data source.
+                                              If the AnyVolumeDataSource feature gate
+                                              is enabled, this field will always have
+                                              the same contents as the DataSourceRef
+                                              field.'
+                                            properties:
+                                              apiGroup:
+                                                description: APIGroup is the group
+                                                  for the resource being referenced.
+                                                  If APIGroup is not specified, the
+                                                  specified Kind must be in the core
+                                                  API group. For any other third-party
+                                                  types, APIGroup is required.
+                                                type: string
+                                              kind:
+                                                description: Kind is the type of resource
+                                                  being referenced
+                                                type: string
+                                              name:
+                                                description: Name is the name of resource
+                                                  being referenced
+                                                type: string
+                                            required:
+                                            - kind
+                                            - name
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          dataSourceRef:
+                                            description: 'dataSourceRef specifies
+                                              the object from which to populate the
+                                              volume with data, if a non-empty volume
+                                              is desired. This may be any local object
+                                              from a non-empty API group (non core
+                                              object) or a PersistentVolumeClaim object.
+                                              When this field is specified, volume
+                                              binding will only succeed if the type
+                                              of the specified object matches some
+                                              installed volume populator or dynamic
+                                              provisioner. This field will replace
+                                              the functionality of the DataSource
+                                              field and as such if both fields are
+                                              non-empty, they must have the same value.
+                                              For backwards compatibility, both fields
+                                              (DataSource and DataSourceRef) will
+                                              be set to the same value automatically
+                                              if one of them is empty and the other
+                                              is non-empty. There are two important
+                                              differences between DataSource and DataSourceRef:
+                                              * While DataSource only allows two specific
+                                              types of objects, DataSourceRef allows
+                                              any non-core object, as well as PersistentVolumeClaim
+                                              objects. * While DataSource ignores
+                                              disallowed values (dropping them), DataSourceRef
+                                              preserves all values, and generates
+                                              an error if a disallowed value is specified.
+                                              (Beta) Using this field requires the
+                                              AnyVolumeDataSource feature gate to
+                                              be enabled.'
+                                            properties:
+                                              apiGroup:
+                                                description: APIGroup is the group
+                                                  for the resource being referenced.
+                                                  If APIGroup is not specified, the
+                                                  specified Kind must be in the core
+                                                  API group. For any other third-party
+                                                  types, APIGroup is required.
+                                                type: string
+                                              kind:
+                                                description: Kind is the type of resource
+                                                  being referenced
+                                                type: string
+                                              name:
+                                                description: Name is the name of resource
+                                                  being referenced
+                                                type: string
+                                            required:
+                                            - kind
+                                            - name
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          resources:
+                                            description: 'resources represents the
+                                              minimum resources the volume should
+                                              have. If RecoverVolumeExpansionFailure
+                                              feature is enabled users are allowed
+                                              to specify resource requirements that
+                                              are lower than previous value but must
+                                              still be higher than capacity recorded
+                                              in the status field of the claim. More
+                                              info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                            properties:
+                                              limits:
+                                                additionalProperties:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                description: 'Limits describes the
+                                                  maximum amount of compute resources
+                                                  allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                type: object
+                                              requests:
+                                                additionalProperties:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                description: 'Requests describes the
+                                                  minimum amount of compute resources
+                                                  required. If Requests is omitted
+                                                  for a container, it defaults to
+                                                  Limits if that is explicitly specified,
+                                                  otherwise to an implementation-defined
+                                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                type: object
+                                            type: object
+                                          selector:
+                                            description: selector is a label query
+                                              over volumes to consider for binding.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents
+                                                        a key's relationship to a
+                                                        set of values. Valid operators
+                                                        are In, NotIn, Exists and
+                                                        DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array
+                                                        of string values. If the operator
+                                                        is In or NotIn, the values
+                                                        array must be non-empty. If
+                                                        the operator is Exists or
+                                                        DoesNotExist, the values array
+                                                        must be empty. This array
+                                                        is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs. A single {key,value}
+                                                  in the matchLabels map is equivalent
+                                                  to an element of matchExpressions,
+                                                  whose key field is "key", the operator
+                                                  is "In", and the values array contains
+                                                  only "value". The requirements are
+                                                  ANDed.
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          storageClassName:
+                                            description: 'storageClassName is the
+                                              name of the StorageClass required by
+                                              the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                            type: string
+                                          volumeMode:
+                                            description: volumeMode defines what type
+                                              of volume is required by the claim.
+                                              Value of Filesystem is implied when
+                                              not included in claim spec.
+                                            type: string
+                                          volumeName:
+                                            description: volumeName is the binding
+                                              reference to the PersistentVolume backing
+                                              this claim.
+                                            type: string
+                                        type: object
+                                    required:
+                                    - spec
+                                    type: object
+                                type: object
+                              fc:
+                                description: fc represents a Fibre Channel resource
+                                  that is attached to a kubelet's host machine and
+                                  then exposed to the pod.
+                                properties:
+                                  fsType:
+                                    description: 'fsType is the filesystem type to
+                                      mount. Must be a filesystem type supported by
+                                      the host operating system. Ex. "ext4", "xfs",
+                                      "ntfs". Implicitly inferred to be "ext4" if
+                                      unspecified. TODO: how do we prevent errors
+                                      in the filesystem from compromising the machine'
+                                    type: string
+                                  lun:
+                                    description: 'lun is Optional: FC target lun number'
+                                    format: int32
+                                    type: integer
+                                  readOnly:
+                                    description: 'readOnly is Optional: Defaults to
+                                      false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.'
+                                    type: boolean
+                                  targetWWNs:
+                                    description: 'targetWWNs is Optional: FC target
+                                      worldwide names (WWNs)'
+                                    items:
+                                      type: string
+                                    type: array
+                                  wwids:
+                                    description: 'wwids Optional: FC volume world
+                                      wide identifiers (wwids) Either wwids or combination
+                                      of targetWWNs and lun must be set, but not both
+                                      simultaneously.'
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              flexVolume:
+                                description: flexVolume represents a generic volume
+                                  resource that is provisioned/attached using an exec
+                                  based plugin.
+                                properties:
+                                  driver:
+                                    description: driver is the name of the driver
+                                      to use for this volume.
+                                    type: string
+                                  fsType:
+                                    description: fsType is the filesystem type to
+                                      mount. Must be a filesystem type supported by
+                                      the host operating system. Ex. "ext4", "xfs",
+                                      "ntfs". The default filesystem depends on FlexVolume
+                                      script.
+                                    type: string
+                                  options:
+                                    additionalProperties:
+                                      type: string
+                                    description: 'options is Optional: this field
+                                      holds extra command options if any.'
+                                    type: object
+                                  readOnly:
+                                    description: 'readOnly is Optional: defaults to
+                                      false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.'
+                                    type: boolean
+                                  secretRef:
+                                    description: 'secretRef is Optional: secretRef
+                                      is reference to the secret object containing
+                                      sensitive information to pass to the plugin
+                                      scripts. This may be empty if no secret object
+                                      is specified. If the secret object contains
+                                      more than one secret, all secrets are passed
+                                      to the plugin scripts.'
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                required:
+                                - driver
+                                type: object
+                              flocker:
+                                description: flocker represents a Flocker volume attached
+                                  to a kubelet's host machine. This depends on the
+                                  Flocker control service being running
+                                properties:
+                                  datasetName:
+                                    description: datasetName is Name of the dataset
+                                      stored as metadata -> name on the dataset for
+                                      Flocker should be considered as deprecated
+                                    type: string
+                                  datasetUUID:
+                                    description: datasetUUID is the UUID of the dataset.
+                                      This is unique identifier of a Flocker dataset
+                                    type: string
+                                type: object
+                              gcePersistentDisk:
+                                description: 'gcePersistentDisk represents a GCE Disk
+                                  resource that is attached to a kubelet''s host machine
+                                  and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                properties:
+                                  fsType:
+                                    description: 'fsType is filesystem type of the
+                                      volume that you want to mount. Tip: Ensure that
+                                      the filesystem type is supported by the host
+                                      operating system. Examples: "ext4", "xfs", "ntfs".
+                                      Implicitly inferred to be "ext4" if unspecified.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                      TODO: how do we prevent errors in the filesystem
+                                      from compromising the machine'
+                                    type: string
+                                  partition:
+                                    description: 'partition is the partition in the
+                                      volume that you want to mount. If omitted, the
+                                      default is to mount by volume name. Examples:
+                                      For volume /dev/sda1, you specify the partition
+                                      as "1". Similarly, the volume partition for
+                                      /dev/sda is "0" (or you can leave the property
+                                      empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                    format: int32
+                                    type: integer
+                                  pdName:
+                                    description: 'pdName is unique name of the PD
+                                      resource in GCE. Used to identify the disk in
+                                      GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                    type: string
+                                  readOnly:
+                                    description: 'readOnly here will force the ReadOnly
+                                      setting in VolumeMounts. Defaults to false.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                    type: boolean
+                                required:
+                                - pdName
+                                type: object
+                              gitRepo:
+                                description: 'gitRepo represents a git repository
+                                  at a particular revision. DEPRECATED: GitRepo is
+                                  deprecated. To provision a container with a git
+                                  repo, mount an EmptyDir into an InitContainer that
+                                  clones the repo using git, then mount the EmptyDir
+                                  into the Pod''s container.'
+                                properties:
+                                  directory:
+                                    description: directory is the target directory
+                                      name. Must not contain or start with '..'.  If
+                                      '.' is supplied, the volume directory will be
+                                      the git repository.  Otherwise, if specified,
+                                      the volume will contain the git repository in
+                                      the subdirectory with the given name.
+                                    type: string
+                                  repository:
+                                    description: repository is the URL
+                                    type: string
+                                  revision:
+                                    description: revision is the commit hash for the
+                                      specified revision.
+                                    type: string
+                                required:
+                                - repository
+                                type: object
+                              glusterfs:
+                                description: 'glusterfs represents a Glusterfs mount
+                                  on the host that shares a pod''s lifetime. More
+                                  info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                                properties:
+                                  endpoints:
+                                    description: 'endpoints is the endpoint name that
+                                      details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                    type: string
+                                  path:
+                                    description: 'path is the Glusterfs volume path.
+                                      More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                    type: string
+                                  readOnly:
+                                    description: 'readOnly here will force the Glusterfs
+                                      volume to be mounted with read-only permissions.
+                                      Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                    type: boolean
+                                required:
+                                - endpoints
+                                - path
+                                type: object
+                              hostPath:
+                                description: 'hostPath represents a pre-existing file
+                                  or directory on the host machine that is directly
+                                  exposed to the container. This is generally used
+                                  for system agents or other privileged things that
+                                  are allowed to see the host machine. Most containers
+                                  will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                  --- TODO(jonesdl) We need to restrict who can use
+                                  host directory mounts and who can/can not mount
+                                  host directories as read/write.'
+                                properties:
+                                  path:
+                                    description: 'path of the directory on the host.
+                                      If the path is a symlink, it will follow the
+                                      link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                    type: string
+                                  type:
+                                    description: 'type for HostPath Volume Defaults
+                                      to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                    type: string
+                                required:
+                                - path
+                                type: object
+                              iscsi:
+                                description: 'iscsi represents an ISCSI Disk resource
+                                  that is attached to a kubelet''s host machine and
+                                  then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                                properties:
+                                  chapAuthDiscovery:
+                                    description: chapAuthDiscovery defines whether
+                                      support iSCSI Discovery CHAP authentication
+                                    type: boolean
+                                  chapAuthSession:
+                                    description: chapAuthSession defines whether support
+                                      iSCSI Session CHAP authentication
+                                    type: boolean
+                                  fsType:
+                                    description: 'fsType is the filesystem type of
+                                      the volume that you want to mount. Tip: Ensure
+                                      that the filesystem type is supported by the
+                                      host operating system. Examples: "ext4", "xfs",
+                                      "ntfs". Implicitly inferred to be "ext4" if
+                                      unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                      TODO: how do we prevent errors in the filesystem
+                                      from compromising the machine'
+                                    type: string
+                                  initiatorName:
+                                    description: initiatorName is the custom iSCSI
+                                      Initiator Name. If initiatorName is specified
+                                      with iscsiInterface simultaneously, new iSCSI
+                                      interface <target portal>:<volume name> will
+                                      be created for the connection.
+                                    type: string
+                                  iqn:
+                                    description: iqn is the target iSCSI Qualified
+                                      Name.
+                                    type: string
+                                  iscsiInterface:
+                                    description: iscsiInterface is the interface Name
+                                      that uses an iSCSI transport. Defaults to 'default'
+                                      (tcp).
+                                    type: string
+                                  lun:
+                                    description: lun represents iSCSI Target Lun number.
+                                    format: int32
+                                    type: integer
+                                  portals:
+                                    description: portals is the iSCSI Target Portal
+                                      List. The portal is either an IP or ip_addr:port
+                                      if the port is other than default (typically
+                                      TCP ports 860 and 3260).
+                                    items:
+                                      type: string
+                                    type: array
+                                  readOnly:
+                                    description: readOnly here will force the ReadOnly
+                                      setting in VolumeMounts. Defaults to false.
+                                    type: boolean
+                                  secretRef:
+                                    description: secretRef is the CHAP Secret for
+                                      iSCSI target and initiator authentication
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  targetPortal:
+                                    description: targetPortal is iSCSI Target Portal.
+                                      The Portal is either an IP or ip_addr:port if
+                                      the port is other than default (typically TCP
+                                      ports 860 and 3260).
+                                    type: string
+                                required:
+                                - iqn
+                                - lun
+                                - targetPortal
+                                type: object
+                              name:
+                                description: 'name of the volume. Must be a DNS_LABEL
+                                  and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              nfs:
+                                description: 'nfs represents an NFS mount on the host
+                                  that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                properties:
+                                  path:
+                                    description: 'path that is exported by the NFS
+                                      server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                    type: string
+                                  readOnly:
+                                    description: 'readOnly here will force the NFS
+                                      export to be mounted with read-only permissions.
+                                      Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                    type: boolean
+                                  server:
+                                    description: 'server is the hostname or IP address
+                                      of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                    type: string
+                                required:
+                                - path
+                                - server
+                                type: object
+                              persistentVolumeClaim:
+                                description: 'persistentVolumeClaimVolumeSource represents
+                                  a reference to a PersistentVolumeClaim in the same
+                                  namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                properties:
+                                  claimName:
+                                    description: 'claimName is the name of a PersistentVolumeClaim
+                                      in the same namespace as the pod using this
+                                      volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                    type: string
+                                  readOnly:
+                                    description: readOnly Will force the ReadOnly
+                                      setting in VolumeMounts. Default false.
+                                    type: boolean
+                                required:
+                                - claimName
+                                type: object
+                              photonPersistentDisk:
+                                description: photonPersistentDisk represents a PhotonController
+                                  persistent disk attached and mounted on kubelets
+                                  host machine
+                                properties:
+                                  fsType:
+                                    description: fsType is the filesystem type to
+                                      mount. Must be a filesystem type supported by
+                                      the host operating system. Ex. "ext4", "xfs",
+                                      "ntfs". Implicitly inferred to be "ext4" if
+                                      unspecified.
+                                    type: string
+                                  pdID:
+                                    description: pdID is the ID that identifies Photon
+                                      Controller persistent disk
+                                    type: string
+                                required:
+                                - pdID
+                                type: object
+                              portworxVolume:
+                                description: portworxVolume represents a portworx
+                                  volume attached and mounted on kubelets host machine
+                                properties:
+                                  fsType:
+                                    description: fSType represents the filesystem
+                                      type to mount Must be a filesystem type supported
+                                      by the host operating system. Ex. "ext4", "xfs".
+                                      Implicitly inferred to be "ext4" if unspecified.
+                                    type: string
+                                  readOnly:
+                                    description: readOnly defaults to false (read/write).
+                                      ReadOnly here will force the ReadOnly setting
+                                      in VolumeMounts.
+                                    type: boolean
+                                  volumeID:
+                                    description: volumeID uniquely identifies a Portworx
+                                      volume
+                                    type: string
+                                required:
+                                - volumeID
+                                type: object
+                              projected:
+                                description: projected items for all in one resources
+                                  secrets, configmaps, and downward API
+                                properties:
+                                  defaultMode:
+                                    description: defaultMode are the mode bits used
+                                      to set permissions on created files by default.
+                                      Must be an octal value between 0000 and 0777
+                                      or a decimal value between 0 and 511. YAML accepts
+                                      both octal and decimal values, JSON requires
+                                      decimal values for mode bits. Directories within
+                                      the path are not affected by this setting. This
+                                      might be in conflict with other options that
+                                      affect the file mode, like fsGroup, and the
+                                      result can be other mode bits set.
+                                    format: int32
+                                    type: integer
+                                  sources:
+                                    description: sources is the list of volume projections
+                                    items:
+                                      description: Projection that may be projected
+                                        along with other supported volume types
+                                      properties:
+                                        configMap:
+                                          description: configMap information about
+                                            the configMap data to project
+                                          properties:
+                                            items:
+                                              description: items if unspecified, each
+                                                key-value pair in the Data field of
+                                                the referenced ConfigMap will be projected
+                                                into the volume as a file whose name
+                                                is the key and content is the value.
+                                                If specified, the listed keys will
+                                                be projected into the specified paths,
+                                                and unlisted keys will not be present.
+                                                If a key is specified which is not
+                                                present in the ConfigMap, the volume
+                                                setup will error unless it is marked
+                                                optional. Paths must be relative and
+                                                may not contain the '..' path or start
+                                                with '..'.
+                                              items:
+                                                description: Maps a string key to
+                                                  a path within a volume.
+                                                properties:
+                                                  key:
+                                                    description: key is the key to
+                                                      project.
+                                                    type: string
+                                                  mode:
+                                                    description: 'mode is Optional:
+                                                      mode bits used to set permissions
+                                                      on this file. Must be an octal
+                                                      value between 0000 and 0777
+                                                      or a decimal value between 0
+                                                      and 511. YAML accepts both octal
+                                                      and decimal values, JSON requires
+                                                      decimal values for mode bits.
+                                                      If not specified, the volume
+                                                      defaultMode will be used. This
+                                                      might be in conflict with other
+                                                      options that affect the file
+                                                      mode, like fsGroup, and the
+                                                      result can be other mode bits
+                                                      set.'
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    description: path is the relative
+                                                      path of the file to map the
+                                                      key to. May not be an absolute
+                                                      path. May not contain the path
+                                                      element '..'. May not start
+                                                      with the string '..'.
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                type: object
+                                              type: array
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: optional specify whether
+                                                the ConfigMap or its keys must be
+                                                defined
+                                              type: boolean
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        downwardAPI:
+                                          description: downwardAPI information about
+                                            the downwardAPI data to project
+                                          properties:
+                                            items:
+                                              description: Items is a list of DownwardAPIVolume
+                                                file
+                                              items:
+                                                description: DownwardAPIVolumeFile
+                                                  represents information to create
+                                                  the file containing the pod field
+                                                properties:
+                                                  fieldRef:
+                                                    description: 'Required: Selects
+                                                      a field of the pod: only annotations,
+                                                      labels, name and namespace are
+                                                      supported.'
+                                                    properties:
+                                                      apiVersion:
+                                                        description: Version of the
+                                                          schema the FieldPath is
+                                                          written in terms of, defaults
+                                                          to "v1".
+                                                        type: string
+                                                      fieldPath:
+                                                        description: Path of the field
+                                                          to select in the specified
+                                                          API version.
+                                                        type: string
+                                                    required:
+                                                    - fieldPath
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  mode:
+                                                    description: 'Optional: mode bits
+                                                      used to set permissions on this
+                                                      file, must be an octal value
+                                                      between 0000 and 0777 or a decimal
+                                                      value between 0 and 511. YAML
+                                                      accepts both octal and decimal
+                                                      values, JSON requires decimal
+                                                      values for mode bits. If not
+                                                      specified, the volume defaultMode
+                                                      will be used. This might be
+                                                      in conflict with other options
+                                                      that affect the file mode, like
+                                                      fsGroup, and the result can
+                                                      be other mode bits set.'
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    description: 'Required: Path is  the
+                                                      relative path name of the file
+                                                      to be created. Must not be absolute
+                                                      or contain the ''..'' path.
+                                                      Must be utf-8 encoded. The first
+                                                      item of the relative path must
+                                                      not start with ''..'''
+                                                    type: string
+                                                  resourceFieldRef:
+                                                    description: 'Selects a resource
+                                                      of the container: only resources
+                                                      limits and requests (limits.cpu,
+                                                      limits.memory, requests.cpu
+                                                      and requests.memory) are currently
+                                                      supported.'
+                                                    properties:
+                                                      containerName:
+                                                        description: 'Container name:
+                                                          required for volumes, optional
+                                                          for env vars'
+                                                        type: string
+                                                      divisor:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        description: Specifies the
+                                                          output format of the exposed
+                                                          resources, defaults to "1"
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      resource:
+                                                        description: 'Required: resource
+                                                          to select'
+                                                        type: string
+                                                    required:
+                                                    - resource
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                required:
+                                                - path
+                                                type: object
+                                              type: array
+                                          type: object
+                                        secret:
+                                          description: secret information about the
+                                            secret data to project
+                                          properties:
+                                            items:
+                                              description: items if unspecified, each
+                                                key-value pair in the Data field of
+                                                the referenced Secret will be projected
+                                                into the volume as a file whose name
+                                                is the key and content is the value.
+                                                If specified, the listed keys will
+                                                be projected into the specified paths,
+                                                and unlisted keys will not be present.
+                                                If a key is specified which is not
+                                                present in the Secret, the volume
+                                                setup will error unless it is marked
+                                                optional. Paths must be relative and
+                                                may not contain the '..' path or start
+                                                with '..'.
+                                              items:
+                                                description: Maps a string key to
+                                                  a path within a volume.
+                                                properties:
+                                                  key:
+                                                    description: key is the key to
+                                                      project.
+                                                    type: string
+                                                  mode:
+                                                    description: 'mode is Optional:
+                                                      mode bits used to set permissions
+                                                      on this file. Must be an octal
+                                                      value between 0000 and 0777
+                                                      or a decimal value between 0
+                                                      and 511. YAML accepts both octal
+                                                      and decimal values, JSON requires
+                                                      decimal values for mode bits.
+                                                      If not specified, the volume
+                                                      defaultMode will be used. This
+                                                      might be in conflict with other
+                                                      options that affect the file
+                                                      mode, like fsGroup, and the
+                                                      result can be other mode bits
+                                                      set.'
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    description: path is the relative
+                                                      path of the file to map the
+                                                      key to. May not be an absolute
+                                                      path. May not contain the path
+                                                      element '..'. May not start
+                                                      with the string '..'.
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                type: object
+                                              type: array
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: optional field specify
+                                                whether the Secret or its key must
+                                                be defined
+                                              type: boolean
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        serviceAccountToken:
+                                          description: serviceAccountToken is information
+                                            about the serviceAccountToken data to
+                                            project
+                                          properties:
+                                            audience:
+                                              description: audience is the intended
+                                                audience of the token. A recipient
+                                                of a token must identify itself with
+                                                an identifier specified in the audience
+                                                of the token, and otherwise should
+                                                reject the token. The audience defaults
+                                                to the identifier of the apiserver.
+                                              type: string
+                                            expirationSeconds:
+                                              description: expirationSeconds is the
+                                                requested duration of validity of
+                                                the service account token. As the
+                                                token approaches expiration, the kubelet
+                                                volume plugin will proactively rotate
+                                                the service account token. The kubelet
+                                                will start trying to rotate the token
+                                                if the token is older than 80 percent
+                                                of its time to live or if the token
+                                                is older than 24 hours.Defaults to
+                                                1 hour and must be at least 10 minutes.
+                                              format: int64
+                                              type: integer
+                                            path:
+                                              description: path is the path relative
+                                                to the mount point of the file to
+                                                project the token into.
+                                              type: string
+                                          required:
+                                          - path
+                                          type: object
+                                      type: object
+                                    type: array
+                                type: object
+                              quobyte:
+                                description: quobyte represents a Quobyte mount on
+                                  the host that shares a pod's lifetime
+                                properties:
+                                  group:
+                                    description: group to map volume access to Default
+                                      is no group
+                                    type: string
+                                  readOnly:
+                                    description: readOnly here will force the Quobyte
+                                      volume to be mounted with read-only permissions.
+                                      Defaults to false.
+                                    type: boolean
+                                  registry:
+                                    description: registry represents a single or multiple
+                                      Quobyte Registry services specified as a string
+                                      as host:port pair (multiple entries are separated
+                                      with commas) which acts as the central registry
+                                      for volumes
+                                    type: string
+                                  tenant:
+                                    description: tenant owning the given Quobyte volume
+                                      in the Backend Used with dynamically provisioned
+                                      Quobyte volumes, value is set by the plugin
+                                    type: string
+                                  user:
+                                    description: user to map volume access to Defaults
+                                      to serivceaccount user
+                                    type: string
+                                  volume:
+                                    description: volume is a string that references
+                                      an already created Quobyte volume by name.
+                                    type: string
+                                required:
+                                - registry
+                                - volume
+                                type: object
+                              rbd:
+                                description: 'rbd represents a Rados Block Device
+                                  mount on the host that shares a pod''s lifetime.
+                                  More info: https://examples.k8s.io/volumes/rbd/README.md'
+                                properties:
+                                  fsType:
+                                    description: 'fsType is the filesystem type of
+                                      the volume that you want to mount. Tip: Ensure
+                                      that the filesystem type is supported by the
+                                      host operating system. Examples: "ext4", "xfs",
+                                      "ntfs". Implicitly inferred to be "ext4" if
+                                      unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                      TODO: how do we prevent errors in the filesystem
+                                      from compromising the machine'
+                                    type: string
+                                  image:
+                                    description: 'image is the rados image name. More
+                                      info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                    type: string
+                                  keyring:
+                                    description: 'keyring is the path to key ring
+                                      for RBDUser. Default is /etc/ceph/keyring. More
+                                      info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                    type: string
+                                  monitors:
+                                    description: 'monitors is a collection of Ceph
+                                      monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                    items:
+                                      type: string
+                                    type: array
+                                  pool:
+                                    description: 'pool is the rados pool name. Default
+                                      is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                    type: string
+                                  readOnly:
+                                    description: 'readOnly here will force the ReadOnly
+                                      setting in VolumeMounts. Defaults to false.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                    type: boolean
+                                  secretRef:
+                                    description: 'secretRef is name of the authentication
+                                      secret for RBDUser. If provided overrides keyring.
+                                      Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  user:
+                                    description: 'user is the rados user name. Default
+                                      is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                    type: string
+                                required:
+                                - image
+                                - monitors
+                                type: object
+                              scaleIO:
+                                description: scaleIO represents a ScaleIO persistent
+                                  volume attached and mounted on Kubernetes nodes.
+                                properties:
+                                  fsType:
+                                    description: fsType is the filesystem type to
+                                      mount. Must be a filesystem type supported by
+                                      the host operating system. Ex. "ext4", "xfs",
+                                      "ntfs". Default is "xfs".
+                                    type: string
+                                  gateway:
+                                    description: gateway is the host address of the
+                                      ScaleIO API Gateway.
+                                    type: string
+                                  protectionDomain:
+                                    description: protectionDomain is the name of the
+                                      ScaleIO Protection Domain for the configured
+                                      storage.
+                                    type: string
+                                  readOnly:
+                                    description: readOnly Defaults to false (read/write).
+                                      ReadOnly here will force the ReadOnly setting
+                                      in VolumeMounts.
+                                    type: boolean
+                                  secretRef:
+                                    description: secretRef references to the secret
+                                      for ScaleIO user and other sensitive information.
+                                      If this is not provided, Login operation will
+                                      fail.
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  sslEnabled:
+                                    description: sslEnabled Flag enable/disable SSL
+                                      communication with Gateway, default false
+                                    type: boolean
+                                  storageMode:
+                                    description: storageMode indicates whether the
+                                      storage for a volume should be ThickProvisioned
+                                      or ThinProvisioned. Default is ThinProvisioned.
+                                    type: string
+                                  storagePool:
+                                    description: storagePool is the ScaleIO Storage
+                                      Pool associated with the protection domain.
+                                    type: string
+                                  system:
+                                    description: system is the name of the storage
+                                      system as configured in ScaleIO.
+                                    type: string
+                                  volumeName:
+                                    description: volumeName is the name of a volume
+                                      already created in the ScaleIO system that is
+                                      associated with this volume source.
+                                    type: string
+                                required:
+                                - gateway
+                                - secretRef
+                                - system
+                                type: object
+                              secret:
+                                description: 'secret represents a secret that should
+                                  populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                properties:
+                                  defaultMode:
+                                    description: 'defaultMode is Optional: mode bits
+                                      used to set permissions on created files by
+                                      default. Must be an octal value between 0000
+                                      and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values,
+                                      JSON requires decimal values for mode bits.
+                                      Defaults to 0644. Directories within the path
+                                      are not affected by this setting. This might
+                                      be in conflict with other options that affect
+                                      the file mode, like fsGroup, and the result
+                                      can be other mode bits set.'
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    description: items If unspecified, each key-value
+                                      pair in the Data field of the referenced Secret
+                                      will be projected into the volume as a file
+                                      whose name is the key and content is the value.
+                                      If specified, the listed keys will be projected
+                                      into the specified paths, and unlisted keys
+                                      will not be present. If a key is specified which
+                                      is not present in the Secret, the volume setup
+                                      will error unless it is marked optional. Paths
+                                      must be relative and may not contain the '..'
+                                      path or start with '..'.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: 'mode is Optional: mode bits
+                                            used to set permissions on this file.
+                                            Must be an octal value between 0000 and
+                                            0777 or a decimal value between 0 and
+                                            511. YAML accepts both octal and decimal
+                                            values, JSON requires decimal values for
+                                            mode bits. If not specified, the volume
+                                            defaultMode will be used. This might be
+                                            in conflict with other options that affect
+                                            the file mode, like fsGroup, and the result
+                                            can be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: path is the relative path of
+                                            the file to map the key to. May not be
+                                            an absolute path. May not contain the
+                                            path element '..'. May not start with
+                                            the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                  optional:
+                                    description: optional field specify whether the
+                                      Secret or its keys must be defined
+                                    type: boolean
+                                  secretName:
+                                    description: 'secretName is the name of the secret
+                                      in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                    type: string
+                                type: object
+                              storageos:
+                                description: storageOS represents a StorageOS volume
+                                  attached and mounted on Kubernetes nodes.
+                                properties:
+                                  fsType:
+                                    description: fsType is the filesystem type to
+                                      mount. Must be a filesystem type supported by
+                                      the host operating system. Ex. "ext4", "xfs",
+                                      "ntfs". Implicitly inferred to be "ext4" if
+                                      unspecified.
+                                    type: string
+                                  readOnly:
+                                    description: readOnly defaults to false (read/write).
+                                      ReadOnly here will force the ReadOnly setting
+                                      in VolumeMounts.
+                                    type: boolean
+                                  secretRef:
+                                    description: secretRef specifies the secret to
+                                      use for obtaining the StorageOS API credentials.  If
+                                      not specified, default values will be attempted.
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  volumeName:
+                                    description: volumeName is the human-readable
+                                      name of the StorageOS volume.  Volume names
+                                      are only unique within a namespace.
+                                    type: string
+                                  volumeNamespace:
+                                    description: volumeNamespace specifies the scope
+                                      of the volume within StorageOS.  If no namespace
+                                      is specified then the Pod's namespace will be
+                                      used.  This allows the Kubernetes name scoping
+                                      to be mirrored within StorageOS for tighter
+                                      integration. Set VolumeName to any name to override
+                                      the default behaviour. Set to "default" if you
+                                      are not using namespaces within StorageOS. Namespaces
+                                      that do not pre-exist within StorageOS will
+                                      be created.
+                                    type: string
+                                type: object
+                              vsphereVolume:
+                                description: vsphereVolume represents a vSphere volume
+                                  attached and mounted on kubelets host machine
+                                properties:
+                                  fsType:
+                                    description: fsType is filesystem type to mount.
+                                      Must be a filesystem type supported by the host
+                                      operating system. Ex. "ext4", "xfs", "ntfs".
+                                      Implicitly inferred to be "ext4" if unspecified.
+                                    type: string
+                                  storagePolicyID:
+                                    description: storagePolicyID is the storage Policy
+                                      Based Management (SPBM) profile ID associated
+                                      with the StoragePolicyName.
+                                    type: string
+                                  storagePolicyName:
+                                    description: storagePolicyName is the storage
+                                      Policy Based Management (SPBM) profile name.
+                                    type: string
+                                  volumePath:
+                                    description: volumePath is the path that identifies
+                                      vSphere volume vmdk
+                                    type: string
+                                required:
+                                - volumePath
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                      required:
+                      - mounts
+                      - volumes
+                      type: object
+                    type: array
                   managed:
                     description: Managed - Whether the node is actually provisioned
                       (True) or should be treated as preprovisioned (False)

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanes.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanes.yaml
@@ -61,6 +61,1903 @@ spec:
                         ansibleVars:
                           description: AnsibleVars for configuring ansible
                           type: string
+                        extraMounts:
+                          description: ExtraMounts containing files which can be mounted
+                            into an Ansible Execution Pod
+                          items:
+                            description: VolMounts is the data structure used to expose
+                              Volumes and Mounts that can be added to a pod according
+                              to the defined Propagation policy
+                            properties:
+                              extraVolType:
+                                description: Label associated to a given extraMount
+                                type: string
+                              mounts:
+                                items:
+                                  description: VolumeMount describes a mounting of
+                                    a Volume within a container.
+                                  properties:
+                                    mountPath:
+                                      description: Path within the container at which
+                                        the volume should be mounted.  Must not contain
+                                        ':'.
+                                      type: string
+                                    mountPropagation:
+                                      description: mountPropagation determines how
+                                        mounts are propagated from the host to container
+                                        and the other way around. When not set, MountPropagationNone
+                                        is used. This field is beta in 1.10.
+                                      type: string
+                                    name:
+                                      description: This must match the Name of a Volume.
+                                      type: string
+                                    readOnly:
+                                      description: Mounted read-only if true, read-write
+                                        otherwise (false or unspecified). Defaults
+                                        to false.
+                                      type: boolean
+                                    subPath:
+                                      description: Path within the volume from which
+                                        the container's volume should be mounted.
+                                        Defaults to "" (volume's root).
+                                      type: string
+                                    subPathExpr:
+                                      description: Expanded path within the volume
+                                        from which the container's volume should be
+                                        mounted. Behaves similarly to SubPath but
+                                        environment variable references $(VAR_NAME)
+                                        are expanded using the container's environment.
+                                        Defaults to "" (volume's root). SubPathExpr
+                                        and SubPath are mutually exclusive.
+                                      type: string
+                                  required:
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                              propagation:
+                                description: Propagation defines which pod should
+                                  mount the volume
+                                items:
+                                  description: PropagationType identifies the Service,
+                                    Group or instance (e.g. the backend) that receives
+                                    an Extra Volume that can potentially be mounted
+                                  type: string
+                                type: array
+                              volumes:
+                                items:
+                                  description: Volume represents a named volume in
+                                    a pod that may be accessed by any container in
+                                    the pod.
+                                  properties:
+                                    awsElasticBlockStore:
+                                      description: 'awsElasticBlockStore represents
+                                        an AWS Disk resource that is attached to a
+                                        kubelet''s host machine and then exposed to
+                                        the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                      properties:
+                                        fsType:
+                                          description: 'fsType is the filesystem type
+                                            of the volume that you want to mount.
+                                            Tip: Ensure that the filesystem type is
+                                            supported by the host operating system.
+                                            Examples: "ext4", "xfs", "ntfs". Implicitly
+                                            inferred to be "ext4" if unspecified.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                            TODO: how do we prevent errors in the
+                                            filesystem from compromising the machine'
+                                          type: string
+                                        partition:
+                                          description: 'partition is the partition
+                                            in the volume that you want to mount.
+                                            If omitted, the default is to mount by
+                                            volume name. Examples: For volume /dev/sda1,
+                                            you specify the partition as "1". Similarly,
+                                            the volume partition for /dev/sda is "0"
+                                            (or you can leave the property empty).'
+                                          format: int32
+                                          type: integer
+                                        readOnly:
+                                          description: 'readOnly value true will force
+                                            the readOnly setting in VolumeMounts.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                          type: boolean
+                                        volumeID:
+                                          description: 'volumeID is unique ID of the
+                                            persistent disk resource in AWS (Amazon
+                                            EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                          type: string
+                                      required:
+                                      - volumeID
+                                      type: object
+                                    azureDisk:
+                                      description: azureDisk represents an Azure Data
+                                        Disk mount on the host and bind mount to the
+                                        pod.
+                                      properties:
+                                        cachingMode:
+                                          description: 'cachingMode is the Host Caching
+                                            mode: None, Read Only, Read Write.'
+                                          type: string
+                                        diskName:
+                                          description: diskName is the Name of the
+                                            data disk in the blob storage
+                                          type: string
+                                        diskURI:
+                                          description: diskURI is the URI of data
+                                            disk in the blob storage
+                                          type: string
+                                        fsType:
+                                          description: fsType is Filesystem type to
+                                            mount. Must be a filesystem type supported
+                                            by the host operating system. Ex. "ext4",
+                                            "xfs", "ntfs". Implicitly inferred to
+                                            be "ext4" if unspecified.
+                                          type: string
+                                        kind:
+                                          description: 'kind expected values are Shared:
+                                            multiple blob disks per storage account  Dedicated:
+                                            single blob disk per storage account  Managed:
+                                            azure managed data disk (only in managed
+                                            availability set). defaults to shared'
+                                          type: string
+                                        readOnly:
+                                          description: readOnly Defaults to false
+                                            (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
+                                          type: boolean
+                                      required:
+                                      - diskName
+                                      - diskURI
+                                      type: object
+                                    azureFile:
+                                      description: azureFile represents an Azure File
+                                        Service mount on the host and bind mount to
+                                        the pod.
+                                      properties:
+                                        readOnly:
+                                          description: readOnly defaults to false
+                                            (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
+                                          type: boolean
+                                        secretName:
+                                          description: secretName is the  name of
+                                            secret that contains Azure Storage Account
+                                            Name and Key
+                                          type: string
+                                        shareName:
+                                          description: shareName is the azure share
+                                            Name
+                                          type: string
+                                      required:
+                                      - secretName
+                                      - shareName
+                                      type: object
+                                    cephfs:
+                                      description: cephFS represents a Ceph FS mount
+                                        on the host that shares a pod's lifetime
+                                      properties:
+                                        monitors:
+                                          description: 'monitors is Required: Monitors
+                                            is a collection of Ceph monitors More
+                                            info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          items:
+                                            type: string
+                                          type: array
+                                        path:
+                                          description: 'path is Optional: Used as
+                                            the mounted root, rather than the full
+                                            Ceph tree, default is /'
+                                          type: string
+                                        readOnly:
+                                          description: 'readOnly is Optional: Defaults
+                                            to false (read/write). ReadOnly here will
+                                            force the ReadOnly setting in VolumeMounts.
+                                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          type: boolean
+                                        secretFile:
+                                          description: 'secretFile is Optional: SecretFile
+                                            is the path to key ring for User, default
+                                            is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          type: string
+                                        secretRef:
+                                          description: 'secretRef is Optional: SecretRef
+                                            is reference to the authentication secret
+                                            for User, default is empty. More info:
+                                            https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        user:
+                                          description: 'user is optional: User is
+                                            the rados user name, default is admin
+                                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          type: string
+                                      required:
+                                      - monitors
+                                      type: object
+                                    cinder:
+                                      description: 'cinder represents a cinder volume
+                                        attached and mounted on kubelets host machine.
+                                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                      properties:
+                                        fsType:
+                                          description: 'fsType is the filesystem type
+                                            to mount. Must be a filesystem type supported
+                                            by the host operating system. Examples:
+                                            "ext4", "xfs", "ntfs". Implicitly inferred
+                                            to be "ext4" if unspecified. More info:
+                                            https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                          type: string
+                                        readOnly:
+                                          description: 'readOnly defaults to false
+                                            (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
+                                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                          type: boolean
+                                        secretRef:
+                                          description: 'secretRef is optional: points
+                                            to a secret object containing parameters
+                                            used to connect to OpenStack.'
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        volumeID:
+                                          description: 'volumeID used to identify
+                                            the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                          type: string
+                                      required:
+                                      - volumeID
+                                      type: object
+                                    configMap:
+                                      description: configMap represents a configMap
+                                        that should populate this volume
+                                      properties:
+                                        defaultMode:
+                                          description: 'defaultMode is optional: mode
+                                            bits used to set permissions on created
+                                            files by default. Must be an octal value
+                                            between 0000 and 0777 or a decimal value
+                                            between 0 and 511. YAML accepts both octal
+                                            and decimal values, JSON requires decimal
+                                            values for mode bits. Defaults to 0644.
+                                            Directories within the path are not affected
+                                            by this setting. This might be in conflict
+                                            with other options that affect the file
+                                            mode, like fsGroup, and the result can
+                                            be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          description: items if unspecified, each
+                                            key-value pair in the Data field of the
+                                            referenced ConfigMap will be projected
+                                            into the volume as a file whose name is
+                                            the key and content is the value. If specified,
+                                            the listed keys will be projected into
+                                            the specified paths, and unlisted keys
+                                            will not be present. If a key is specified
+                                            which is not present in the ConfigMap,
+                                            the volume setup will error unless it
+                                            is marked optional. Paths must be relative
+                                            and may not contain the '..' path or start
+                                            with '..'.
+                                          items:
+                                            description: Maps a string key to a path
+                                              within a volume.
+                                            properties:
+                                              key:
+                                                description: key is the key to project.
+                                                type: string
+                                              mode:
+                                                description: 'mode is Optional: mode
+                                                  bits used to set permissions on
+                                                  this file. Must be an octal value
+                                                  between 0000 and 0777 or a decimal
+                                                  value between 0 and 511. YAML accepts
+                                                  both octal and decimal values, JSON
+                                                  requires decimal values for mode
+                                                  bits. If not specified, the volume
+                                                  defaultMode will be used. This might
+                                                  be in conflict with other options
+                                                  that affect the file mode, like
+                                                  fsGroup, and the result can be other
+                                                  mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: path is the relative
+                                                  path of the file to map the key
+                                                  to. May not be an absolute path.
+                                                  May not contain the path element
+                                                  '..'. May not start with the string
+                                                  '..'.
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: optional specify whether the
+                                            ConfigMap or its keys must be defined
+                                          type: boolean
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    csi:
+                                      description: csi (Container Storage Interface)
+                                        represents ephemeral storage that is handled
+                                        by certain external CSI drivers (Beta feature).
+                                      properties:
+                                        driver:
+                                          description: driver is the name of the CSI
+                                            driver that handles this volume. Consult
+                                            with your admin for the correct name as
+                                            registered in the cluster.
+                                          type: string
+                                        fsType:
+                                          description: fsType to mount. Ex. "ext4",
+                                            "xfs", "ntfs". If not provided, the empty
+                                            value is passed to the associated CSI
+                                            driver which will determine the default
+                                            filesystem to apply.
+                                          type: string
+                                        nodePublishSecretRef:
+                                          description: nodePublishSecretRef is a reference
+                                            to the secret object containing sensitive
+                                            information to pass to the CSI driver
+                                            to complete the CSI NodePublishVolume
+                                            and NodeUnpublishVolume calls. This field
+                                            is optional, and  may be empty if no secret
+                                            is required. If the secret object contains
+                                            more than one secret, all secret references
+                                            are passed.
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        readOnly:
+                                          description: readOnly specifies a read-only
+                                            configuration for the volume. Defaults
+                                            to false (read/write).
+                                          type: boolean
+                                        volumeAttributes:
+                                          additionalProperties:
+                                            type: string
+                                          description: volumeAttributes stores driver-specific
+                                            properties that are passed to the CSI
+                                            driver. Consult your driver's documentation
+                                            for supported values.
+                                          type: object
+                                      required:
+                                      - driver
+                                      type: object
+                                    downwardAPI:
+                                      description: downwardAPI represents downward
+                                        API about the pod that should populate this
+                                        volume
+                                      properties:
+                                        defaultMode:
+                                          description: 'Optional: mode bits to use
+                                            on created files by default. Must be a
+                                            Optional: mode bits used to set permissions
+                                            on created files by default. Must be an
+                                            octal value between 0000 and 0777 or a
+                                            decimal value between 0 and 511. YAML
+                                            accepts both octal and decimal values,
+                                            JSON requires decimal values for mode
+                                            bits. Defaults to 0644. Directories within
+                                            the path are not affected by this setting.
+                                            This might be in conflict with other options
+                                            that affect the file mode, like fsGroup,
+                                            and the result can be other mode bits
+                                            set.'
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          description: Items is a list of downward
+                                            API volume file
+                                          items:
+                                            description: DownwardAPIVolumeFile represents
+                                              information to create the file containing
+                                              the pod field
+                                            properties:
+                                              fieldRef:
+                                                description: 'Required: Selects a
+                                                  field of the pod: only annotations,
+                                                  labels, name and namespace are supported.'
+                                                properties:
+                                                  apiVersion:
+                                                    description: Version of the schema
+                                                      the FieldPath is written in
+                                                      terms of, defaults to "v1".
+                                                    type: string
+                                                  fieldPath:
+                                                    description: Path of the field
+                                                      to select in the specified API
+                                                      version.
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              mode:
+                                                description: 'Optional: mode bits
+                                                  used to set permissions on this
+                                                  file, must be an octal value between
+                                                  0000 and 0777 or a decimal value
+                                                  between 0 and 511. YAML accepts
+                                                  both octal and decimal values, JSON
+                                                  requires decimal values for mode
+                                                  bits. If not specified, the volume
+                                                  defaultMode will be used. This might
+                                                  be in conflict with other options
+                                                  that affect the file mode, like
+                                                  fsGroup, and the result can be other
+                                                  mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: 'Required: Path is  the
+                                                  relative path name of the file to
+                                                  be created. Must not be absolute
+                                                  or contain the ''..'' path. Must
+                                                  be utf-8 encoded. The first item
+                                                  of the relative path must not start
+                                                  with ''..'''
+                                                type: string
+                                              resourceFieldRef:
+                                                description: 'Selects a resource of
+                                                  the container: only resources limits
+                                                  and requests (limits.cpu, limits.memory,
+                                                  requests.cpu and requests.memory)
+                                                  are currently supported.'
+                                                properties:
+                                                  containerName:
+                                                    description: 'Container name:
+                                                      required for volumes, optional
+                                                      for env vars'
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: Specifies the output
+                                                      format of the exposed resources,
+                                                      defaults to "1"
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    description: 'Required: resource
+                                                      to select'
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            required:
+                                            - path
+                                            type: object
+                                          type: array
+                                      type: object
+                                    emptyDir:
+                                      description: 'emptyDir represents a temporary
+                                        directory that shares a pod''s lifetime. More
+                                        info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                      properties:
+                                        medium:
+                                          description: 'medium represents what type
+                                            of storage medium should back this directory.
+                                            The default is "" which means to use the
+                                            node''s default medium. Must be an empty
+                                            string (default) or Memory. More info:
+                                            https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                          type: string
+                                        sizeLimit:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: 'sizeLimit is the total amount
+                                            of local storage required for this EmptyDir
+                                            volume. The size limit is also applicable
+                                            for memory medium. The maximum usage on
+                                            memory medium EmptyDir would be the minimum
+                                            value between the SizeLimit specified
+                                            here and the sum of memory limits of all
+                                            containers in a pod. The default is nil
+                                            which means that the limit is undefined.
+                                            More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                      type: object
+                                    ephemeral:
+                                      description: "ephemeral represents a volume
+                                        that is handled by a cluster storage driver.
+                                        The volume's lifecycle is tied to the pod
+                                        that defines it - it will be created before
+                                        the pod starts, and deleted when the pod is
+                                        removed. \n Use this if: a) the volume is
+                                        only needed while the pod runs, b) features
+                                        of normal volumes like restoring from snapshot
+                                        or capacity tracking are needed, c) the storage
+                                        driver is specified through a storage class,
+                                        and d) the storage driver supports dynamic
+                                        volume provisioning through a PersistentVolumeClaim
+                                        (see EphemeralVolumeSource for more information
+                                        on the connection between this volume type
+                                        and PersistentVolumeClaim). \n Use PersistentVolumeClaim
+                                        or one of the vendor-specific APIs for volumes
+                                        that persist for longer than the lifecycle
+                                        of an individual pod. \n Use CSI for light-weight
+                                        local ephemeral volumes if the CSI driver
+                                        is meant to be used that way - see the documentation
+                                        of the driver for more information. \n A pod
+                                        can use both types of ephemeral volumes and
+                                        persistent volumes at the same time."
+                                      properties:
+                                        volumeClaimTemplate:
+                                          description: "Will be used to create a stand-alone
+                                            PVC to provision the volume. The pod in
+                                            which this EphemeralVolumeSource is embedded
+                                            will be the owner of the PVC, i.e. the
+                                            PVC will be deleted together with the
+                                            pod.  The name of the PVC will be `<pod
+                                            name>-<volume name>` where `<volume name>`
+                                            is the name from the `PodSpec.Volumes`
+                                            array entry. Pod validation will reject
+                                            the pod if the concatenated name is not
+                                            valid for a PVC (for example, too long).
+                                            \n An existing PVC with that name that
+                                            is not owned by the pod will *not* be
+                                            used for the pod to avoid using an unrelated
+                                            volume by mistake. Starting the pod is
+                                            then blocked until the unrelated PVC is
+                                            removed. If such a pre-created PVC is
+                                            meant to be used by the pod, the PVC has
+                                            to updated with an owner reference to
+                                            the pod once the pod exists. Normally
+                                            this should not be necessary, but it may
+                                            be useful when manually reconstructing
+                                            a broken cluster. \n This field is read-only
+                                            and no changes will be made by Kubernetes
+                                            to the PVC after it has been created.
+                                            \n Required, must not be nil."
+                                          properties:
+                                            metadata:
+                                              description: May contain labels and
+                                                annotations that will be copied into
+                                                the PVC when creating it. No other
+                                                fields are allowed and will be rejected
+                                                during validation.
+                                              type: object
+                                            spec:
+                                              description: The specification for the
+                                                PersistentVolumeClaim. The entire
+                                                content is copied unchanged into the
+                                                PVC that gets created from this template.
+                                                The same fields as in a PersistentVolumeClaim
+                                                are also valid here.
+                                              properties:
+                                                accessModes:
+                                                  description: 'accessModes contains
+                                                    the desired access modes the volume
+                                                    should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                dataSource:
+                                                  description: 'dataSource field can
+                                                    be used to specify either: * An
+                                                    existing VolumeSnapshot object
+                                                    (snapshot.storage.k8s.io/VolumeSnapshot)
+                                                    * An existing PVC (PersistentVolumeClaim)
+                                                    If the provisioner or an external
+                                                    controller can support the specified
+                                                    data source, it will create a
+                                                    new volume based on the contents
+                                                    of the specified data source.
+                                                    If the AnyVolumeDataSource feature
+                                                    gate is enabled, this field will
+                                                    always have the same contents
+                                                    as the DataSourceRef field.'
+                                                  properties:
+                                                    apiGroup:
+                                                      description: APIGroup is the
+                                                        group for the resource being
+                                                        referenced. If APIGroup is
+                                                        not specified, the specified
+                                                        Kind must be in the core API
+                                                        group. For any other third-party
+                                                        types, APIGroup is required.
+                                                      type: string
+                                                    kind:
+                                                      description: Kind is the type
+                                                        of resource being referenced
+                                                      type: string
+                                                    name:
+                                                      description: Name is the name
+                                                        of resource being referenced
+                                                      type: string
+                                                  required:
+                                                  - kind
+                                                  - name
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                dataSourceRef:
+                                                  description: 'dataSourceRef specifies
+                                                    the object from which to populate
+                                                    the volume with data, if a non-empty
+                                                    volume is desired. This may be
+                                                    any local object from a non-empty
+                                                    API group (non core object) or
+                                                    a PersistentVolumeClaim object.
+                                                    When this field is specified,
+                                                    volume binding will only succeed
+                                                    if the type of the specified object
+                                                    matches some installed volume
+                                                    populator or dynamic provisioner.
+                                                    This field will replace the functionality
+                                                    of the DataSource field and as
+                                                    such if both fields are non-empty,
+                                                    they must have the same value.
+                                                    For backwards compatibility, both
+                                                    fields (DataSource and DataSourceRef)
+                                                    will be set to the same value
+                                                    automatically if one of them is
+                                                    empty and the other is non-empty.
+                                                    There are two important differences
+                                                    between DataSource and DataSourceRef:
+                                                    * While DataSource only allows
+                                                    two specific types of objects,
+                                                    DataSourceRef allows any non-core
+                                                    object, as well as PersistentVolumeClaim
+                                                    objects. * While DataSource ignores
+                                                    disallowed values (dropping them),
+                                                    DataSourceRef preserves all values,
+                                                    and generates an error if a disallowed
+                                                    value is specified. (Beta) Using
+                                                    this field requires the AnyVolumeDataSource
+                                                    feature gate to be enabled.'
+                                                  properties:
+                                                    apiGroup:
+                                                      description: APIGroup is the
+                                                        group for the resource being
+                                                        referenced. If APIGroup is
+                                                        not specified, the specified
+                                                        Kind must be in the core API
+                                                        group. For any other third-party
+                                                        types, APIGroup is required.
+                                                      type: string
+                                                    kind:
+                                                      description: Kind is the type
+                                                        of resource being referenced
+                                                      type: string
+                                                    name:
+                                                      description: Name is the name
+                                                        of resource being referenced
+                                                      type: string
+                                                  required:
+                                                  - kind
+                                                  - name
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                resources:
+                                                  description: 'resources represents
+                                                    the minimum resources the volume
+                                                    should have. If RecoverVolumeExpansionFailure
+                                                    feature is enabled users are allowed
+                                                    to specify resource requirements
+                                                    that are lower than previous value
+                                                    but must still be higher than
+                                                    capacity recorded in the status
+                                                    field of the claim. More info:
+                                                    https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                                  properties:
+                                                    limits:
+                                                      additionalProperties:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      description: 'Limits describes
+                                                        the maximum amount of compute
+                                                        resources allowed. More info:
+                                                        https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                      type: object
+                                                    requests:
+                                                      additionalProperties:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      description: 'Requests describes
+                                                        the minimum amount of compute
+                                                        resources required. If Requests
+                                                        is omitted for a container,
+                                                        it defaults to Limits if that
+                                                        is explicitly specified, otherwise
+                                                        to an implementation-defined
+                                                        value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                      type: object
+                                                  type: object
+                                                selector:
+                                                  description: selector is a label
+                                                    query over volumes to consider
+                                                    for binding.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                storageClassName:
+                                                  description: 'storageClassName is
+                                                    the name of the StorageClass required
+                                                    by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                                  type: string
+                                                volumeMode:
+                                                  description: volumeMode defines
+                                                    what type of volume is required
+                                                    by the claim. Value of Filesystem
+                                                    is implied when not included in
+                                                    claim spec.
+                                                  type: string
+                                                volumeName:
+                                                  description: volumeName is the binding
+                                                    reference to the PersistentVolume
+                                                    backing this claim.
+                                                  type: string
+                                              type: object
+                                          required:
+                                          - spec
+                                          type: object
+                                      type: object
+                                    fc:
+                                      description: fc represents a Fibre Channel resource
+                                        that is attached to a kubelet's host machine
+                                        and then exposed to the pod.
+                                      properties:
+                                        fsType:
+                                          description: 'fsType is the filesystem type
+                                            to mount. Must be a filesystem type supported
+                                            by the host operating system. Ex. "ext4",
+                                            "xfs", "ntfs". Implicitly inferred to
+                                            be "ext4" if unspecified. TODO: how do
+                                            we prevent errors in the filesystem from
+                                            compromising the machine'
+                                          type: string
+                                        lun:
+                                          description: 'lun is Optional: FC target
+                                            lun number'
+                                          format: int32
+                                          type: integer
+                                        readOnly:
+                                          description: 'readOnly is Optional: Defaults
+                                            to false (read/write). ReadOnly here will
+                                            force the ReadOnly setting in VolumeMounts.'
+                                          type: boolean
+                                        targetWWNs:
+                                          description: 'targetWWNs is Optional: FC
+                                            target worldwide names (WWNs)'
+                                          items:
+                                            type: string
+                                          type: array
+                                        wwids:
+                                          description: 'wwids Optional: FC volume
+                                            world wide identifiers (wwids) Either
+                                            wwids or combination of targetWWNs and
+                                            lun must be set, but not both simultaneously.'
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    flexVolume:
+                                      description: flexVolume represents a generic
+                                        volume resource that is provisioned/attached
+                                        using an exec based plugin.
+                                      properties:
+                                        driver:
+                                          description: driver is the name of the driver
+                                            to use for this volume.
+                                          type: string
+                                        fsType:
+                                          description: fsType is the filesystem type
+                                            to mount. Must be a filesystem type supported
+                                            by the host operating system. Ex. "ext4",
+                                            "xfs", "ntfs". The default filesystem
+                                            depends on FlexVolume script.
+                                          type: string
+                                        options:
+                                          additionalProperties:
+                                            type: string
+                                          description: 'options is Optional: this
+                                            field holds extra command options if any.'
+                                          type: object
+                                        readOnly:
+                                          description: 'readOnly is Optional: defaults
+                                            to false (read/write). ReadOnly here will
+                                            force the ReadOnly setting in VolumeMounts.'
+                                          type: boolean
+                                        secretRef:
+                                          description: 'secretRef is Optional: secretRef
+                                            is reference to the secret object containing
+                                            sensitive information to pass to the plugin
+                                            scripts. This may be empty if no secret
+                                            object is specified. If the secret object
+                                            contains more than one secret, all secrets
+                                            are passed to the plugin scripts.'
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      required:
+                                      - driver
+                                      type: object
+                                    flocker:
+                                      description: flocker represents a Flocker volume
+                                        attached to a kubelet's host machine. This
+                                        depends on the Flocker control service being
+                                        running
+                                      properties:
+                                        datasetName:
+                                          description: datasetName is Name of the
+                                            dataset stored as metadata -> name on
+                                            the dataset for Flocker should be considered
+                                            as deprecated
+                                          type: string
+                                        datasetUUID:
+                                          description: datasetUUID is the UUID of
+                                            the dataset. This is unique identifier
+                                            of a Flocker dataset
+                                          type: string
+                                      type: object
+                                    gcePersistentDisk:
+                                      description: 'gcePersistentDisk represents a
+                                        GCE Disk resource that is attached to a kubelet''s
+                                        host machine and then exposed to the pod.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                      properties:
+                                        fsType:
+                                          description: 'fsType is filesystem type
+                                            of the volume that you want to mount.
+                                            Tip: Ensure that the filesystem type is
+                                            supported by the host operating system.
+                                            Examples: "ext4", "xfs", "ntfs". Implicitly
+                                            inferred to be "ext4" if unspecified.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                            TODO: how do we prevent errors in the
+                                            filesystem from compromising the machine'
+                                          type: string
+                                        partition:
+                                          description: 'partition is the partition
+                                            in the volume that you want to mount.
+                                            If omitted, the default is to mount by
+                                            volume name. Examples: For volume /dev/sda1,
+                                            you specify the partition as "1". Similarly,
+                                            the volume partition for /dev/sda is "0"
+                                            (or you can leave the property empty).
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                          format: int32
+                                          type: integer
+                                        pdName:
+                                          description: 'pdName is unique name of the
+                                            PD resource in GCE. Used to identify the
+                                            disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                          type: string
+                                        readOnly:
+                                          description: 'readOnly here will force the
+                                            ReadOnly setting in VolumeMounts. Defaults
+                                            to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                          type: boolean
+                                      required:
+                                      - pdName
+                                      type: object
+                                    gitRepo:
+                                      description: 'gitRepo represents a git repository
+                                        at a particular revision. DEPRECATED: GitRepo
+                                        is deprecated. To provision a container with
+                                        a git repo, mount an EmptyDir into an InitContainer
+                                        that clones the repo using git, then mount
+                                        the EmptyDir into the Pod''s container.'
+                                      properties:
+                                        directory:
+                                          description: directory is the target directory
+                                            name. Must not contain or start with '..'.  If
+                                            '.' is supplied, the volume directory
+                                            will be the git repository.  Otherwise,
+                                            if specified, the volume will contain
+                                            the git repository in the subdirectory
+                                            with the given name.
+                                          type: string
+                                        repository:
+                                          description: repository is the URL
+                                          type: string
+                                        revision:
+                                          description: revision is the commit hash
+                                            for the specified revision.
+                                          type: string
+                                      required:
+                                      - repository
+                                      type: object
+                                    glusterfs:
+                                      description: 'glusterfs represents a Glusterfs
+                                        mount on the host that shares a pod''s lifetime.
+                                        More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                                      properties:
+                                        endpoints:
+                                          description: 'endpoints is the endpoint
+                                            name that details Glusterfs topology.
+                                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                          type: string
+                                        path:
+                                          description: 'path is the Glusterfs volume
+                                            path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                          type: string
+                                        readOnly:
+                                          description: 'readOnly here will force the
+                                            Glusterfs volume to be mounted with read-only
+                                            permissions. Defaults to false. More info:
+                                            https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                          type: boolean
+                                      required:
+                                      - endpoints
+                                      - path
+                                      type: object
+                                    hostPath:
+                                      description: 'hostPath represents a pre-existing
+                                        file or directory on the host machine that
+                                        is directly exposed to the container. This
+                                        is generally used for system agents or other
+                                        privileged things that are allowed to see
+                                        the host machine. Most containers will NOT
+                                        need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                        --- TODO(jonesdl) We need to restrict who
+                                        can use host directory mounts and who can/can
+                                        not mount host directories as read/write.'
+                                      properties:
+                                        path:
+                                          description: 'path of the directory on the
+                                            host. If the path is a symlink, it will
+                                            follow the link to the real path. More
+                                            info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                          type: string
+                                        type:
+                                          description: 'type for HostPath Volume Defaults
+                                            to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                          type: string
+                                      required:
+                                      - path
+                                      type: object
+                                    iscsi:
+                                      description: 'iscsi represents an ISCSI Disk
+                                        resource that is attached to a kubelet''s
+                                        host machine and then exposed to the pod.
+                                        More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                                      properties:
+                                        chapAuthDiscovery:
+                                          description: chapAuthDiscovery defines whether
+                                            support iSCSI Discovery CHAP authentication
+                                          type: boolean
+                                        chapAuthSession:
+                                          description: chapAuthSession defines whether
+                                            support iSCSI Session CHAP authentication
+                                          type: boolean
+                                        fsType:
+                                          description: 'fsType is the filesystem type
+                                            of the volume that you want to mount.
+                                            Tip: Ensure that the filesystem type is
+                                            supported by the host operating system.
+                                            Examples: "ext4", "xfs", "ntfs". Implicitly
+                                            inferred to be "ext4" if unspecified.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                            TODO: how do we prevent errors in the
+                                            filesystem from compromising the machine'
+                                          type: string
+                                        initiatorName:
+                                          description: initiatorName is the custom
+                                            iSCSI Initiator Name. If initiatorName
+                                            is specified with iscsiInterface simultaneously,
+                                            new iSCSI interface <target portal>:<volume
+                                            name> will be created for the connection.
+                                          type: string
+                                        iqn:
+                                          description: iqn is the target iSCSI Qualified
+                                            Name.
+                                          type: string
+                                        iscsiInterface:
+                                          description: iscsiInterface is the interface
+                                            Name that uses an iSCSI transport. Defaults
+                                            to 'default' (tcp).
+                                          type: string
+                                        lun:
+                                          description: lun represents iSCSI Target
+                                            Lun number.
+                                          format: int32
+                                          type: integer
+                                        portals:
+                                          description: portals is the iSCSI Target
+                                            Portal List. The portal is either an IP
+                                            or ip_addr:port if the port is other than
+                                            default (typically TCP ports 860 and 3260).
+                                          items:
+                                            type: string
+                                          type: array
+                                        readOnly:
+                                          description: readOnly here will force the
+                                            ReadOnly setting in VolumeMounts. Defaults
+                                            to false.
+                                          type: boolean
+                                        secretRef:
+                                          description: secretRef is the CHAP Secret
+                                            for iSCSI target and initiator authentication
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        targetPortal:
+                                          description: targetPortal is iSCSI Target
+                                            Portal. The Portal is either an IP or
+                                            ip_addr:port if the port is other than
+                                            default (typically TCP ports 860 and 3260).
+                                          type: string
+                                      required:
+                                      - iqn
+                                      - lun
+                                      - targetPortal
+                                      type: object
+                                    name:
+                                      description: 'name of the volume. Must be a
+                                        DNS_LABEL and unique within the pod. More
+                                        info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    nfs:
+                                      description: 'nfs represents an NFS mount on
+                                        the host that shares a pod''s lifetime More
+                                        info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                      properties:
+                                        path:
+                                          description: 'path that is exported by the
+                                            NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                          type: string
+                                        readOnly:
+                                          description: 'readOnly here will force the
+                                            NFS export to be mounted with read-only
+                                            permissions. Defaults to false. More info:
+                                            https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                          type: boolean
+                                        server:
+                                          description: 'server is the hostname or
+                                            IP address of the NFS server. More info:
+                                            https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                          type: string
+                                      required:
+                                      - path
+                                      - server
+                                      type: object
+                                    persistentVolumeClaim:
+                                      description: 'persistentVolumeClaimVolumeSource
+                                        represents a reference to a PersistentVolumeClaim
+                                        in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                      properties:
+                                        claimName:
+                                          description: 'claimName is the name of a
+                                            PersistentVolumeClaim in the same namespace
+                                            as the pod using this volume. More info:
+                                            https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                          type: string
+                                        readOnly:
+                                          description: readOnly Will force the ReadOnly
+                                            setting in VolumeMounts. Default false.
+                                          type: boolean
+                                      required:
+                                      - claimName
+                                      type: object
+                                    photonPersistentDisk:
+                                      description: photonPersistentDisk represents
+                                        a PhotonController persistent disk attached
+                                        and mounted on kubelets host machine
+                                      properties:
+                                        fsType:
+                                          description: fsType is the filesystem type
+                                            to mount. Must be a filesystem type supported
+                                            by the host operating system. Ex. "ext4",
+                                            "xfs", "ntfs". Implicitly inferred to
+                                            be "ext4" if unspecified.
+                                          type: string
+                                        pdID:
+                                          description: pdID is the ID that identifies
+                                            Photon Controller persistent disk
+                                          type: string
+                                      required:
+                                      - pdID
+                                      type: object
+                                    portworxVolume:
+                                      description: portworxVolume represents a portworx
+                                        volume attached and mounted on kubelets host
+                                        machine
+                                      properties:
+                                        fsType:
+                                          description: fSType represents the filesystem
+                                            type to mount Must be a filesystem type
+                                            supported by the host operating system.
+                                            Ex. "ext4", "xfs". Implicitly inferred
+                                            to be "ext4" if unspecified.
+                                          type: string
+                                        readOnly:
+                                          description: readOnly defaults to false
+                                            (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
+                                          type: boolean
+                                        volumeID:
+                                          description: volumeID uniquely identifies
+                                            a Portworx volume
+                                          type: string
+                                      required:
+                                      - volumeID
+                                      type: object
+                                    projected:
+                                      description: projected items for all in one
+                                        resources secrets, configmaps, and downward
+                                        API
+                                      properties:
+                                        defaultMode:
+                                          description: defaultMode are the mode bits
+                                            used to set permissions on created files
+                                            by default. Must be an octal value between
+                                            0000 and 0777 or a decimal value between
+                                            0 and 511. YAML accepts both octal and
+                                            decimal values, JSON requires decimal
+                                            values for mode bits. Directories within
+                                            the path are not affected by this setting.
+                                            This might be in conflict with other options
+                                            that affect the file mode, like fsGroup,
+                                            and the result can be other mode bits
+                                            set.
+                                          format: int32
+                                          type: integer
+                                        sources:
+                                          description: sources is the list of volume
+                                            projections
+                                          items:
+                                            description: Projection that may be projected
+                                              along with other supported volume types
+                                            properties:
+                                              configMap:
+                                                description: configMap information
+                                                  about the configMap data to project
+                                                properties:
+                                                  items:
+                                                    description: items if unspecified,
+                                                      each key-value pair in the Data
+                                                      field of the referenced ConfigMap
+                                                      will be projected into the volume
+                                                      as a file whose name is the
+                                                      key and content is the value.
+                                                      If specified, the listed keys
+                                                      will be projected into the specified
+                                                      paths, and unlisted keys will
+                                                      not be present. If a key is
+                                                      specified which is not present
+                                                      in the ConfigMap, the volume
+                                                      setup will error unless it is
+                                                      marked optional. Paths must
+                                                      be relative and may not contain
+                                                      the '..' path or start with
+                                                      '..'.
+                                                    items:
+                                                      description: Maps a string key
+                                                        to a path within a volume.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            key to project.
+                                                          type: string
+                                                        mode:
+                                                          description: 'mode is Optional:
+                                                            mode bits used to set
+                                                            permissions on this file.
+                                                            Must be an octal value
+                                                            between 0000 and 0777
+                                                            or a decimal value between
+                                                            0 and 511. YAML accepts
+                                                            both octal and decimal
+                                                            values, JSON requires
+                                                            decimal values for mode
+                                                            bits. If not specified,
+                                                            the volume defaultMode
+                                                            will be used. This might
+                                                            be in conflict with other
+                                                            options that affect the
+                                                            file mode, like fsGroup,
+                                                            and the result can be
+                                                            other mode bits set.'
+                                                          format: int32
+                                                          type: integer
+                                                        path:
+                                                          description: path is the
+                                                            relative path of the file
+                                                            to map the key to. May
+                                                            not be an absolute path.
+                                                            May not contain the path
+                                                            element '..'. May not
+                                                            start with the string
+                                                            '..'.
+                                                          type: string
+                                                      required:
+                                                      - key
+                                                      - path
+                                                      type: object
+                                                    type: array
+                                                  name:
+                                                    description: 'Name of the referent.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                      TODO: Add other useful fields.
+                                                      apiVersion, kind, uid?'
+                                                    type: string
+                                                  optional:
+                                                    description: optional specify
+                                                      whether the ConfigMap or its
+                                                      keys must be defined
+                                                    type: boolean
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              downwardAPI:
+                                                description: downwardAPI information
+                                                  about the downwardAPI data to project
+                                                properties:
+                                                  items:
+                                                    description: Items is a list of
+                                                      DownwardAPIVolume file
+                                                    items:
+                                                      description: DownwardAPIVolumeFile
+                                                        represents information to
+                                                        create the file containing
+                                                        the pod field
+                                                      properties:
+                                                        fieldRef:
+                                                          description: 'Required:
+                                                            Selects a field of the
+                                                            pod: only annotations,
+                                                            labels, name and namespace
+                                                            are supported.'
+                                                          properties:
+                                                            apiVersion:
+                                                              description: Version
+                                                                of the schema the
+                                                                FieldPath is written
+                                                                in terms of, defaults
+                                                                to "v1".
+                                                              type: string
+                                                            fieldPath:
+                                                              description: Path of
+                                                                the field to select
+                                                                in the specified API
+                                                                version.
+                                                              type: string
+                                                          required:
+                                                          - fieldPath
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        mode:
+                                                          description: 'Optional:
+                                                            mode bits used to set
+                                                            permissions on this file,
+                                                            must be an octal value
+                                                            between 0000 and 0777
+                                                            or a decimal value between
+                                                            0 and 511. YAML accepts
+                                                            both octal and decimal
+                                                            values, JSON requires
+                                                            decimal values for mode
+                                                            bits. If not specified,
+                                                            the volume defaultMode
+                                                            will be used. This might
+                                                            be in conflict with other
+                                                            options that affect the
+                                                            file mode, like fsGroup,
+                                                            and the result can be
+                                                            other mode bits set.'
+                                                          format: int32
+                                                          type: integer
+                                                        path:
+                                                          description: 'Required:
+                                                            Path is  the relative
+                                                            path name of the file
+                                                            to be created. Must not
+                                                            be absolute or contain
+                                                            the ''..'' path. Must
+                                                            be utf-8 encoded. The
+                                                            first item of the relative
+                                                            path must not start with
+                                                            ''..'''
+                                                          type: string
+                                                        resourceFieldRef:
+                                                          description: 'Selects a
+                                                            resource of the container:
+                                                            only resources limits
+                                                            and requests (limits.cpu,
+                                                            limits.memory, requests.cpu
+                                                            and requests.memory) are
+                                                            currently supported.'
+                                                          properties:
+                                                            containerName:
+                                                              description: 'Container
+                                                                name: required for
+                                                                volumes, optional
+                                                                for env vars'
+                                                              type: string
+                                                            divisor:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              description: Specifies
+                                                                the output format
+                                                                of the exposed resources,
+                                                                defaults to "1"
+                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                              x-kubernetes-int-or-string: true
+                                                            resource:
+                                                              description: 'Required:
+                                                                resource to select'
+                                                              type: string
+                                                          required:
+                                                          - resource
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                      required:
+                                                      - path
+                                                      type: object
+                                                    type: array
+                                                type: object
+                                              secret:
+                                                description: secret information about
+                                                  the secret data to project
+                                                properties:
+                                                  items:
+                                                    description: items if unspecified,
+                                                      each key-value pair in the Data
+                                                      field of the referenced Secret
+                                                      will be projected into the volume
+                                                      as a file whose name is the
+                                                      key and content is the value.
+                                                      If specified, the listed keys
+                                                      will be projected into the specified
+                                                      paths, and unlisted keys will
+                                                      not be present. If a key is
+                                                      specified which is not present
+                                                      in the Secret, the volume setup
+                                                      will error unless it is marked
+                                                      optional. Paths must be relative
+                                                      and may not contain the '..'
+                                                      path or start with '..'.
+                                                    items:
+                                                      description: Maps a string key
+                                                        to a path within a volume.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            key to project.
+                                                          type: string
+                                                        mode:
+                                                          description: 'mode is Optional:
+                                                            mode bits used to set
+                                                            permissions on this file.
+                                                            Must be an octal value
+                                                            between 0000 and 0777
+                                                            or a decimal value between
+                                                            0 and 511. YAML accepts
+                                                            both octal and decimal
+                                                            values, JSON requires
+                                                            decimal values for mode
+                                                            bits. If not specified,
+                                                            the volume defaultMode
+                                                            will be used. This might
+                                                            be in conflict with other
+                                                            options that affect the
+                                                            file mode, like fsGroup,
+                                                            and the result can be
+                                                            other mode bits set.'
+                                                          format: int32
+                                                          type: integer
+                                                        path:
+                                                          description: path is the
+                                                            relative path of the file
+                                                            to map the key to. May
+                                                            not be an absolute path.
+                                                            May not contain the path
+                                                            element '..'. May not
+                                                            start with the string
+                                                            '..'.
+                                                          type: string
+                                                      required:
+                                                      - key
+                                                      - path
+                                                      type: object
+                                                    type: array
+                                                  name:
+                                                    description: 'Name of the referent.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                      TODO: Add other useful fields.
+                                                      apiVersion, kind, uid?'
+                                                    type: string
+                                                  optional:
+                                                    description: optional field specify
+                                                      whether the Secret or its key
+                                                      must be defined
+                                                    type: boolean
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              serviceAccountToken:
+                                                description: serviceAccountToken is
+                                                  information about the serviceAccountToken
+                                                  data to project
+                                                properties:
+                                                  audience:
+                                                    description: audience is the intended
+                                                      audience of the token. A recipient
+                                                      of a token must identify itself
+                                                      with an identifier specified
+                                                      in the audience of the token,
+                                                      and otherwise should reject
+                                                      the token. The audience defaults
+                                                      to the identifier of the apiserver.
+                                                    type: string
+                                                  expirationSeconds:
+                                                    description: expirationSeconds
+                                                      is the requested duration of
+                                                      validity of the service account
+                                                      token. As the token approaches
+                                                      expiration, the kubelet volume
+                                                      plugin will proactively rotate
+                                                      the service account token. The
+                                                      kubelet will start trying to
+                                                      rotate the token if the token
+                                                      is older than 80 percent of
+                                                      its time to live or if the token
+                                                      is older than 24 hours.Defaults
+                                                      to 1 hour and must be at least
+                                                      10 minutes.
+                                                    format: int64
+                                                    type: integer
+                                                  path:
+                                                    description: path is the path
+                                                      relative to the mount point
+                                                      of the file to project the token
+                                                      into.
+                                                    type: string
+                                                required:
+                                                - path
+                                                type: object
+                                            type: object
+                                          type: array
+                                      type: object
+                                    quobyte:
+                                      description: quobyte represents a Quobyte mount
+                                        on the host that shares a pod's lifetime
+                                      properties:
+                                        group:
+                                          description: group to map volume access
+                                            to Default is no group
+                                          type: string
+                                        readOnly:
+                                          description: readOnly here will force the
+                                            Quobyte volume to be mounted with read-only
+                                            permissions. Defaults to false.
+                                          type: boolean
+                                        registry:
+                                          description: registry represents a single
+                                            or multiple Quobyte Registry services
+                                            specified as a string as host:port pair
+                                            (multiple entries are separated with commas)
+                                            which acts as the central registry for
+                                            volumes
+                                          type: string
+                                        tenant:
+                                          description: tenant owning the given Quobyte
+                                            volume in the Backend Used with dynamically
+                                            provisioned Quobyte volumes, value is
+                                            set by the plugin
+                                          type: string
+                                        user:
+                                          description: user to map volume access to
+                                            Defaults to serivceaccount user
+                                          type: string
+                                        volume:
+                                          description: volume is a string that references
+                                            an already created Quobyte volume by name.
+                                          type: string
+                                      required:
+                                      - registry
+                                      - volume
+                                      type: object
+                                    rbd:
+                                      description: 'rbd represents a Rados Block Device
+                                        mount on the host that shares a pod''s lifetime.
+                                        More info: https://examples.k8s.io/volumes/rbd/README.md'
+                                      properties:
+                                        fsType:
+                                          description: 'fsType is the filesystem type
+                                            of the volume that you want to mount.
+                                            Tip: Ensure that the filesystem type is
+                                            supported by the host operating system.
+                                            Examples: "ext4", "xfs", "ntfs". Implicitly
+                                            inferred to be "ext4" if unspecified.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                            TODO: how do we prevent errors in the
+                                            filesystem from compromising the machine'
+                                          type: string
+                                        image:
+                                          description: 'image is the rados image name.
+                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          type: string
+                                        keyring:
+                                          description: 'keyring is the path to key
+                                            ring for RBDUser. Default is /etc/ceph/keyring.
+                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          type: string
+                                        monitors:
+                                          description: 'monitors is a collection of
+                                            Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          items:
+                                            type: string
+                                          type: array
+                                        pool:
+                                          description: 'pool is the rados pool name.
+                                            Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          type: string
+                                        readOnly:
+                                          description: 'readOnly here will force the
+                                            ReadOnly setting in VolumeMounts. Defaults
+                                            to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          type: boolean
+                                        secretRef:
+                                          description: 'secretRef is name of the authentication
+                                            secret for RBDUser. If provided overrides
+                                            keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        user:
+                                          description: 'user is the rados user name.
+                                            Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          type: string
+                                      required:
+                                      - image
+                                      - monitors
+                                      type: object
+                                    scaleIO:
+                                      description: scaleIO represents a ScaleIO persistent
+                                        volume attached and mounted on Kubernetes
+                                        nodes.
+                                      properties:
+                                        fsType:
+                                          description: fsType is the filesystem type
+                                            to mount. Must be a filesystem type supported
+                                            by the host operating system. Ex. "ext4",
+                                            "xfs", "ntfs". Default is "xfs".
+                                          type: string
+                                        gateway:
+                                          description: gateway is the host address
+                                            of the ScaleIO API Gateway.
+                                          type: string
+                                        protectionDomain:
+                                          description: protectionDomain is the name
+                                            of the ScaleIO Protection Domain for the
+                                            configured storage.
+                                          type: string
+                                        readOnly:
+                                          description: readOnly Defaults to false
+                                            (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
+                                          type: boolean
+                                        secretRef:
+                                          description: secretRef references to the
+                                            secret for ScaleIO user and other sensitive
+                                            information. If this is not provided,
+                                            Login operation will fail.
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        sslEnabled:
+                                          description: sslEnabled Flag enable/disable
+                                            SSL communication with Gateway, default
+                                            false
+                                          type: boolean
+                                        storageMode:
+                                          description: storageMode indicates whether
+                                            the storage for a volume should be ThickProvisioned
+                                            or ThinProvisioned. Default is ThinProvisioned.
+                                          type: string
+                                        storagePool:
+                                          description: storagePool is the ScaleIO
+                                            Storage Pool associated with the protection
+                                            domain.
+                                          type: string
+                                        system:
+                                          description: system is the name of the storage
+                                            system as configured in ScaleIO.
+                                          type: string
+                                        volumeName:
+                                          description: volumeName is the name of a
+                                            volume already created in the ScaleIO
+                                            system that is associated with this volume
+                                            source.
+                                          type: string
+                                      required:
+                                      - gateway
+                                      - secretRef
+                                      - system
+                                      type: object
+                                    secret:
+                                      description: 'secret represents a secret that
+                                        should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                      properties:
+                                        defaultMode:
+                                          description: 'defaultMode is Optional: mode
+                                            bits used to set permissions on created
+                                            files by default. Must be an octal value
+                                            between 0000 and 0777 or a decimal value
+                                            between 0 and 511. YAML accepts both octal
+                                            and decimal values, JSON requires decimal
+                                            values for mode bits. Defaults to 0644.
+                                            Directories within the path are not affected
+                                            by this setting. This might be in conflict
+                                            with other options that affect the file
+                                            mode, like fsGroup, and the result can
+                                            be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          description: items If unspecified, each
+                                            key-value pair in the Data field of the
+                                            referenced Secret will be projected into
+                                            the volume as a file whose name is the
+                                            key and content is the value. If specified,
+                                            the listed keys will be projected into
+                                            the specified paths, and unlisted keys
+                                            will not be present. If a key is specified
+                                            which is not present in the Secret, the
+                                            volume setup will error unless it is marked
+                                            optional. Paths must be relative and may
+                                            not contain the '..' path or start with
+                                            '..'.
+                                          items:
+                                            description: Maps a string key to a path
+                                              within a volume.
+                                            properties:
+                                              key:
+                                                description: key is the key to project.
+                                                type: string
+                                              mode:
+                                                description: 'mode is Optional: mode
+                                                  bits used to set permissions on
+                                                  this file. Must be an octal value
+                                                  between 0000 and 0777 or a decimal
+                                                  value between 0 and 511. YAML accepts
+                                                  both octal and decimal values, JSON
+                                                  requires decimal values for mode
+                                                  bits. If not specified, the volume
+                                                  defaultMode will be used. This might
+                                                  be in conflict with other options
+                                                  that affect the file mode, like
+                                                  fsGroup, and the result can be other
+                                                  mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: path is the relative
+                                                  path of the file to map the key
+                                                  to. May not be an absolute path.
+                                                  May not contain the path element
+                                                  '..'. May not start with the string
+                                                  '..'.
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                        optional:
+                                          description: optional field specify whether
+                                            the Secret or its keys must be defined
+                                          type: boolean
+                                        secretName:
+                                          description: 'secretName is the name of
+                                            the secret in the pod''s namespace to
+                                            use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                          type: string
+                                      type: object
+                                    storageos:
+                                      description: storageOS represents a StorageOS
+                                        volume attached and mounted on Kubernetes
+                                        nodes.
+                                      properties:
+                                        fsType:
+                                          description: fsType is the filesystem type
+                                            to mount. Must be a filesystem type supported
+                                            by the host operating system. Ex. "ext4",
+                                            "xfs", "ntfs". Implicitly inferred to
+                                            be "ext4" if unspecified.
+                                          type: string
+                                        readOnly:
+                                          description: readOnly defaults to false
+                                            (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
+                                          type: boolean
+                                        secretRef:
+                                          description: secretRef specifies the secret
+                                            to use for obtaining the StorageOS API
+                                            credentials.  If not specified, default
+                                            values will be attempted.
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        volumeName:
+                                          description: volumeName is the human-readable
+                                            name of the StorageOS volume.  Volume
+                                            names are only unique within a namespace.
+                                          type: string
+                                        volumeNamespace:
+                                          description: volumeNamespace specifies the
+                                            scope of the volume within StorageOS.  If
+                                            no namespace is specified then the Pod's
+                                            namespace will be used.  This allows the
+                                            Kubernetes name scoping to be mirrored
+                                            within StorageOS for tighter integration.
+                                            Set VolumeName to any name to override
+                                            the default behaviour. Set to "default"
+                                            if you are not using namespaces within
+                                            StorageOS. Namespaces that do not pre-exist
+                                            within StorageOS will be created.
+                                          type: string
+                                      type: object
+                                    vsphereVolume:
+                                      description: vsphereVolume represents a vSphere
+                                        volume attached and mounted on kubelets host
+                                        machine
+                                      properties:
+                                        fsType:
+                                          description: fsType is filesystem type to
+                                            mount. Must be a filesystem type supported
+                                            by the host operating system. Ex. "ext4",
+                                            "xfs", "ntfs". Implicitly inferred to
+                                            be "ext4" if unspecified.
+                                          type: string
+                                        storagePolicyID:
+                                          description: storagePolicyID is the storage
+                                            Policy Based Management (SPBM) profile
+                                            ID associated with the StoragePolicyName.
+                                          type: string
+                                        storagePolicyName:
+                                          description: storagePolicyName is the storage
+                                            Policy Based Management (SPBM) profile
+                                            name.
+                                          type: string
+                                        volumePath:
+                                          description: volumePath is the path that
+                                            identifies vSphere volume vmdk
+                                          type: string
+                                      required:
+                                      - volumePath
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                            required:
+                            - mounts
+                            - volumes
+                            type: object
+                          type: array
                         managed:
                           description: Managed - Whether the node is actually provisioned
                             (True) or should be treated as preprovisioned (False)

--- a/controllers/openstackdataplanenode_controller.go
+++ b/controllers/openstackdataplanenode_controller.go
@@ -206,7 +206,7 @@ func (r *OpenStackDataPlaneNodeReconciler) Reconcile(ctx context.Context, req ct
 	}
 
 	if instance.Spec.DeployStrategy.Deploy {
-		result, err = deployment.Deploy(ctx, helper, instance, ansibleSSHPrivateKeySecret, inventoryConfigMap, &instance.Status, instance.Spec.NetworkAttachments, instance.Spec.OpenStackAnsibleEERunnerImage, instance.Spec.DeployStrategy.AnsibleTags)
+		result, err = deployment.Deploy(ctx, helper, instance, ansibleSSHPrivateKeySecret, inventoryConfigMap, &instance.Status, instance.Spec.NetworkAttachments, instance.Spec.OpenStackAnsibleEERunnerImage, instance.Spec.DeployStrategy.AnsibleTags, instance.Spec.Node.ExtraMounts)
 		if err != nil {
 			util.LogErrorForObject(helper, err, fmt.Sprintf("Unable to deploy %s", instance.Name), instance)
 			instance.Status.Conditions.Set(condition.FalseCondition(

--- a/docs/openstack_dataplanenode.md
+++ b/docs/openstack_dataplanenode.md
@@ -59,6 +59,7 @@ NodeSection is a specification of the node attributes
 | ansiblePort | AnsiblePort SSH port for Ansible connection | int | false |
 | ansibleVars | AnsibleVars for configuring ansible | string | false |
 | ansibleSSHPrivateKeySecret | AnsibleSSHPrivateKeySecret Private SSH Key secret containing private SSH key for connecting to node. Must be of the form: Secret.data.ssh-privatekey: <base64 encoded private key contents> https://kubernetes.io/docs/concepts/configuration/secret/#ssh-authentication-secrets | string | true |
+| extraMounts | ExtraMounts containing files which can be mounted into an Ansible Execution Pod | []storage.VolMounts | false |
 
 [Back to Custom Resources](#custom-resources)
 

--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -29,11 +29,12 @@ import (
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
+	"github.com/openstack-k8s-operators/lib-common/modules/storage"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // deployFuncDef so we can pass a function to ConditionalDeploy
-type deployFuncDef func(context.Context, *helper.Helper, client.Object, string, string, []string, string, string) error
+type deployFuncDef func(context.Context, *helper.Helper, client.Object, string, string, []string, string, string, []storage.VolMounts) error
 
 // Deploy function encapsulating primary deloyment handling
 func Deploy(
@@ -46,6 +47,7 @@ func Deploy(
 	networkAttachments []string,
 	openStackAnsibleEERunnerImage string,
 	ansibleTags string,
+	extraMounts []storage.VolMounts,
 ) (ctrl.Result, error) {
 
 	var result ctrl.Result
@@ -90,6 +92,7 @@ func Deploy(
 		networkAttachments,
 		openStackAnsibleEERunnerImage,
 		ansibleTags,
+		extraMounts,
 	)
 	if err != nil || result.RequeueAfter > 0 {
 		return result, err
@@ -120,6 +123,7 @@ func Deploy(
 		networkAttachments,
 		openStackAnsibleEERunnerImage,
 		ansibleTags,
+		extraMounts,
 	)
 	if err != nil || result.RequeueAfter > 0 {
 		return result, err
@@ -149,7 +153,8 @@ func Deploy(
 		deployLabel,
 		networkAttachments,
 		openStackAnsibleEERunnerImage,
-		ansibleTags)
+		ansibleTags,
+		extraMounts)
 	if err != nil || result.RequeueAfter > 0 {
 		return result, err
 	}
@@ -178,7 +183,8 @@ func Deploy(
 		deployLabel,
 		networkAttachments,
 		openStackAnsibleEERunnerImage,
-		ansibleTags)
+		ansibleTags,
+		extraMounts)
 	if err != nil || result.RequeueAfter > 0 {
 		return result, err
 	}
@@ -207,7 +213,8 @@ func Deploy(
 		deployLabel,
 		networkAttachments,
 		openStackAnsibleEERunnerImage,
-		ansibleTags)
+		ansibleTags,
+		extraMounts)
 	if err != nil || result.RequeueAfter > 0 {
 		return result, err
 	}
@@ -236,7 +243,8 @@ func Deploy(
 		deployLabel,
 		networkAttachments,
 		openStackAnsibleEERunnerImage,
-		ansibleTags)
+		ansibleTags,
+		extraMounts)
 	if err != nil || result.RequeueAfter > 0 {
 		return result, err
 	}
@@ -265,7 +273,8 @@ func Deploy(
 		deployLabel,
 		networkAttachments,
 		openStackAnsibleEERunnerImage,
-		ansibleTags)
+		ansibleTags,
+		extraMounts)
 	if err != nil || result.RequeueAfter > 0 {
 		return result, err
 	}
@@ -294,7 +303,8 @@ func Deploy(
 		deployLabel,
 		networkAttachments,
 		openStackAnsibleEERunnerImage,
-		ansibleTags)
+		ansibleTags,
+		extraMounts)
 	if err != nil || result.RequeueAfter > 0 {
 		return result, err
 	}
@@ -323,6 +333,7 @@ func ConditionalDeploy(
 	networkAttachments []string,
 	openStackAnsibleEERunnerImage string,
 	ansibleTags string,
+	extraMounts []storage.VolMounts,
 ) (ctrl.Result, error) {
 
 	var err error
@@ -332,7 +343,7 @@ func ConditionalDeploy(
 		log.Info(fmt.Sprintf("%s Unknown, starting %s", readyCondition, deployName))
 		err = deployFunc(ctx, helper, obj, sshKeySecret, inventoryConfigMap, networkAttachments,
 			openStackAnsibleEERunnerImage,
-			ansibleTags)
+			ansibleTags, extraMounts)
 		if err != nil {
 			util.LogErrorForObject(helper, err, fmt.Sprintf("Unable to %s for %s", deployName, obj.GetName()), obj)
 			return ctrl.Result{}, err

--- a/pkg/deployment/network.go
+++ b/pkg/deployment/network.go
@@ -23,11 +23,12 @@ import (
 
 	dataplaneutil "github.com/openstack-k8s-operators/dataplane-operator/pkg/util"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
+	"github.com/openstack-k8s-operators/lib-common/modules/storage"
 	ansibleeev1alpha1 "github.com/openstack-k8s-operators/openstack-ansibleee-operator/api/v1alpha1"
 )
 
 // ConfigureNetwork ensures the network config
-func ConfigureNetwork(ctx context.Context, helper *helper.Helper, obj client.Object, sshKeySecret string, inventoryConfigMap string, networkAttachments []string, openStackAnsibleEERunnerImage string, ansibleTags string) error {
+func ConfigureNetwork(ctx context.Context, helper *helper.Helper, obj client.Object, sshKeySecret string, inventoryConfigMap string, networkAttachments []string, openStackAnsibleEERunnerImage string, ansibleTags string, extraMounts []storage.VolMounts) error {
 
 	role := ansibleeev1alpha1.Role{
 		Name:     "edpm_network_config",
@@ -44,7 +45,7 @@ func ConfigureNetwork(ctx context.Context, helper *helper.Helper, obj client.Obj
 		},
 	}
 
-	err := dataplaneutil.AnsibleExecution(ctx, helper, obj, ConfigureNetworkLabel, sshKeySecret, inventoryConfigMap, "", role, networkAttachments, openStackAnsibleEERunnerImage, ansibleTags)
+	err := dataplaneutil.AnsibleExecution(ctx, helper, obj, ConfigureNetworkLabel, sshKeySecret, inventoryConfigMap, "", role, networkAttachments, openStackAnsibleEERunnerImage, ansibleTags, extraMounts)
 	if err != nil {
 		helper.GetLogger().Error(err, "Unable to execute Ansible for ConfigureNetwork")
 		return err
@@ -55,7 +56,7 @@ func ConfigureNetwork(ctx context.Context, helper *helper.Helper, obj client.Obj
 }
 
 // ValidateNetwork ensures the node network config
-func ValidateNetwork(ctx context.Context, helper *helper.Helper, obj client.Object, sshKeySecret string, inventoryConfigMap string, networkAttachments []string, openStackAnsibleEERunnerImage string, ansibleTags string) error {
+func ValidateNetwork(ctx context.Context, helper *helper.Helper, obj client.Object, sshKeySecret string, inventoryConfigMap string, networkAttachments []string, openStackAnsibleEERunnerImage string, ansibleTags string, extraMounts []storage.VolMounts) error {
 
 	role := ansibleeev1alpha1.Role{
 		Name:     "edpm_nodes_validation",
@@ -72,7 +73,7 @@ func ValidateNetwork(ctx context.Context, helper *helper.Helper, obj client.Obje
 		},
 	}
 
-	err := dataplaneutil.AnsibleExecution(ctx, helper, obj, ValidateNetworkLabel, sshKeySecret, inventoryConfigMap, "", role, networkAttachments, openStackAnsibleEERunnerImage, ansibleTags)
+	err := dataplaneutil.AnsibleExecution(ctx, helper, obj, ValidateNetworkLabel, sshKeySecret, inventoryConfigMap, "", role, networkAttachments, openStackAnsibleEERunnerImage, ansibleTags, extraMounts)
 	if err != nil {
 		helper.GetLogger().Error(err, "Unable to execute Ansible for ValidateNetwork")
 		return err

--- a/pkg/deployment/openstack.go
+++ b/pkg/deployment/openstack.go
@@ -21,12 +21,13 @@ import (
 
 	dataplaneutil "github.com/openstack-k8s-operators/dataplane-operator/pkg/util"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
+	"github.com/openstack-k8s-operators/lib-common/modules/storage"
 	ansibleeev1alpha1 "github.com/openstack-k8s-operators/openstack-ansibleee-operator/api/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // InstallOpenStack ensures the node OpenStack is installed
-func InstallOpenStack(ctx context.Context, helper *helper.Helper, obj client.Object, sshKeySecret string, inventoryConfigMap string, networkAttachments []string, openStackAnsibleEERunnerImage string, ansibleTags string) error {
+func InstallOpenStack(ctx context.Context, helper *helper.Helper, obj client.Object, sshKeySecret string, inventoryConfigMap string, networkAttachments []string, openStackAnsibleEERunnerImage string, ansibleTags string, extraMounts []storage.VolMounts) error {
 
 	tasks := []dataplaneutil.Task{
 		{
@@ -51,7 +52,7 @@ func InstallOpenStack(ctx context.Context, helper *helper.Helper, obj client.Obj
 		Tasks:          dataplaneutil.PopulateTasks(tasks),
 	}
 
-	err := dataplaneutil.AnsibleExecution(ctx, helper, obj, InstallOpenStackLabel, sshKeySecret, inventoryConfigMap, "", role, networkAttachments, openStackAnsibleEERunnerImage, ansibleTags)
+	err := dataplaneutil.AnsibleExecution(ctx, helper, obj, InstallOpenStackLabel, sshKeySecret, inventoryConfigMap, "", role, networkAttachments, openStackAnsibleEERunnerImage, ansibleTags, extraMounts)
 	if err != nil {
 		helper.GetLogger().Error(err, "Unable to execute Ansible for InstallOpenStack")
 		return err
@@ -62,7 +63,7 @@ func InstallOpenStack(ctx context.Context, helper *helper.Helper, obj client.Obj
 }
 
 // ConfigureOpenStack ensures the node OpenStack config
-func ConfigureOpenStack(ctx context.Context, helper *helper.Helper, obj client.Object, sshKeySecret string, inventoryConfigMap string, networkAttachments []string, openStackAnsibleEERunnerImage string, ansibleTags string) error {
+func ConfigureOpenStack(ctx context.Context, helper *helper.Helper, obj client.Object, sshKeySecret string, inventoryConfigMap string, networkAttachments []string, openStackAnsibleEERunnerImage string, ansibleTags string, extraMounts []storage.VolMounts) error {
 
 	tasks := []dataplaneutil.Task{
 		{
@@ -99,7 +100,7 @@ func ConfigureOpenStack(ctx context.Context, helper *helper.Helper, obj client.O
 		Tasks:          dataplaneutil.PopulateTasks(tasks),
 	}
 
-	err := dataplaneutil.AnsibleExecution(ctx, helper, obj, ConfigureOpenStackLabel, sshKeySecret, inventoryConfigMap, "", role, networkAttachments, openStackAnsibleEERunnerImage, ansibleTags)
+	err := dataplaneutil.AnsibleExecution(ctx, helper, obj, ConfigureOpenStackLabel, sshKeySecret, inventoryConfigMap, "", role, networkAttachments, openStackAnsibleEERunnerImage, ansibleTags, extraMounts)
 	if err != nil {
 		helper.GetLogger().Error(err, "Unable to execute Ansible for ConfigureOpenStack")
 		return err
@@ -110,7 +111,7 @@ func ConfigureOpenStack(ctx context.Context, helper *helper.Helper, obj client.O
 }
 
 // RunOpenStack ensures the node OpenStack is running
-func RunOpenStack(ctx context.Context, helper *helper.Helper, obj client.Object, sshKeySecret string, inventoryConfigMap string, networkAttachments []string, openStackAnsibleEERunnerImage string, ansibleTags string) error {
+func RunOpenStack(ctx context.Context, helper *helper.Helper, obj client.Object, sshKeySecret string, inventoryConfigMap string, networkAttachments []string, openStackAnsibleEERunnerImage string, ansibleTags string, extraMounts []storage.VolMounts) error {
 
 	tasks := []dataplaneutil.Task{
 		{
@@ -142,7 +143,7 @@ func RunOpenStack(ctx context.Context, helper *helper.Helper, obj client.Object,
 		Tasks:          dataplaneutil.PopulateTasks(tasks),
 	}
 
-	err := dataplaneutil.AnsibleExecution(ctx, helper, obj, RunOpenStackLabel, sshKeySecret, inventoryConfigMap, "", role, networkAttachments, openStackAnsibleEERunnerImage, ansibleTags)
+	err := dataplaneutil.AnsibleExecution(ctx, helper, obj, RunOpenStackLabel, sshKeySecret, inventoryConfigMap, "", role, networkAttachments, openStackAnsibleEERunnerImage, ansibleTags, extraMounts)
 	if err != nil {
 		helper.GetLogger().Error(err, "Unable to execute Ansible for RunOpenStack")
 		return err

--- a/pkg/deployment/os.go
+++ b/pkg/deployment/os.go
@@ -21,12 +21,13 @@ import (
 
 	dataplaneutil "github.com/openstack-k8s-operators/dataplane-operator/pkg/util"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
+	"github.com/openstack-k8s-operators/lib-common/modules/storage"
 	ansibleeev1alpha1 "github.com/openstack-k8s-operators/openstack-ansibleee-operator/api/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // InstallOS ensures the node Operating System is installed
-func InstallOS(ctx context.Context, helper *helper.Helper, obj client.Object, sshKeySecret string, inventoryConfigMap string, networkAttachments []string, openStackAnsibleEERunnerImage string, ansibleTags string) error {
+func InstallOS(ctx context.Context, helper *helper.Helper, obj client.Object, sshKeySecret string, inventoryConfigMap string, networkAttachments []string, openStackAnsibleEERunnerImage string, ansibleTags string, extraMounts []storage.VolMounts) error {
 
 	tasks := []dataplaneutil.Task{
 		{
@@ -76,7 +77,7 @@ func InstallOS(ctx context.Context, helper *helper.Helper, obj client.Object, ss
 		Tasks:          dataplaneutil.PopulateTasks(tasks),
 	}
 
-	err := dataplaneutil.AnsibleExecution(ctx, helper, obj, InstallOSLabel, sshKeySecret, inventoryConfigMap, "", role, networkAttachments, openStackAnsibleEERunnerImage, ansibleTags)
+	err := dataplaneutil.AnsibleExecution(ctx, helper, obj, InstallOSLabel, sshKeySecret, inventoryConfigMap, "", role, networkAttachments, openStackAnsibleEERunnerImage, ansibleTags, extraMounts)
 	if err != nil {
 		helper.GetLogger().Error(err, "Unable to execute Ansible for InstallOS")
 		return err
@@ -87,7 +88,7 @@ func InstallOS(ctx context.Context, helper *helper.Helper, obj client.Object, ss
 }
 
 // ConfigureOS ensures the node Operating System config
-func ConfigureOS(ctx context.Context, helper *helper.Helper, obj client.Object, sshKeySecret string, inventoryConfigMap string, networkAttachments []string, openStackAnsibleEERunnerImage string, ansibleTags string) error {
+func ConfigureOS(ctx context.Context, helper *helper.Helper, obj client.Object, sshKeySecret string, inventoryConfigMap string, networkAttachments []string, openStackAnsibleEERunnerImage string, ansibleTags string, extraMounts []storage.VolMounts) error {
 
 	tasks := []dataplaneutil.Task{
 		{
@@ -143,7 +144,7 @@ func ConfigureOS(ctx context.Context, helper *helper.Helper, obj client.Object, 
 		Tasks:          dataplaneutil.PopulateTasks(tasks),
 	}
 
-	err := dataplaneutil.AnsibleExecution(ctx, helper, obj, ConfigureOSLabel, sshKeySecret, inventoryConfigMap, "", role, networkAttachments, openStackAnsibleEERunnerImage, ansibleTags)
+	err := dataplaneutil.AnsibleExecution(ctx, helper, obj, ConfigureOSLabel, sshKeySecret, inventoryConfigMap, "", role, networkAttachments, openStackAnsibleEERunnerImage, ansibleTags, extraMounts)
 	if err != nil {
 		helper.GetLogger().Error(err, "Unable to execute Ansible for ConfigureOS")
 		return err
@@ -154,7 +155,7 @@ func ConfigureOS(ctx context.Context, helper *helper.Helper, obj client.Object, 
 }
 
 // RunOS ensures the node Operating System is running
-func RunOS(ctx context.Context, helper *helper.Helper, obj client.Object, sshKeySecret string, inventoryConfigMap string, networkAttachments []string, openStackAnsibleEERunnerImage string, ansibleTags string) error {
+func RunOS(ctx context.Context, helper *helper.Helper, obj client.Object, sshKeySecret string, inventoryConfigMap string, networkAttachments []string, openStackAnsibleEERunnerImage string, ansibleTags string, extraMounts []storage.VolMounts) error {
 
 	tasks := []dataplaneutil.Task{
 		{
@@ -204,7 +205,7 @@ func RunOS(ctx context.Context, helper *helper.Helper, obj client.Object, sshKey
 		Tasks:          dataplaneutil.PopulateTasks(tasks),
 	}
 
-	err := dataplaneutil.AnsibleExecution(ctx, helper, obj, RunOSLabel, sshKeySecret, inventoryConfigMap, "", role, networkAttachments, openStackAnsibleEERunnerImage, ansibleTags)
+	err := dataplaneutil.AnsibleExecution(ctx, helper, obj, RunOSLabel, sshKeySecret, inventoryConfigMap, "", role, networkAttachments, openStackAnsibleEERunnerImage, ansibleTags, extraMounts)
 	if err != nil {
 		helper.GetLogger().Error(err, "Unable to execute Ansible for RunOS")
 		return err

--- a/pkg/util/ansible_execution.go
+++ b/pkg/util/ansible_execution.go
@@ -49,6 +49,7 @@ func AnsibleExecution(
 	networkAttachments []string,
 	openStackAnsibleEERunnerImage string,
 	ansibleTags string,
+	extraMounts []storage.VolMounts,
 ) error {
 
 	var err error
@@ -127,7 +128,7 @@ func AnsibleExecution(
 		ansibleEEMounts.Mounts = append(ansibleEEMounts.Mounts, sshKeyMount)
 		ansibleEEMounts.Mounts = append(ansibleEEMounts.Mounts, inventoryMount)
 
-		ansibleEE.Spec.ExtraMounts = []storage.VolMounts{ansibleEEMounts}
+		ansibleEE.Spec.ExtraMounts = append(extraMounts, []storage.VolMounts{ansibleEEMounts}...)
 
 		err := controllerutil.SetControllerReference(obj, ansibleEE, helper.GetScheme())
 		if err != nil {


### PR DESCRIPTION
OpenStackDataPlaneNode (DPN) is already using ExtraMounts when it calls OpenStackAnsibleEE (AEE). This patch allows ExtraMounts to be set in a DPN CR so that its Ansible pod can access those files in order to configure a node.

A subsequent patch will use ExtraMounts so the AEE pod can access the same `extraVolType: Ceph` used by control plane pods and apply the same configuration to DPNs for Ceph client configuration. Additional applications are possible.

Related: [OSP-22956](https://issues.redhat.com//browse/OSP-22956) [OSP-19983](https://issues.redhat.com//browse/OSP-19983)