### PR TITLE
Configure OpenStackDataPlaneNode as Ceph clients

### DIFF
--- a/api/v1beta1/conditions.go
+++ b/api/v1beta1/conditions.go
@@ -112,6 +112,19 @@ const (
 	// RunOSErrorMessage error
 	RunOSErrorMessage = "RunOS error occurred %s"
 
+	// ConfigureCephClientReadyCondition Status=True condition indicates if the
+	// Ceph client configuration is finished and successful.
+	ConfigureCephClientReadyCondition condition.Type = "ConfigureCephClientReady"
+
+	// ConfigureCephClientReadyMessage ready
+	ConfigureCephClientReadyMessage = "ConfigureCephClient ready"
+
+	// ConfigureCephClientReadyWaitingMessage not yet ready
+	ConfigureCephClientReadyWaitingMessage = "ConfigureCephClient not yet ready"
+
+	// ConfigureCephClientErrorMessage error
+	ConfigureCephClientErrorMessage = "ConfigureCephClient error occurred %s"
+
 	// InstallOpenStackReadyCondition Status=True condition indicates if the
 	// OpenStack configuration is finished and successful.
 	InstallOpenStackReadyCondition condition.Type = "InstallOpenStackReady"

--- a/controllers/openstackdataplanenode_controller.go
+++ b/controllers/openstackdataplanenode_controller.go
@@ -167,6 +167,7 @@ func (r *OpenStackDataPlaneNodeReconciler) Reconcile(ctx context.Context, req ct
 			condition.UnknownCondition(dataplanev1beta1.InstallOSReadyCondition, condition.InitReason, condition.InitReason),
 			condition.UnknownCondition(dataplanev1beta1.ConfigureOSReadyCondition, condition.InitReason, condition.InitReason),
 			condition.UnknownCondition(dataplanev1beta1.RunOSReadyCondition, condition.InitReason, condition.InitReason),
+			condition.UnknownCondition(dataplanev1beta1.ConfigureCephClientReadyCondition, condition.InitReason, condition.InitReason),
 			condition.UnknownCondition(dataplanev1beta1.InstallOpenStackReadyCondition, condition.InitReason, condition.InitReason),
 			condition.UnknownCondition(dataplanev1beta1.ConfigureOpenStackReadyCondition, condition.InitReason, condition.InitReason),
 			condition.UnknownCondition(dataplanev1beta1.RunOpenStackReadyCondition, condition.InitReason, condition.InitReason),

--- a/pkg/deployment/ceph_client.go
+++ b/pkg/deployment/ceph_client.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployment
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	dataplaneutil "github.com/openstack-k8s-operators/dataplane-operator/pkg/util"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
+	"github.com/openstack-k8s-operators/lib-common/modules/storage"
+	ansibleeev1alpha1 "github.com/openstack-k8s-operators/openstack-ansibleee-operator/api/v1alpha1"
+)
+
+// ConfigureCephClient ensures the Ceph client configuration files are on data plane nodes
+func ConfigureCephClient(ctx context.Context, helper *helper.Helper, obj client.Object, sshKeySecret string, inventoryConfigMap string, networkAttachments []string, openStackAnsibleEERunnerImage string, ansibleTags string, extraMounts []storage.VolMounts) error {
+
+	role := ansibleeev1alpha1.Role{
+		Name:     "edpm_ceph_client_files",
+		Hosts:    "all",
+		Strategy: "linear",
+		Tasks: []ansibleeev1alpha1.Task{
+			{
+				Name: "import edpm_ceph_client_files",
+				ImportRole: ansibleeev1alpha1.ImportRole{
+					Name:      "edpm_ceph_client_files",
+					TasksFrom: "main.yml",
+				},
+			},
+		},
+	}
+
+	err := dataplaneutil.AnsibleExecution(ctx, helper, obj, ConfigureCephClientLabel, sshKeySecret, inventoryConfigMap, "", role, networkAttachments, openStackAnsibleEERunnerImage, ansibleTags, extraMounts)
+	if err != nil {
+		helper.GetLogger().Error(err, "Unable to execute Ansible for ConfigureCephClient")
+		return err
+	}
+
+	return nil
+
+}

--- a/pkg/deployment/const.go
+++ b/pkg/deployment/const.go
@@ -33,6 +33,9 @@ const (
 	// RunOSLabel for RunOS OpenStackAnsibleEE
 	RunOSLabel = "dataplane-deployment-run-os"
 
+	// ConfigureCephClientLabel for ConfigureCephClient OpenStackAnsibleEE
+	ConfigureCephClientLabel = "dataplane-deployment-configure-ceph-client"
+
 	// InstallOpenStackLabel for InstallOpenStack OpenStackAnsibleEE
 	InstallOpenStackLabel = "dataplane-deployment-install-openstack"
 


### PR DESCRIPTION
If an OpenStackDataPlaneNode has any extraMounts items where extraVolType is Ceph, then call the Ansible Role edpm_ceph_client_files and pass it the mounted files. This results in nodes having Ceph configuration files (e.g. ceph.conf or a cephx key) so that the OpenStack services on those nodes can be clients of a Ceph cluster.

Closes: [OSP-22956](https://issues.redhat.com//browse/OSP-22956)