### PR TITLE
Trigger role reconcile for NovaExternalCompute update

### DIFF
--- a/controllers/openstackdataplanenode_controller.go
+++ b/controllers/openstackdataplanenode_controller.go
@@ -239,6 +239,7 @@ func (r *OpenStackDataPlaneNodeReconciler) Reconcile(ctx context.Context, req ct
 			ctx,
 			helper,
 			instance,
+			instance,
 			ansibleSSHPrivateKeySecret,
 			inventoryConfigMap,
 			&instance.Status,

--- a/pkg/deployment/nova.go
+++ b/pkg/deployment/nova.go
@@ -32,7 +32,7 @@ import (
 )
 
 // DeployNovaExternalCompute deploys the nova compute configuration and services
-func DeployNovaExternalCompute(ctx context.Context, helper *helper.Helper, obj client.Object, sshKeySecret string, inventoryConfigMap string, status *dataplanev1beta1.OpenStackDataPlaneStatus, networkAttachments []string, openStackAnsibleEERunnerImage string) (ctrl.Result, *novav1beta1.NovaExternalCompute, error) {
+func DeployNovaExternalCompute(ctx context.Context, helper *helper.Helper, obj client.Object, owner client.Object, sshKeySecret string, inventoryConfigMap string, status *dataplanev1beta1.OpenStackDataPlaneStatus, networkAttachments []string, openStackAnsibleEERunnerImage string) (ctrl.Result, *novav1beta1.NovaExternalCompute, error) {
 
 	log := helper.GetLogger()
 	log.Info(fmt.Sprintf("NovaExternalCompute deploy for %s", obj.GetName()))
@@ -58,7 +58,7 @@ func DeployNovaExternalCompute(ctx context.Context, helper *helper.Helper, obj c
 		novaExternalCompute.Spec.NetworkAttachments = networkAttachments
 		novaExternalCompute.Spec.AnsibleEEContainerImage = openStackAnsibleEERunnerImage
 
-		err := controllerutil.SetControllerReference(obj, novaExternalCompute, helper.GetScheme())
+		err := controllerutil.SetControllerReference(owner, novaExternalCompute, helper.GetScheme())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
OpenStackDataPlaneRole was not being reconciled when the associated
NovaExternalCompute's it had started were updated. This was due to 2
reasons.

First, the manager was not setup to Own the resources. This patch also
adds the other missing Owns, and adds the kubebuilder rules for the
other resources that both OpenStackDataPlaneRole and
OpenStackDataPlaneNode should own.

Second, the controller reference set on NovaExternalCompute was for the
node. In the case of a role deploy, this needs to be the role, so that
the role reconcile is triggered. The function signature of
DeployNovaExternalCompute needed to change to take an additional owner
parameter so that the owner can be set as either the node or role
depending on which type of deploy is triggered.

With these changes, roles are now reconciled a final time after all
NovaExternalCompute's are Ready, which is needed to set the final ready
state to true on the role.

Signed-off-by: James Slagle <jslagle@redhat.com>
