### PR TITLE
Include openstack services containers related vars

### DIFF
--- a/config/samples/dataplane_v1beta1_openstackdataplane.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplane.yaml
@@ -46,5 +46,14 @@ spec:
           edpm_chrony_ntp_servers:
             - clock.redhat.com
             - clock2.redhat.com
+          registry_name: quay.io
+          registry_namespace: tripleozedcentos9
+          image_tag: current-tripleo
+          edpm_ovn_controller_agent_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-ovn-controller:{{ image_tag }}"
+          edpm_iscsid_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-iscsid:{{ image_tag }}"
+          edpm_logrotate_crond_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-cron:{{ image_tag }}"
+          edpm_nova_compute_container_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-nova-compute:{{ image_tag }}"
+          edpm_nova_libvirt_container_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-nova-libvirt:{{ image_tag }}"
+          edpm_ovn_metadata_agent_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-neutron-metadata-agent-ovn:{{ image_tag }}"
       deployStrategy:
         deploy: false

--- a/config/samples/dataplane_v1beta1_openstackdataplanenode_edpm_compute_0_full.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenode_edpm_compute_0_full.yaml
@@ -9,6 +9,7 @@ spec:
   node:
     ansibleUser: root
     ansiblePort: 22
+    ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
     ansibleVars: |
       tenant_ip: 192.168.24.100
       edpm_network_config_template: templates/net_config_bridge.j2
@@ -22,6 +23,14 @@ spec:
       edpm_chrony_ntp_servers:
         - clock.redhat.com
         - clock2.redhat.com
-    ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
+      registry_name: "quay.io"
+      registry_namespace: "tripleozedcentos9"
+      image_tag: "current-tripleo"
+      edpm_ovn_controller_agent_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-ovn-controller:{{ image_tag }}"
+      edpm_iscsid_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-iscsid:{{ image_tag }}"
+      edpm_logrotate_crond_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-cron:{{ image_tag }}"
+      edpm_nova_compute_container_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-nova-compute:{{ image_tag }}"
+      edpm_nova_libvirt_container_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-nova-libvirt:{{ image_tag }}"
+      edpm_ovn_metadata_agent_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-neutron-metadata-agent-ovn:{{ image_tag }}"
   deployStrategy:
     deploy: false

--- a/config/samples/dataplane_v1beta1_openstackdataplanerole_edpm_compute.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanerole_edpm_compute.yaml
@@ -21,5 +21,14 @@ spec:
       edpm_chrony_ntp_servers:
         - clock.redhat.com
         - clock2.redhat.com
+      registry_name: "quay.io"
+      registry_namespace: "tripleozedcentos9"
+      image_tag: "current-tripleo"
+      edpm_ovn_controller_agent_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-ovn-controller:{{ image_tag }}"
+      edpm_iscsid_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-iscsid:{{ image_tag }}"
+      edpm_logrotate_crond_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-cron:{{ image_tag }}"
+      edpm_nova_compute_container_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-nova-compute:{{ image_tag }}"
+      edpm_nova_libvirt_container_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-nova-libvirt:{{ image_tag }}"
+      edpm_ovn_metadata_agent_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-neutron-metadata-agent-ovn:{{ image_tag }}"
   deployStrategy:
     deploy: false


### PR DESCRIPTION
In Upstream and Downstream CI, we pull containers
from different registery, namespace and image tag.

In order to use the same, we need add these vars
in dataplane sample crd. So that it gets
consumed in CI.