### PR TITLE
Refactor deployment.go to use Interfaces

### DIFF
--- a/pkg/deployment/ceph_client.go
+++ b/pkg/deployment/ceph_client.go
@@ -18,6 +18,7 @@ package deployment
 
 import (
 	"context"
+	"fmt"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -27,8 +28,8 @@ import (
 	ansibleeev1alpha1 "github.com/openstack-k8s-operators/openstack-ansibleee-operator/api/v1alpha1"
 )
 
-// ConfigureCephClient ensures the Ceph client configuration files are on data plane nodes
-func ConfigureCephClient(ctx context.Context, helper *helper.Helper, obj client.Object, sshKeySecret string, inventoryConfigMap string, aeeSpec dataplanev1beta1.AnsibleEESpec) error {
+// Configure ensures the Ceph client configuration files are on data plane nodes
+func (c CephClient) Configure(ctx context.Context, helper *helper.Helper, obj client.Object, sshKeySecret string, inventoryConfigMap string, aeeSpec dataplanev1beta1.AnsibleEESpec) error {
 
 	tasks := []dataplaneutil.Task{
 		{
@@ -54,4 +55,19 @@ func ConfigureCephClient(ctx context.Context, helper *helper.Helper, obj client.
 
 	return nil
 
+}
+
+// Validate - CephClient does not implement this method but is required to satisfy the interface contract
+func (c CephClient) Validate(ctx context.Context, helper *helper.Helper, obj client.Object, sshKeySecret string, inventoryConfigMap string, aeeSpec dataplanev1beta1.AnsibleEESpec) error {
+	return fmt.Errorf("CephClient does not implement the Validate method")
+}
+
+// Install - CephClient does not implement this method but is required to satisfy the interface contract
+func (c CephClient) Install(ctx context.Context, helper *helper.Helper, obj client.Object, sshKeySecret string, inventoryConfigMap string, aeeSpec dataplanev1beta1.AnsibleEESpec) error {
+	return fmt.Errorf("CephClient does not implement the Install method")
+}
+
+// Run - CephClient does not implement this method but is required to satisfy the interface contract
+func (c CephClient) Run(ctx context.Context, helper *helper.Helper, obj client.Object, sshKeySecret string, inventoryConfigMap string, aeeSpec dataplanev1beta1.AnsibleEESpec) error {
+	return fmt.Errorf("CephClient does not implement the Run method")
 }

--- a/pkg/deployment/network.go
+++ b/pkg/deployment/network.go
@@ -18,6 +18,7 @@ package deployment
 
 import (
 	"context"
+	"fmt"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -27,8 +28,8 @@ import (
 	ansibleeev1alpha1 "github.com/openstack-k8s-operators/openstack-ansibleee-operator/api/v1alpha1"
 )
 
-// ConfigureNetwork ensures the network config
-func ConfigureNetwork(ctx context.Context, helper *helper.Helper, obj client.Object, sshKeySecret string, inventoryConfigMap string, aeeSpec dataplanev1beta1.AnsibleEESpec) error {
+// Configure ensures the network config
+func (n Networker) Configure(ctx context.Context, helper *helper.Helper, obj client.Object, sshKeySecret string, inventoryConfigMap string, aeeSpec dataplanev1beta1.AnsibleEESpec) error {
 
 	tasks := []dataplaneutil.Task{
 		{
@@ -61,8 +62,8 @@ func ConfigureNetwork(ctx context.Context, helper *helper.Helper, obj client.Obj
 
 }
 
-// ValidateNetwork ensures the node network config
-func ValidateNetwork(ctx context.Context, helper *helper.Helper, obj client.Object, sshKeySecret string, inventoryConfigMap string, aeeSpec dataplanev1beta1.AnsibleEESpec) error {
+// Validate ensures the node network config
+func (n Networker) Validate(ctx context.Context, helper *helper.Helper, obj client.Object, sshKeySecret string, inventoryConfigMap string, aeeSpec dataplanev1beta1.AnsibleEESpec) error {
 
 	role := ansibleeev1alpha1.Role{
 		Name:     "osp.edpm.edpm_nodes_validation",
@@ -87,4 +88,14 @@ func ValidateNetwork(ctx context.Context, helper *helper.Helper, obj client.Obje
 
 	return nil
 
+}
+
+// Install - Networker does not implement this method but is required to satisfy the interface contract
+func (n Networker) Install(ctx context.Context, helper *helper.Helper, obj client.Object, sshKeySecret string, inventoryConfigMap string, aeeSpec dataplanev1beta1.AnsibleEESpec) error {
+	return fmt.Errorf("Network does not implement the Install method")
+}
+
+// Run - Networker does not implement this method but is required to satisfy the interface contract
+func (n Networker) Run(ctx context.Context, helper *helper.Helper, obj client.Object, sshKeySecret string, inventoryConfigMap string, aeeSpec dataplanev1beta1.AnsibleEESpec) error {
+	return fmt.Errorf("Network does not implement the Run method")
 }

--- a/pkg/deployment/os.go
+++ b/pkg/deployment/os.go
@@ -18,6 +18,7 @@ package deployment
 
 import (
 	"context"
+	"fmt"
 
 	dataplanev1beta1 "github.com/openstack-k8s-operators/dataplane-operator/api/v1beta1"
 	dataplaneutil "github.com/openstack-k8s-operators/dataplane-operator/pkg/util"
@@ -26,8 +27,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// InstallOS ensures the node Operating System is installed
-func InstallOS(ctx context.Context, helper *helper.Helper, obj client.Object, sshKeySecret string, inventoryConfigMap string, aeeSpec dataplanev1beta1.AnsibleEESpec) error {
+// Install ensures the node Operating System is installed
+func (os OperatingSystem) Install(ctx context.Context, helper *helper.Helper, obj client.Object, sshKeySecret string, inventoryConfigMap string, aeeSpec dataplanev1beta1.AnsibleEESpec) error {
 
 	tasks := []dataplaneutil.Task{
 		{
@@ -87,8 +88,8 @@ func InstallOS(ctx context.Context, helper *helper.Helper, obj client.Object, ss
 
 }
 
-// ConfigureOS ensures the node Operating System config
-func ConfigureOS(ctx context.Context, helper *helper.Helper, obj client.Object, sshKeySecret string, inventoryConfigMap string, aeeSpec dataplanev1beta1.AnsibleEESpec) error {
+// Configure ensures the node Operating System config
+func (os OperatingSystem) Configure(ctx context.Context, helper *helper.Helper, obj client.Object, sshKeySecret string, inventoryConfigMap string, aeeSpec dataplanev1beta1.AnsibleEESpec) error {
 
 	tasks := []dataplaneutil.Task{
 		{
@@ -154,8 +155,8 @@ func ConfigureOS(ctx context.Context, helper *helper.Helper, obj client.Object, 
 
 }
 
-// RunOS ensures the node Operating System is running
-func RunOS(ctx context.Context, helper *helper.Helper, obj client.Object, sshKeySecret string, inventoryConfigMap string, aeeSpec dataplanev1beta1.AnsibleEESpec) error {
+// Run ensures the node Operating System is running
+func (os OperatingSystem) Run(ctx context.Context, helper *helper.Helper, obj client.Object, sshKeySecret string, inventoryConfigMap string, aeeSpec dataplanev1beta1.AnsibleEESpec) error {
 
 	tasks := []dataplaneutil.Task{
 		{
@@ -213,4 +214,9 @@ func RunOS(ctx context.Context, helper *helper.Helper, obj client.Object, sshKey
 
 	return nil
 
+}
+
+// Validate is not implemented for OS, but is required to satisfy the interface contract
+func (os OperatingSystem) Validate(ctx context.Context, helper *helper.Helper, obj client.Object, sshKeySecret string, inventoryConfigMap string, aeeSpec dataplanev1beta1.AnsibleEESpec) error {
+	return fmt.Errorf("OS does not implement the Validate method")
 }


### PR DESCRIPTION
This change refactors the current implementation of deployment.go to leverage interfaces and structs for each deploy step.

This change standardises the implementation for each module based around a set of standard verbs used in edpm_ansible, and abstracts any of the complexity into the deployments.go file.