### PR TITLE
Use already initialized Client and Logger

### DIFF
--- a/controllers/openstackdataplanenode_controller.go
+++ b/controllers/openstackdataplanenode_controller.go
@@ -126,7 +126,7 @@ func (r *OpenStackDataPlaneNodeReconciler) Reconcile(ctx context.Context, req ct
 		[]string{
 			"ssh-privatekey",
 		},
-		helper.GetClient(),
+		r.Client,
 		time.Duration(5)*time.Second,
 	)
 	if err != nil {

--- a/controllers/openstackdataplanerole_controller.go
+++ b/controllers/openstackdataplanerole_controller.go
@@ -125,7 +125,7 @@ func (r *OpenStackDataPlaneRoleReconciler) Reconcile(ctx context.Context, req ct
 		labels := client.MatchingLabels(labelSelector)
 		listOpts = append(listOpts, labels)
 	}
-	err = helper.GetClient().List(ctx, nodes, listOpts...)
+	err = r.Client.List(ctx, nodes, listOpts...)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -177,7 +177,7 @@ func (r *OpenStackDataPlaneRoleReconciler) Reconcile(ctx context.Context, req ct
 		[]string{
 			"ssh-privatekey",
 		},
-		helper.GetClient(),
+		r.Client,
 		time.Duration(5)*time.Second,
 	)
 	if err != nil {
@@ -283,7 +283,7 @@ func (r *OpenStackDataPlaneRoleReconciler) Reconcile(ctx context.Context, req ct
 		instance.Status.Conditions.Set(condition.TrueCondition(condition.ReadyCondition, dataplanev1beta1.DataPlaneRoleReadyMessage))
 		for _, node := range nodes.Items {
 			if !node.IsReady() {
-				_, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), &node, func() error {
+				_, err := controllerutil.CreateOrPatch(ctx, r.Client, &node, func() error {
 					node.Status.Deployed = true
 					return nil
 				})


### PR DESCRIPTION
We already initialize the Logger and Client as part of the OpenStackDataPlaneReconciler struct. These can be reused instead of calling helper.GetClient(), helper.GetLogger() repetitively through out the controller.

This change configures inheritence of the OpenStackDataPlaneReconciler struct using receiver functions.