### PR TITLE
Remove omitempty from fields with defaults

### DIFF
--- a/api/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
@@ -1854,7 +1854,6 @@ spec:
                       os-net-config related properties.
                     properties:
                       template:
-                        default: templates/net_config_bridge.j2
                         description: Template - ansible j2 nic config template to
                           use when applying node network configuration
                         type: string

--- a/api/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
@@ -1819,7 +1819,6 @@ spec:
                       os-net-config related properties.
                     properties:
                       template:
-                        default: templates/net_config_bridge.j2
                         description: Template - ansible j2 nic config template to
                           use when applying node network configuration
                         type: string

--- a/api/bases/dataplane.openstack.org_openstackdataplanes.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplanes.yaml
@@ -1971,7 +1971,6 @@ spec:
                             Contains os-net-config related properties.
                           properties:
                             template:
-                              default: templates/net_config_bridge.j2
                               description: Template - ansible j2 nic config template
                                 to use when applying node network configuration
                               type: string

--- a/api/v1beta1/openstackdataplanenode_types.go
+++ b/api/v1beta1/openstackdataplanenode_types.go
@@ -102,7 +102,7 @@ type NodeSection struct {
 	// ExtraMounts containing files which can be mounted into an Ansible Execution Pod
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default={}
-	ExtraMounts []storage.VolMounts `json:"extraMounts,omitempty"`
+	ExtraMounts []storage.VolMounts `json:"extraMounts"`
 }
 
 // DeployStrategySection for fields controlling the deployment
@@ -122,7 +122,6 @@ type DeployStrategySection struct {
 type NetworkConfigSection struct {
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default=templates/net_config_bridge.j2
 	// Template - ansible j2 nic config template to use when applying node
 	// network configuration
 	Template string `json:"template,omitempty" yaml:"template,omitempty"`

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
@@ -1854,7 +1854,6 @@ spec:
                       os-net-config related properties.
                     properties:
                       template:
-                        default: templates/net_config_bridge.j2
                         description: Template - ansible j2 nic config template to
                           use when applying node network configuration
                         type: string

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
@@ -1819,7 +1819,6 @@ spec:
                       os-net-config related properties.
                     properties:
                       template:
-                        default: templates/net_config_bridge.j2
                         description: Template - ansible j2 nic config template to
                           use when applying node network configuration
                         type: string

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanes.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanes.yaml
@@ -1971,7 +1971,6 @@ spec:
                             Contains os-net-config related properties.
                           properties:
                             template:
-                              default: templates/net_config_bridge.j2
                               description: Template - ansible j2 nic config template
                                 to use when applying node network configuration
                               type: string

--- a/docs/openstack_dataplanenode.md
+++ b/docs/openstack_dataplanenode.md
@@ -59,7 +59,7 @@ NodeSection is a specification of the node attributes
 | ansiblePort | AnsiblePort SSH port for Ansible connection | int | false |
 | ansibleVars | AnsibleVars for configuring ansible | string | false |
 | ansibleSSHPrivateKeySecret | AnsibleSSHPrivateKeySecret Private SSH Key secret containing private SSH key for connecting to node. Must be of the form: Secret.data.ssh-privatekey: <base64 encoded private key contents> https://kubernetes.io/docs/concepts/configuration/secret/#ssh-authentication-secrets | string | true |
-| extraMounts | ExtraMounts containing files which can be mounted into an Ansible Execution Pod | []storage.VolMounts | false |
+| extraMounts | ExtraMounts containing files which can be mounted into an Ansible Execution Pod | []storage.VolMounts | true |
 
 [Back to Custom Resources](#custom-resources)
 


### PR DESCRIPTION
make operator-lint now fails if a field has both a default value and is
marked omitempty. Remove omitempty in these cases.

Signed-off-by: James Slagle <jslagle@redhat.com>
