### PR TITLE
Enable ginkgolinter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -4,6 +4,7 @@ linters:
   enable:
     - errorlint
     - revive
+    - ginkgolinter
     - gofmt
     - govet
 linters-settings:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,11 +25,6 @@ repos:
   hooks:
     - id: go-mod-tidy
 
-- repo: https://github.com/golangci/golangci-lint
-  rev: v1.50.1
-  hooks:
-    - id: golangci-lint
-
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.4.0
   hooks:


### PR DESCRIPTION
This PR also removed the duplicate hook for golangci-lint.