### PR TITLE
Added EDPM based Zuul jobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,6 @@ BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
 # BUNDLE_GEN_FLAGS are the flags passed to the operator-sdk generate bundle command
 BUNDLE_GEN_FLAGS ?= -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 
-VERIFY_TLS ?= true
-
 # USE_IMAGE_DIGESTS defines if images are resolved via tags or digests
 # You can enable this value if you would like to use SHA Based Digests
 # To enable set flag to true
@@ -130,7 +128,7 @@ docker-build: test ## Build docker image with the manager.
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
-	podman push --tls-verify=${VERIFY_TLS} ${IMG}
+	podman push ${IMG}
 
 # PLATFORMS defines the target platforms for  the manager image be build to provide support to multiple
 # architectures. (i.e. make docker-buildx IMG=myregistry/mypoperator:0.0.1). To use this option you need to:

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -1,0 +1,18 @@
+---
+- job:
+    name: dataplane-operator-content-provider
+    parent: content-provider-base
+    vars:
+      cifmw_operator_build_org: openstack-k8s-operators
+      cifmw_operator_build_operators:
+        - name: "dataplane-operator"
+          src: "{{ ansible_user_dir }}/src/github.com/{{ cifmw_operator_build_org }}/dataplane-operator"
+        - name: "openstack-operator"
+          src: "{{ ansible_user_dir }}/src/github.com/{{ cifmw_operator_build_org }}/openstack-operator"
+          image_base: dataplane
+
+- job:
+    name: dataplane-operator-crc-podified-edpm-deployment
+    parent: cifmw-crc-podified-edpm-deployment
+    vars:
+      bmo_setup: true

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -1,0 +1,9 @@
+---
+- project:
+    name: openstack-k8s-operators/dataplane-operator
+    github-check:
+      jobs:
+        - dataplane-operator-content-provider
+        - dataplane-operator-crc-podified-edpm-deployment:
+            dependencies:
+              - dataplane-operator-content-provider


### PR DESCRIPTION
    It adds following jobs which will run against dataplane operator.:

    - dataplane-operator-content-provider job which will build the operator
      and meta operator images and push it to local registry. The job will
      be paused to serve as a registry.
    - dataplane-operator-crc-podified-edpm-deployment is the child job which
      will pull the required meta operator images from content provider.
      The Zuul will pass the necessary vars to the child job.
    
    It also removes VERIFY_TLS flag from makefile as it is default
    to true in podman.
    
    Signed-off-by: Chandan Kumar (raukadah) <raukadah@gmail.com>


Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/312
Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/171