### PR TITLE
Add sample for a full edpm_compute_0

### DIFF
--- a/config/samples/dataplane_v1beta1_openstackdataplanenode_edpm_compute_0_full.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenode_edpm_compute_0_full.yaml
@@ -1,0 +1,27 @@
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneNode
+metadata:
+  name: edpm-compute-0
+spec:
+  hostName: edpm-compute-0
+  ansibleHost: 192.168.122.100
+  ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
+  node:
+    ansibleUser: root
+    ansiblePort: 22
+    ansibleVars: |
+      tenant_ip: 192.168.24.100
+      edpm_network_config_template: templates/net_config_bridge.j2
+      edpm_network_config_hide_sensitive_logs: false
+      neutron_physical_bridge_name: br-ex
+      neutron_public_interface_name: eth0
+      ctlplane_dns_nameservers:
+      - 192.168.122.1
+      dns_search_domains: []
+      edpm_ovn_dbs: 192.168.24.1
+      edpm_chrony_ntp_servers:
+        - clock.redhat.com
+        - clock2.redhat.com
+    ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
+  deployStrategy:
+    deploy: false

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,5 +1,9 @@
 ## Append samples you want in your CSV to this file as resources ##
 resources:
+- dataplane_v1beta1_openstackdataplanerole_edpm_compute.yaml
+- dataplane_v1beta1_openstackdataplanenode_edpm_compute_0.yaml
+- dataplane_v1beta1_openstackdataplanenode_edpm_compute_1.yaml
+- dataplane_v1beta1_openstackdataplanenode_edpm_compute_0_full.yaml
 - dataplane_v1beta1_openstackdataplane.yaml
 - dataplane_v1beta1_openstackdataplanerole.yaml
 - dataplane_v1beta1_openstackdataplanenode.yaml


### PR DESCRIPTION
This example for edpm_compute_0 can be used without first creating a
role. A full set of required ansibleVars is set on the node, so nothing
needs to be inherited from the role.

Signed-off-by: James Slagle <jslagle@redhat.com>
