### PR TITLE
Add dash to generated name for AnsibleEE

### DIFF
--- a/pkg/util/ansible_execution.go
+++ b/pkg/util/ansible_execution.go
@@ -59,7 +59,7 @@ func AnsibleExecution(
 		return err
 	}
 	if ansibleEE == nil {
-		executionName := names.SimpleNameGenerator.GenerateName(label)
+		executionName := names.SimpleNameGenerator.GenerateName(fmt.Sprintf("%s-", label))
 		ansibleEE = &ansibleeev1alpha1.OpenStackAnsibleEE{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      executionName,


### PR DESCRIPTION
Add a dash between the label and the generated part of the AnsibleEE
name. It makes it easier to read.

Signed-off-by: James Slagle <jslagle@redhat.com>
