### PR TITLE
Add DeployNovaExternalCompute to role deploy

### DIFF
--- a/api/v1beta1/conditions.go
+++ b/api/v1beta1/conditions.go
@@ -21,10 +21,6 @@ import (
 )
 
 const (
-	// DataPlaneNodeReadyCondition Status=True condition indicates
-	// DataPlaneNode is ready.
-	DataPlaneNodeReadyCondition condition.Type = "DataPlaneNodeReady"
-
 	// DataPlaneNodeReadyMessage ready
 	DataPlaneNodeReadyMessage = "DataPlaneNode ready"
 
@@ -33,10 +29,6 @@ const (
 
 	// DataPlaneNodeErrorMessage error
 	DataPlaneNodeErrorMessage = "DataPlaneNode error occurred %s"
-
-	// DataPlaneRoleReadyCondition Status=True condition indicates
-	// DataPlaneRole is ready.
-	DataPlaneRoleReadyCondition condition.Type = "DataPlaneRoleReady"
 
 	// DataPlaneRoleReadyMessage ready
 	DataPlaneRoleReadyMessage = "DataPlaneRole ready"

--- a/api/v1beta1/openstackdataplanenode_types.go
+++ b/api/v1beta1/openstackdataplanenode_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -84,5 +85,5 @@ func init() {
 
 // IsReady - returns true if the DataPlane is ready
 func (instance OpenStackDataPlaneNode) IsReady() bool {
-	return instance.Status.Conditions.IsTrue(DataPlaneNodeReadyCondition)
+	return instance.Status.Conditions.IsTrue(condition.ReadyCondition)
 }

--- a/api/v1beta1/openstackdataplanerole_types.go
+++ b/api/v1beta1/openstackdataplanerole_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -78,5 +79,5 @@ func init() {
 
 // IsReady - returns true if the DataPlane is ready
 func (instance OpenStackDataPlaneRole) IsReady() bool {
-	return instance.Status.Conditions.IsTrue(DataPlaneRoleReadyCondition)
+	return instance.Status.Conditions.IsTrue(condition.ReadyCondition)
 }

--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -60,9 +60,9 @@ func Deploy(
 	var deployName string
 	var deployLabel string
 
-	// Set DataPlaneNodeReadyCondition to requested
+	// Set ReadyCondition to requested
 	status.Conditions.Set(condition.FalseCondition(
-		dataplanev1beta1.DataPlaneNodeReadyCondition,
+		condition.ReadyCondition,
 		condition.RequestedReason,
 		condition.SeverityInfo,
 		dataplanev1beta1.DataPlaneNodeReadyWaitingMessage))
@@ -351,22 +351,6 @@ func Deploy(
 		return result, err
 	}
 
-	result, err = DeployNovaExternalCompute(
-		ctx,
-		helper,
-		obj,
-		sshKeySecret,
-		inventoryConfigMap,
-		status,
-		networkAttachments,
-		openStackAnsibleEERunnerImage)
-	if err != nil || result.RequeueAfter > 0 {
-		return result, err
-	}
-
-	if status.Conditions.IsTrue(dataplanev1beta1.NovaComputeReadyCondition) {
-		status.Deployed = true
-	}
 	return ctrl.Result{}, nil
 
 }


### PR DESCRIPTION
As the last step in the role deploy, DeployNovaExternalCompute is called
to deploy the nova services. This commit refactors the function since
the returns need to be handled differently whether it's a node deploy or
a role deploy.

During a node deploy, only the single created (or patched)
NovaExternalCompute needs to be checked for errors or the
ReadyCondition. However, during a role deploy, each NovaExternalCompute
for each corresponding node needs to be checked. If any of the
NovaExternalCompute CR's is in error, or not ready, then the entire role
is set as in error or not ready.

The call to DeployNovaExternalCompute is refactored out of the Deploy
func and called directly from the node and role controller instead so
that the return handling can be different.

This change also switches to use the standard ReadyCondition from
lib-common instead of the custom types DataPlaneNodeReadyCondition and
DataPlaneRoleReadyCondition. The custom types are not needed as a custom
message can already be set on the standard ReadyCondition. The standard
ReadyCondition is also used to reflect the overall status in the CLI and
UI.

Signed-off-by: James Slagle <jslagle@redhat.com>
