### PR TITLE
Add support for `ansible-playbook --skip-tags` in DeployStrategy

### DIFF
--- a/api/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
@@ -45,6 +45,8 @@ spec:
                 properties:
                   ansibleLimit:
                     type: string
+                  ansibleSkipTags:
+                    type: string
                   ansibleTags:
                     type: string
                   deploy:

--- a/api/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
@@ -45,6 +45,8 @@ spec:
                 properties:
                   ansibleLimit:
                     type: string
+                  ansibleSkipTags:
+                    type: string
                   ansibleTags:
                     type: string
                   deploy:

--- a/api/bases/dataplane.openstack.org_openstackdataplanes.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplanes.yaml
@@ -45,6 +45,8 @@ spec:
                 properties:
                   ansibleLimit:
                     type: string
+                  ansibleSkipTags:
+                    type: string
                   ansibleTags:
                     type: string
                   deploy:
@@ -61,6 +63,8 @@ spec:
                     deployStrategy:
                       properties:
                         ansibleLimit:
+                          type: string
+                        ansibleSkipTags:
                           type: string
                         ansibleTags:
                           type: string
@@ -929,6 +933,8 @@ spec:
                     deployStrategy:
                       properties:
                         ansibleLimit:
+                          type: string
+                        ansibleSkipTags:
                           type: string
                         ansibleTags:
                           type: string

--- a/api/v1beta1/common.go
+++ b/api/v1beta1/common.go
@@ -87,6 +87,10 @@ type DeployStrategySection struct {
 	// +kubebuilder:validation:Optional
 	// AnsibleLimit for ansible execution
 	AnsibleLimit string `json:"ansibleLimit,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// AnsibleSkipTags for ansible execution
+	AnsibleSkipTags string `json:"ansibleSkipTags,omitempty"`
 }
 
 // NetworkConfigSection is a specification of the Network configuration details
@@ -148,6 +152,9 @@ type AnsibleEESpec struct {
 	// +kubebuilder:validation:Optional
 	// AnsibleLimit for ansible execution
 	AnsibleLimit string `json:"ansibleLimit,omitempty"`
+	// +kubebuilder:validation:Optional
+	// AnsibleSkipTags for ansible execution
+	AnsibleSkipTags string `json:"ansibleSkipTags,omitempty"`
 	// ExtraMounts containing files which can be mounted into an Ansible Execution Pod
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default={}

--- a/api/v1beta1/openstackdataplanenode_types.go
+++ b/api/v1beta1/openstackdataplanenode_types.go
@@ -129,6 +129,11 @@ func (instance OpenStackDataPlaneNode) GetAnsibleEESpec(role OpenStackDataPlaneR
 	} else {
 		aee.AnsibleLimit = role.Spec.DeployStrategy.AnsibleLimit
 	}
+	if len(instance.Spec.DeployStrategy.AnsibleSkipTags) > 0 {
+		aee.AnsibleSkipTags = instance.Spec.DeployStrategy.AnsibleSkipTags
+	} else {
+		aee.AnsibleSkipTags = role.Spec.DeployStrategy.AnsibleSkipTags
+	}
 	if len(instance.Spec.Env) > 0 {
 		aee.Env = instance.Spec.Env
 	} else {

--- a/api/v1beta1/openstackdataplanerole_types.go
+++ b/api/v1beta1/openstackdataplanerole_types.go
@@ -140,6 +140,7 @@ func (instance OpenStackDataPlaneRole) GetAnsibleEESpec() AnsibleEESpec {
 		OpenStackAnsibleEERunnerImage: instance.Spec.OpenStackAnsibleEERunnerImage,
 		AnsibleTags:                   instance.Spec.DeployStrategy.AnsibleTags,
 		AnsibleLimit:                  instance.Spec.DeployStrategy.AnsibleLimit,
+		AnsibleSkipTags:               instance.Spec.DeployStrategy.AnsibleSkipTags,
 		ExtraMounts:                   instance.Spec.NodeTemplate.ExtraMounts,
 		Env:                           instance.Spec.Env,
 	}

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
@@ -45,6 +45,8 @@ spec:
                 properties:
                   ansibleLimit:
                     type: string
+                  ansibleSkipTags:
+                    type: string
                   ansibleTags:
                     type: string
                   deploy:

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
@@ -45,6 +45,8 @@ spec:
                 properties:
                   ansibleLimit:
                     type: string
+                  ansibleSkipTags:
+                    type: string
                   ansibleTags:
                     type: string
                   deploy:

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanes.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanes.yaml
@@ -45,6 +45,8 @@ spec:
                 properties:
                   ansibleLimit:
                     type: string
+                  ansibleSkipTags:
+                    type: string
                   ansibleTags:
                     type: string
                   deploy:
@@ -61,6 +63,8 @@ spec:
                     deployStrategy:
                       properties:
                         ansibleLimit:
+                          type: string
+                        ansibleSkipTags:
                           type: string
                         ansibleTags:
                           type: string
@@ -929,6 +933,8 @@ spec:
                     deployStrategy:
                       properties:
                         ansibleLimit:
+                          type: string
+                        ansibleSkipTags:
                           type: string
                         ansibleTags:
                           type: string

--- a/docs/openstack_dataplanenode.md
+++ b/docs/openstack_dataplanenode.md
@@ -23,6 +23,7 @@ AnsibleEESpec is a specification of the ansible EE attributes
 | openStackAnsibleEERunnerImage | OpenStackAnsibleEERunnerImage image to use as the ansibleEE runner image | string | true |
 | ansibleTags | AnsibleTags for ansible execution | string | false |
 | ansibleLimit | AnsibleLimit for ansible execution | string | false |
+| ansibleSkipTags | AnsibleSkipTags for ansible execution | string | false |
 | extraMounts | ExtraMounts containing files which can be mounted into an Ansible Execution Pod | []storage.VolMounts | true |
 | env | Env is a list containing the environment variables to pass to the pod | []corev1.EnvVar | false |
 
@@ -37,6 +38,7 @@ DeployStrategySection for fields controlling the deployment
 | deploy | Deploy boolean to trigger ansible execution | bool | true |
 | ansibleTags | AnsibleTags for ansible execution | string | false |
 | ansibleLimit | AnsibleLimit for ansible execution | string | false |
+| ansibleSkipTags | AnsibleSkipTags for ansible execution | string | false |
 
 [Back to Custom Resources](#custom-resources)
 

--- a/docs/openstack_dataplanerole.md
+++ b/docs/openstack_dataplanerole.md
@@ -23,6 +23,7 @@ AnsibleEESpec is a specification of the ansible EE attributes
 | openStackAnsibleEERunnerImage | OpenStackAnsibleEERunnerImage image to use as the ansibleEE runner image | string | true |
 | ansibleTags | AnsibleTags for ansible execution | string | false |
 | ansibleLimit | AnsibleLimit for ansible execution | string | false |
+| ansibleSkipTags | AnsibleSkipTags for ansible execution | string | false |
 | extraMounts | ExtraMounts containing files which can be mounted into an Ansible Execution Pod | []storage.VolMounts | true |
 | env | Env is a list containing the environment variables to pass to the pod | []corev1.EnvVar | false |
 
@@ -37,6 +38,7 @@ DeployStrategySection for fields controlling the deployment
 | deploy | Deploy boolean to trigger ansible execution | bool | true |
 | ansibleTags | AnsibleTags for ansible execution | string | false |
 | ansibleLimit | AnsibleLimit for ansible execution | string | false |
+| ansibleSkipTags | AnsibleSkipTags for ansible execution | string | false |
 
 [Back to Custom Resources](#custom-resources)
 

--- a/pkg/util/ansible_execution.go
+++ b/pkg/util/ansible_execution.go
@@ -19,6 +19,7 @@ package util
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -50,6 +51,7 @@ func AnsibleExecution(
 ) error {
 
 	var err error
+	var cmdLineArguments strings.Builder
 
 	ansibleEE, err := GetAnsibleExecution(ctx, helper, obj, label)
 	if err != nil && !k8serrors.IsNotFound(err) {
@@ -72,14 +74,18 @@ func AnsibleExecution(
 		ansibleEE.Spec.Image = aeeSpec.OpenStackAnsibleEERunnerImage
 		ansibleEE.Spec.NetworkAttachments = aeeSpec.NetworkAttachments
 		if len(aeeSpec.AnsibleTags) > 0 {
-			ansibleEE.Spec.CmdLine = fmt.Sprintf("--tags %s", aeeSpec.AnsibleTags)
+			fmt.Fprintf(&cmdLineArguments, "--tags %s ", aeeSpec.AnsibleTags)
 		}
 		if len(aeeSpec.AnsibleLimit) > 0 {
-			ansibleEE.Spec.CmdLine = fmt.Sprintf("--limit %s", aeeSpec.AnsibleLimit)
+			fmt.Fprintf(&cmdLineArguments, "--limit %s ", aeeSpec.AnsibleLimit)
 		}
 		if len(aeeSpec.AnsibleSkipTags) > 0 {
-			ansibleEE.Spec.CmdLine = fmt.Sprintf("--skip-tags %s", aeeSpec.AnsibleSkipTags)
+			fmt.Fprintf(&cmdLineArguments, "--skip-tags %s ", aeeSpec.AnsibleSkipTags)
 		}
+		if cmdLineArguments.Len() > 0 {
+			ansibleEE.Spec.CmdLine = strings.TrimSpace(cmdLineArguments.String())
+		}
+
 		// TODO(slagle): Handle either play or role being specified
 		ansibleEE.Spec.Role = &role
 

--- a/pkg/util/ansible_execution.go
+++ b/pkg/util/ansible_execution.go
@@ -77,6 +77,9 @@ func AnsibleExecution(
 		if len(aeeSpec.AnsibleLimit) > 0 {
 			ansibleEE.Spec.CmdLine = fmt.Sprintf("--limit %s", aeeSpec.AnsibleLimit)
 		}
+		if len(aeeSpec.AnsibleSkipTags) > 0 {
+			ansibleEE.Spec.CmdLine = fmt.Sprintf("--skip-tags %s", aeeSpec.AnsibleSkipTags)
+		}
 		// TODO(slagle): Handle either play or role being specified
 		ansibleEE.Spec.Role = &role
 


### PR DESCRIPTION
It adds the `AnsibleSkipTags` property for `deployStrategy` to enable the support to `ansible-playbook --skip-tags` feature during playbook executions.