### PR TITLE
Typo in dataplaneS url

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ single managing operator and UX for a complete OpenStack deployment
 The dataplane-operator exposes the concepts of data plane role and nodes. These
 are represented as CRD's within the operator:
 
-* [OpenStackDataPlane](https://github.com/openstack-k8s-operators/dataplane-operator/blob/main/config/crd/bases/dataplane.openstack.org_openstackdataplane.yaml)
+* [OpenStackDataPlane](https://github.com/openstack-k8s-operators/dataplane-operator/blob/main/config/crd/bases/dataplane.openstack.org_openstackdataplanes.yaml)
 * [OpenStackDataPlaneRole](https://github.com/openstack-k8s-operators/dataplane-operator/blob/main/config/crd/bases/dataplane.openstack.org_openstackdataplaneroles.yaml)
 * [OpenStackDataPlaneNode](https://github.com/openstack-k8s-operators/dataplane-operator/blob/main/config/crd/bases/dataplane.openstack.org_openstackdataplanenodes.yaml)
 


### PR DESCRIPTION
The README.md pointed to not existing url.
The url using plural form, 's' at the end.