### PR TITLE
Remove fmt dependency from make tidy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -315,7 +315,7 @@ gowork: ## Generate go.work file to support our multi module repository
 
 APIPATH ?= $(shell pwd)/api
 .PHONY: tidy
-tidy: fmt
+tidy: ## Run go mod tidy on every mod file in the repo
 	go mod tidy; \
 	pushd $(APIPATH); \
 	go mod tidy; \


### PR DESCRIPTION
The fmt dependency cannot be run if the go.mod file needs an update:
```
 $ make tidy
 go fmt ./...
 go: updates to go.mod needed; to update it:
 	go mod tidy
 make: *** [Makefile:103: fmt] Error 1
```