### PR TITLE
Handle when ansibleVars is missing from node or role

### DIFF
--- a/controllers/openstackdataplanenode_controller.go
+++ b/controllers/openstackdataplanenode_controller.go
@@ -412,6 +412,13 @@ func (r *OpenStackDataPlaneNodeReconciler) GetAnsibleVars(instance *dataplanev1b
 		return nil, nodeYamlError
 	}
 
+	if role == nil && node != nil {
+		return node, nil
+	}
+	if role != nil && node == nil {
+		return role, nil
+	}
+
 	// Merge the two maps
 	for k, v := range node {
 		role[k] = v


### PR DESCRIPTION
If ansibleVars was not set in the role, then use the ansibleVars from the node and vice versa. Otherwise merge them. If ansibleVars is not in either the role or node, then the inventory is created without them. This is OK since ansibleVars is for extra vars.

Follow fix to 5295e54f0bf27624a4549d9e7643c28f100ed8b2

Related: [OSP-23184](https://issues.redhat.com//browse/OSP-23184)