### PR TITLE
Rename edpm approvers in OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,6 +5,6 @@ approvers:
   - openstack-approvers
 
 reviewers:
-  - edpm-approvers
+  - dataplane-approvers
   - ci-approvers
   - openstack-approvers


### PR DESCRIPTION
We missed to update this partially in [1]

[1] https://github.com/openstack-k8s-operators/dataplane-operator/pull/161