### PR TITLE
Add handling for custom nic config

### DIFF
--- a/api/v1beta1/common.go
+++ b/api/v1beta1/common.go
@@ -89,7 +89,7 @@ type DeployStrategySection struct {
 type NetworkConfigSection struct {
 
 	// +kubebuilder:validation:Optional
-	// Template - ansible j2 nic config template to use when applying node
+	// Template - Contains a Ansible j2 nic config template to use when applying node
 	// network configuration
 	Template string `json:"template,omitempty" yaml:"template,omitempty"`
 }

--- a/config/samples/dataplane_v1beta1_openstackdataplane_customnetworks.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplane_customnetworks.yaml
@@ -1,0 +1,174 @@
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlane
+metadata:
+  name: openstack-edpm
+spec:
+  deployStrategy:
+    deploy: false
+  nodes:
+    edpm-compute-0:
+      role: edpm-compute
+      hostName: edpm-compute-0
+      ansibleHost: 192.168.1.5
+      node:
+        ansibleVars: |
+          ctlplane_ip: 192.168.1.5
+          internal_api_ip: 172.17.0.101
+          storage_ip: 172.18.0.101
+          tenant_ip: 172.10.0.101
+          external_ip: 172.20.12.76
+          fqdn_internal_api: edpm-compute-1.example.com
+          ansible_ssh_transfer_method: scp
+        ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
+        ansibleUser: root
+      deployStrategy:
+        deploy: true
+  roles:
+    edpm-compute:
+      env:
+        - name: ANSIBLE_FORCE_COLOR
+          value: "True"
+        - name: ANSIBLE_ENABLE_TASK_DEBUGGER
+          value: "True"
+        - name: ANSIBLE_VERBOSITY
+          value: 4
+        - name: ANSIBLE_HOST_KEY_CHECKING
+          value: false
+      nodeTemplate:
+        managed: false
+        managementNetwork: ctlplane
+        ansibleUser: root
+        ansiblePort: 22
+        ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
+        networkConfig:
+          template: |
+            ---
+            network_config:
+            - type: interface
+              name: nic2
+              mtu: 1500
+              addresses:
+                - ip_netmask:
+                    {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+            - type: ovs_bridge
+              name: {{ neutron_physical_bridge_name }}
+              mtu: 1500
+              use_dhcp: false
+              dns_servers: {{ ctlplane_dns_nameservers }}
+              domain: []
+              addresses:
+              - ip_netmask: {{ lookup('vars', networks_lower["External"] ~ '_ip') }}/{{ lookup('vars', networks_lower["External"] ~ '_cidr') }}
+              routes: [{'ip_netmask': '0.0.0.0/0', 'next_hop': '192.168.1.254'}]
+              members:
+              - type: interface
+                name: nic1
+                mtu: 1500
+                # force the MAC address of the bridge to this interface
+                primary: true
+              - type: vlan
+                mtu: 1500
+                vlan_id: 20
+                addresses:
+                - ip_netmask:
+                    172.17.0.101/24
+                routes: []
+              - type: vlan
+                mtu: 1500
+                vlan_id: 25
+                addresses:
+                - ip_netmask:
+                    172.18.0.101/24
+                routes: []
+              - type: vlan
+                mtu: 1500
+                vlan_id: 22
+                addresses:
+                - ip_netmask:
+                    172.10.0.101/24
+                routes: []
+        ansibleVars: |
+          # edpm_network_config
+          # Default nic config template for a EDPM compute node
+          # These vars are edpm_network_config role vars
+          edpm_network_config_template: /runner/network/nic-config-template
+          edpm_network_config_hide_sensitive_logs: false
+          edpm_network_config_update: false
+          #
+          # These vars are for the network config templates themselves and are
+          # considered EDPM network defaults.
+          neutron_physical_bridge_name: br-ex
+          neutron_public_interface_name: enp7s0
+          ctlplane_mtu: 1500
+          ctlplane_subnet_cidr: 24
+          ctlplane_gateway_ip: 192.168.1.254
+          ctlplane_host_routes:
+          - ip_netmask: 0.0.0.0/0
+            next_hop: 192.168.1.254
+          external_mtu: 1500
+          external_vlan_id: 4
+          external_cidr: '24'
+          external_host_routes: []
+          internal_api_mtu: 1500
+          internal_api_vlan_id: 20
+          internal_api_cidr: '24'
+          internal_api_host_routes: []
+          storage_mtu: 1500
+          storage_vlan_id: 21
+          storage_cidr: '24'
+          storage_host_routes: []
+          tenant_mtu: 1500
+          tenant_vlan_id: 22
+          tenant_cidr: '24'
+          tenant_host_routes: []
+          role_networks:
+          - InternalApi
+          - Storage
+          - Tenant
+          - External
+          networks_lower:
+            External: external
+            InternalApi: internal_api
+            Storage: storage
+            Tenant: tenant
+
+          # edpm_nodes_validation
+          edpm_nodes_validation_validate_controllers_icmp: false
+          edpm_nodes_validation_validate_gateway_icmp: false
+
+          edpm_ovn_metadata_agent_default_transport_url: rabbit://default_user@rabbitmq.openstack.svc:5672
+          edpm_ovn_metadata_agent_metadata_agent_ovn_ovn_sb_connection: tcp:10.217.5.121:6642
+          edpm_ovn_metadata_agent_metadata_agent_default_nova_metadata_host: 127.0.0.1
+          edpm_ovn_metadata_agent_metadata_agent_default_metadata_proxy_shared_secret: 12345678
+          edpm_ovn_metadata_agent_default_bind_host: 127.0.0.1
+
+          ctlplane_dns_nameservers:
+          - 192.168.1.254
+          dns_search_domains: []
+          edpm_ovn_dbs:
+          - 192.168.24.1
+
+          edpm_ovn_controller_agent_image: quay.io/tripleozedcentos9/openstack-ovn-controller:current-tripleo
+          edpm_iscsid_image: quay.io/tripleozedcentos9/openstack-iscsid:current-tripleo
+          edpm_logrotate_crond_image: quay.io/tripleozedcentos9/openstack-cron:current-tripleo
+          edpm_nova_compute_container_image: quay.io/tripleozedcentos9/openstack-nova-compute:current-tripleo
+          edpm_nova_libvirt_container_image: quay.io/tripleozedcentos9/openstack-nova-libvirt:current-tripleo
+          edpm_ovn_metadata_agent_image: quay.io/tripleozedcentos9/openstack-neutron-metadata-agent-ovn:current-tripleo
+
+          gather_facts: false
+          enable_debug: false
+          # edpm firewall, change the allowed CIDR if needed
+          edpm_sshd_configure_firewall: true
+          edpm_sshd_allowed_ranges: ['192.168.0.0/24', '172.20.0.0/16']
+          # SELinux module
+          edpm_selinux_mode: enforcing
+          edpm_hosts_entries_undercloud_hosts_entries: []
+          # edpm_hosts_entries role
+          edpm_hosts_entries_extra_hosts_entries:
+          - 172.17.0.80 glance-internal.openstack.svc neutron-internal.openstack.svc cinder-internal.openstack.svc nova-internal.openstack.svc placement-internal.openstack.svc keystone-internal.openstack.svc
+          - 172.17.0.85 rabbitmq.openstack.svc
+          - 172.17.0.86 rabbitmq-cell1.openstack.svc
+          edpm_hosts_entries_vip_hosts_entries: []
+          hosts_entries: []
+          hosts_entry: []
+      deployStrategy:
+        deploy: false

--- a/docs/openstack_dataplanenode.md
+++ b/docs/openstack_dataplanenode.md
@@ -44,7 +44,7 @@ NetworkConfigSection is a specification of the Network configuration details
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| template | Template - ansible j2 nic config template to use when applying node network configuration | string | false |
+| template | Template - Contains a Ansible j2 nic config template to use when applying node network configuration | string | false |
 
 [Back to Custom Resources](#custom-resources)
 

--- a/docs/openstack_dataplanerole.md
+++ b/docs/openstack_dataplanerole.md
@@ -44,7 +44,7 @@ NetworkConfigSection is a specification of the Network configuration details
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| template | Template - ansible j2 nic config template to use when applying node network configuration | string | false |
+| template | Template - Contains a Ansible j2 nic config template to use when applying node network configuration | string | false |
 
 [Back to Custom Resources](#custom-resources)
 

--- a/pkg/deployment/const.go
+++ b/pkg/deployment/const.go
@@ -44,4 +44,7 @@ const (
 
 	// RunOpenStackLabel for RunOpenStack OpenStackAnsibleEE
 	RunOpenStackLabel = "dataplane-deployment-run-openstack"
+
+	// NicConfigTemplateFile is the custom nic config file we use when user provided network config templates are provided.
+	NicConfigTemplateFile = "/runner/network/nic-config-template"
 )

--- a/pkg/util/ansible_execution.go
+++ b/pkg/util/ansible_execution.go
@@ -110,6 +110,10 @@ func AnsibleExecution(
 							Key:  "inventory",
 							Path: "inventory",
 						},
+						{
+							Key:  "network",
+							Path: "network",
+						},
 					},
 				},
 			},
@@ -119,11 +123,17 @@ func AnsibleExecution(
 			MountPath: "/runner/inventory/hosts",
 			SubPath:   "inventory",
 		}
+		networkConfigMount := corev1.VolumeMount{
+			Name:      "inventory",
+			MountPath: "/runner/network/nic-config-template",
+			SubPath:   "network",
+		}
 
 		ansibleEEMounts.Volumes = append(ansibleEEMounts.Volumes, sshKeyVolume)
 		ansibleEEMounts.Volumes = append(ansibleEEMounts.Volumes, inventoryVolume)
 		ansibleEEMounts.Mounts = append(ansibleEEMounts.Mounts, sshKeyMount)
 		ansibleEEMounts.Mounts = append(ansibleEEMounts.Mounts, inventoryMount)
+		ansibleEEMounts.Mounts = append(ansibleEEMounts.Mounts, networkConfigMount)
 
 		ansibleEE.Spec.ExtraMounts = append(aeeSpec.ExtraMounts, []storage.VolMounts{ansibleEEMounts}...)
 		ansibleEE.Spec.Env = aeeSpec.Env


### PR DESCRIPTION
Users should be able to provide their own custom jinja2 or static nic-config template to be used during the os-net-config stage. This change adds handling for a nic-config template file, and wires in the relevant mounts to ensure the file is present within the AEE container.
