### PR TITLE
Use correct conditions for DataPlane

### DIFF
--- a/api/v1beta1/conditions.go
+++ b/api/v1beta1/conditions.go
@@ -30,10 +30,6 @@ const (
 	// DataPlaneNodeErrorMessage error
 	DataPlaneNodeErrorMessage = "DataPlaneNode error occurred %s"
 
-	// DataPlaneRoleReadyCondition Status=True condition indicates
-	// DataPlaneRole is ready.
-	DataPlaneRoleReadyCondition condition.Type = "DataPlaneRoleReady"
-
 	// DataPlaneRoleReadyMessage ready
 	DataPlaneRoleReadyMessage = "DataPlaneRole ready"
 
@@ -42,6 +38,15 @@ const (
 
 	// DataPlaneRoleErrorMessage error
 	DataPlaneRoleErrorMessage = "DataPlaneRole error occurred %s"
+
+	// DataPlaneReadyMessage ready
+	DataPlaneReadyMessage = "DataPlane ready"
+
+	// DataPlaneReadyWaitingMessage ready
+	DataPlaneReadyWaitingMessage = "DataPlane not yet ready"
+
+	// DataPlaneErrorMessage error
+	DataPlaneErrorMessage = "DataPlane error occurred %s"
 
 	// ConfigureNetworkReadyCondition Status=True condition indicates if the
 	// network configuration is finished and successful.

--- a/api/v1beta1/openstackdataplane_types.go
+++ b/api/v1beta1/openstackdataplane_types.go
@@ -89,7 +89,7 @@ func (instance OpenStackDataPlane) InitConditions() {
 	if instance.Status.Conditions == nil {
 		instance.Status.Conditions = condition.Conditions{}
 	}
-	cl := condition.CreateList(condition.UnknownCondition(DataPlaneRoleReadyCondition, condition.InitReason, condition.InitReason))
+	cl := condition.CreateList(condition.UnknownCondition(condition.ReadyCondition, condition.InitReason, condition.InitReason))
 	// initialize conditions used later as Status=Unknown
 	instance.Status.Conditions.Init(&cl)
 }

--- a/controllers/openstackdataplane_controller.go
+++ b/controllers/openstackdataplane_controller.go
@@ -94,7 +94,7 @@ func (r *OpenStackDataPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 	defer func() {
 		// update the overall status condition if service is ready
 		if instance.IsReady() {
-			instance.Status.Conditions.MarkTrue(condition.ReadyCondition, dataplanev1beta1.DataPlaneRoleReadyMessage)
+			instance.Status.Conditions.MarkTrue(condition.ReadyCondition, dataplanev1beta1.DataPlaneReadyMessage)
 		} else {
 			// something is not ready so reset the Ready condition
 			instance.Status.Conditions.MarkUnknown(
@@ -148,7 +148,7 @@ func (r *OpenStackDataPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 			return ctrl.Result{}, err
 		}
 
-		instance.Status.Conditions.Set(condition.FalseCondition(dataplanev1beta1.DataPlaneRoleReadyCondition, condition.InitReason, condition.SeverityInfo, dataplanev1beta1.DataPlaneRoleReadyWaitingMessage))
+		instance.Status.Conditions.Set(condition.FalseCondition(condition.ReadyCondition, condition.InitReason, condition.SeverityInfo, dataplanev1beta1.DataPlaneReadyWaitingMessage))
 		for _, role := range roles.Items {
 			if role.Spec.DataPlane != instance.Name {
 				err = fmt.Errorf("role %s: role.DataPlane does not match with role.Label", role.Name)
@@ -186,10 +186,10 @@ func (r *OpenStackDataPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 		util.LogErrorForObject(helper, err, fmt.Sprintf("Unable to deploy %s", instance.Name), instance)
 		err = fmt.Errorf(fmt.Sprintf("DeployDataplane error(s): %s", deployErrors))
 		instance.Status.Conditions.Set(condition.FalseCondition(
-			dataplanev1beta1.DataPlaneRoleReadyCondition,
+			condition.ReadyCondition,
 			condition.ErrorReason,
 			condition.SeverityError,
-			dataplanev1beta1.DataPlaneRoleErrorMessage,
+			dataplanev1beta1.DataPlaneErrorMessage,
 			err.Error()))
 		return ctrl.Result{}, err
 	}
@@ -197,14 +197,14 @@ func (r *OpenStackDataPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{RequeueAfter: time.Second * 5}, nil
 	}
 	if instance.Spec.DeployStrategy.Deploy && len(deployErrors) == 0 {
-		r.Log.Info("Set DataPlaneRoleReadyCondition true")
-		instance.Status.Conditions.Set(condition.TrueCondition(dataplanev1beta1.DataPlaneRoleReadyCondition, dataplanev1beta1.DataPlaneRoleReadyMessage))
+		r.Log.Info("Set ReadyCondition true")
+		instance.Status.Conditions.Set(condition.TrueCondition(condition.ReadyCondition, dataplanev1beta1.DataPlaneReadyMessage))
 	}
 
-	// Set DataPlaneRoleReadyCondition to False if it was unknown
-	if instance.Status.Conditions.IsUnknown(dataplanev1beta1.DataPlaneRoleReadyCondition) {
-		r.Log.Info("Set DataPlaneRoleReadyCondition false")
-		instance.Status.Conditions.Set(condition.FalseCondition(dataplanev1beta1.DataPlaneRoleReadyCondition, condition.RequestedReason, condition.SeverityInfo, dataplanev1beta1.DataPlaneRoleReadyWaitingMessage))
+	// Set ReadyCondition to False if it was unknown
+	if instance.Status.Conditions.IsUnknown(condition.ReadyCondition) {
+		r.Log.Info("Set ReadyCondition false")
+		instance.Status.Conditions.Set(condition.FalseCondition(condition.ReadyCondition, condition.RequestedReason, condition.SeverityInfo, dataplanev1beta1.DataPlaneReadyWaitingMessage))
 	}
 
 	// Explicitly set instance.Spec.Deploy = false
@@ -230,10 +230,10 @@ func CreateDataPlaneResources(ctx context.Context, instance *dataplanev1beta1.Op
 	err := CreateDataPlaneRole(ctx, instance, helper)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
-			dataplanev1beta1.DataPlaneRoleReadyCondition,
+			condition.ReadyCondition,
 			condition.ErrorReason,
 			condition.SeverityError,
-			dataplanev1beta1.DataPlaneRoleErrorMessage,
+			dataplanev1beta1.DataPlaneErrorMessage,
 			err.Error()))
 		return ctrl.Result{}, err
 	}


### PR DESCRIPTION
The DataPlane controller should use the standard ReadyCondition from
lib-common. The condition messages should also be DataPlane specific,
and not the role messages.

Signed-off-by: James Slagle <jslagle@redhat.com>
