### PR TITLE
add support for `ansible-playbook --limit` in DeployStrategy

### DIFF
--- a/api/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
@@ -43,6 +43,8 @@ spec:
                 type: string
               deployStrategy:
                 properties:
+                  ansibleLimit:
+                    type: string
                   ansibleTags:
                     type: string
                   deploy:

--- a/api/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
@@ -43,6 +43,8 @@ spec:
                 type: string
               deployStrategy:
                 properties:
+                  ansibleLimit:
+                    type: string
                   ansibleTags:
                     type: string
                   deploy:

--- a/api/bases/dataplane.openstack.org_openstackdataplanes.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplanes.yaml
@@ -43,6 +43,8 @@ spec:
             properties:
               deployStrategy:
                 properties:
+                  ansibleLimit:
+                    type: string
                   ansibleTags:
                     type: string
                   deploy:
@@ -58,6 +60,8 @@ spec:
                       type: string
                     deployStrategy:
                       properties:
+                        ansibleLimit:
+                          type: string
                         ansibleTags:
                           type: string
                         deploy:
@@ -924,6 +928,8 @@ spec:
                       type: string
                     deployStrategy:
                       properties:
+                        ansibleLimit:
+                          type: string
                         ansibleTags:
                           type: string
                         deploy:

--- a/api/v1beta1/common.go
+++ b/api/v1beta1/common.go
@@ -83,6 +83,10 @@ type DeployStrategySection struct {
 	// +kubebuilder:validation:Optional
 	// AnsibleTags for ansible execution
 	AnsibleTags string `json:"ansibleTags,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// AnsibleLimit for ansible execution
+	AnsibleLimit string `json:"ansibleLimit,omitempty"`
 }
 
 // NetworkConfigSection is a specification of the Network configuration details
@@ -141,6 +145,9 @@ type AnsibleEESpec struct {
 	// +kubebuilder:validation:Optional
 	// AnsibleTags for ansible execution
 	AnsibleTags string `json:"ansibleTags,omitempty"`
+	// +kubebuilder:validation:Optional
+	// AnsibleLimit for ansible execution
+	AnsibleLimit string `json:"ansibleLimit,omitempty"`
 	// ExtraMounts containing files which can be mounted into an Ansible Execution Pod
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default={}

--- a/api/v1beta1/openstackdataplanenode_types.go
+++ b/api/v1beta1/openstackdataplanenode_types.go
@@ -124,6 +124,11 @@ func (instance OpenStackDataPlaneNode) GetAnsibleEESpec(role OpenStackDataPlaneR
 	} else {
 		aee.AnsibleTags = role.Spec.DeployStrategy.AnsibleTags
 	}
+	if len(instance.Spec.DeployStrategy.AnsibleLimit) > 0 {
+		aee.AnsibleLimit = instance.Spec.DeployStrategy.AnsibleLimit
+	} else {
+		aee.AnsibleLimit = role.Spec.DeployStrategy.AnsibleLimit
+	}
 	if len(instance.Spec.Env) > 0 {
 		aee.Env = instance.Spec.Env
 	} else {

--- a/api/v1beta1/openstackdataplanerole_types.go
+++ b/api/v1beta1/openstackdataplanerole_types.go
@@ -139,6 +139,7 @@ func (instance OpenStackDataPlaneRole) GetAnsibleEESpec() AnsibleEESpec {
 		NetworkAttachments:            instance.Spec.NetworkAttachments,
 		OpenStackAnsibleEERunnerImage: instance.Spec.OpenStackAnsibleEERunnerImage,
 		AnsibleTags:                   instance.Spec.DeployStrategy.AnsibleTags,
+		AnsibleLimit:                  instance.Spec.DeployStrategy.AnsibleLimit,
 		ExtraMounts:                   instance.Spec.NodeTemplate.ExtraMounts,
 		Env:                           instance.Spec.Env,
 	}

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
@@ -43,6 +43,8 @@ spec:
                 type: string
               deployStrategy:
                 properties:
+                  ansibleLimit:
+                    type: string
                   ansibleTags:
                     type: string
                   deploy:

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
@@ -43,6 +43,8 @@ spec:
                 type: string
               deployStrategy:
                 properties:
+                  ansibleLimit:
+                    type: string
                   ansibleTags:
                     type: string
                   deploy:

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanes.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanes.yaml
@@ -43,6 +43,8 @@ spec:
             properties:
               deployStrategy:
                 properties:
+                  ansibleLimit:
+                    type: string
                   ansibleTags:
                     type: string
                   deploy:
@@ -58,6 +60,8 @@ spec:
                       type: string
                     deployStrategy:
                       properties:
+                        ansibleLimit:
+                          type: string
                         ansibleTags:
                           type: string
                         deploy:
@@ -924,6 +928,8 @@ spec:
                       type: string
                     deployStrategy:
                       properties:
+                        ansibleLimit:
+                          type: string
                         ansibleTags:
                           type: string
                         deploy:

--- a/docs/openstack_dataplanenode.md
+++ b/docs/openstack_dataplanenode.md
@@ -22,6 +22,7 @@ AnsibleEESpec is a specification of the ansible EE attributes
 | networkAttachments | NetworkAttachments is a list of NetworkAttachment resource names to pass to the ansibleee resource which allows to connect the ansibleee runner to the given network | []string | true |
 | openStackAnsibleEERunnerImage | OpenStackAnsibleEERunnerImage image to use as the ansibleEE runner image | string | true |
 | ansibleTags | AnsibleTags for ansible execution | string | false |
+| ansibleLimit | AnsibleLimit for ansible execution | string | false |
 | extraMounts | ExtraMounts containing files which can be mounted into an Ansible Execution Pod | []storage.VolMounts | true |
 | env | Env is a list containing the environment variables to pass to the pod | []corev1.EnvVar | false |
 
@@ -35,6 +36,7 @@ DeployStrategySection for fields controlling the deployment
 | ----- | ----------- | ------ | -------- |
 | deploy | Deploy boolean to trigger ansible execution | bool | true |
 | ansibleTags | AnsibleTags for ansible execution | string | false |
+| ansibleLimit | AnsibleLimit for ansible execution | string | false |
 
 [Back to Custom Resources](#custom-resources)
 

--- a/docs/openstack_dataplanerole.md
+++ b/docs/openstack_dataplanerole.md
@@ -22,6 +22,7 @@ AnsibleEESpec is a specification of the ansible EE attributes
 | networkAttachments | NetworkAttachments is a list of NetworkAttachment resource names to pass to the ansibleee resource which allows to connect the ansibleee runner to the given network | []string | true |
 | openStackAnsibleEERunnerImage | OpenStackAnsibleEERunnerImage image to use as the ansibleEE runner image | string | true |
 | ansibleTags | AnsibleTags for ansible execution | string | false |
+| ansibleLimit | AnsibleLimit for ansible execution | string | false |
 | extraMounts | ExtraMounts containing files which can be mounted into an Ansible Execution Pod | []storage.VolMounts | true |
 | env | Env is a list containing the environment variables to pass to the pod | []corev1.EnvVar | false |
 
@@ -35,6 +36,7 @@ DeployStrategySection for fields controlling the deployment
 | ----- | ----------- | ------ | -------- |
 | deploy | Deploy boolean to trigger ansible execution | bool | true |
 | ansibleTags | AnsibleTags for ansible execution | string | false |
+| ansibleLimit | AnsibleLimit for ansible execution | string | false |
 
 [Back to Custom Resources](#custom-resources)
 

--- a/pkg/util/ansible_execution.go
+++ b/pkg/util/ansible_execution.go
@@ -74,6 +74,9 @@ func AnsibleExecution(
 		if len(aeeSpec.AnsibleTags) > 0 {
 			ansibleEE.Spec.CmdLine = fmt.Sprintf("--tags %s", aeeSpec.AnsibleTags)
 		}
+		if len(aeeSpec.AnsibleLimit) > 0 {
+			ansibleEE.Spec.CmdLine = fmt.Sprintf("--limit %s", aeeSpec.AnsibleLimit)
+		}
 		// TODO(slagle): Handle either play or role being specified
 		ansibleEE.Spec.Role = &role
 


### PR DESCRIPTION
It adds the `AnsibleLimit` property for `deployStrategy` to enable the support to `ansible --limit` feature during playbook executions.