### PR TITLE
Revert "Drop explicit requeues for OpenStackAnsibleEE"

### DIFF
--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -19,6 +19,7 @@ package deployment
 import (
 	"context"
 	"fmt"
+	"time"
 
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -45,8 +46,7 @@ func Deploy(
 	aeeSpec dataplanev1beta1.AnsibleEESpec,
 ) (ctrl.Result, error) {
 
-	log := helper.GetLogger()
-
+	var result ctrl.Result
 	var err error
 	var readyCondition condition.Type
 	var readyMessage string
@@ -71,7 +71,7 @@ func Deploy(
 	deployFunc = ConfigureNetwork
 	deployName = "ConfigureNetwork"
 	deployLabel = ConfigureNetworkLabel
-	err = ConditionalDeploy(
+	result, err = ConditionalDeploy(
 		ctx,
 		helper,
 		obj,
@@ -87,11 +87,9 @@ func Deploy(
 		deployLabel,
 		aeeSpec,
 	)
-
-	if err != nil || !status.Conditions.IsTrue(readyCondition) {
-		return ctrl.Result{}, err
+	if err != nil || result.RequeueAfter > 0 {
+		return result, err
 	}
-	log.Info(fmt.Sprintf("Condition %s ready", readyCondition))
 
 	// ValidateNetwork
 	readyCondition = dataplanev1beta1.ValidateNetworkReadyCondition
@@ -101,7 +99,7 @@ func Deploy(
 	deployFunc = ValidateNetwork
 	deployName = "ValidateNetwork"
 	deployLabel = ValidateNetworkLabel
-	err = ConditionalDeploy(
+	result, err = ConditionalDeploy(
 		ctx,
 		helper,
 		obj,
@@ -117,11 +115,9 @@ func Deploy(
 		deployLabel,
 		aeeSpec,
 	)
-
-	if err != nil || !status.Conditions.IsTrue(readyCondition) {
-		return ctrl.Result{}, err
+	if err != nil || result.RequeueAfter > 0 {
+		return result, err
 	}
-	log.Info(fmt.Sprintf("Condition %s ready", readyCondition))
 
 	// InstallOS
 	readyCondition = dataplanev1beta1.InstallOSReadyCondition
@@ -131,7 +127,7 @@ func Deploy(
 	deployFunc = InstallOS
 	deployName = "InstallOS"
 	deployLabel = InstallOSLabel
-	err = ConditionalDeploy(
+	result, err = ConditionalDeploy(
 		ctx,
 		helper,
 		obj,
@@ -146,11 +142,9 @@ func Deploy(
 		deployName,
 		deployLabel,
 		aeeSpec)
-
-	if err != nil || !status.Conditions.IsTrue(readyCondition) {
-		return ctrl.Result{}, err
+	if err != nil || result.RequeueAfter > 0 {
+		return result, err
 	}
-	log.Info(fmt.Sprintf("Condition %s ready", readyCondition))
 
 	// ConfigureOS
 	readyCondition = dataplanev1beta1.ConfigureOSReadyCondition
@@ -160,7 +154,7 @@ func Deploy(
 	deployFunc = ConfigureOS
 	deployName = "ConfigureOS"
 	deployLabel = ConfigureOSLabel
-	err = ConditionalDeploy(
+	result, err = ConditionalDeploy(
 		ctx,
 		helper,
 		obj,
@@ -175,11 +169,9 @@ func Deploy(
 		deployName,
 		deployLabel,
 		aeeSpec)
-
-	if err != nil || !status.Conditions.IsTrue(readyCondition) {
-		return ctrl.Result{}, err
+	if err != nil || result.RequeueAfter > 0 {
+		return result, err
 	}
-	log.Info(fmt.Sprintf("Condition %s ready", readyCondition))
 
 	// RunOS
 	readyCondition = dataplanev1beta1.RunOSReadyCondition
@@ -189,7 +181,7 @@ func Deploy(
 	deployFunc = RunOS
 	deployName = "RunOS"
 	deployLabel = RunOSLabel
-	err = ConditionalDeploy(
+	result, err = ConditionalDeploy(
 		ctx,
 		helper,
 		obj,
@@ -204,11 +196,9 @@ func Deploy(
 		deployName,
 		deployLabel,
 		aeeSpec)
-
-	if err != nil || !status.Conditions.IsTrue(readyCondition) {
-		return ctrl.Result{}, err
+	if err != nil || result.RequeueAfter > 0 {
+		return result, err
 	}
-	log.Info(fmt.Sprintf("Condition %s ready", readyCondition))
 
 	// ConfigureCephClient
 	haveCephSecret := false
@@ -228,7 +218,7 @@ func Deploy(
 		deployFunc = ConfigureCephClient
 		deployName = "ConfigureCephClient"
 		deployLabel = ConfigureCephClientLabel
-		err = ConditionalDeploy(
+		result, err = ConditionalDeploy(
 			ctx,
 			helper,
 			obj,
@@ -244,11 +234,9 @@ func Deploy(
 			deployLabel,
 			aeeSpec,
 		)
-
-		if err != nil || !status.Conditions.IsTrue(readyCondition) {
-			return ctrl.Result{}, err
+		if err != nil || result.RequeueAfter > 0 {
+			return result, err
 		}
-		log.Info(fmt.Sprintf("Condition %s ready", readyCondition))
 	}
 
 	// InstallOpenStack
@@ -259,7 +247,7 @@ func Deploy(
 	deployFunc = InstallOpenStack
 	deployName = "InstallOpenStack"
 	deployLabel = InstallOpenStackLabel
-	err = ConditionalDeploy(
+	result, err = ConditionalDeploy(
 		ctx,
 		helper,
 		obj,
@@ -274,11 +262,9 @@ func Deploy(
 		deployName,
 		deployLabel,
 		aeeSpec)
-
-	if err != nil || !status.Conditions.IsTrue(readyCondition) {
-		return ctrl.Result{}, err
+	if err != nil || result.RequeueAfter > 0 {
+		return result, err
 	}
-	log.Info(fmt.Sprintf("Condition %s ready", readyCondition))
 
 	// ConfigureOpenStack
 	readyCondition = dataplanev1beta1.ConfigureOpenStackReadyCondition
@@ -288,7 +274,7 @@ func Deploy(
 	deployFunc = ConfigureOpenStack
 	deployName = "ConfigureOpenStack"
 	deployLabel = ConfigureOpenStackLabel
-	err = ConditionalDeploy(
+	result, err = ConditionalDeploy(
 		ctx,
 		helper,
 		obj,
@@ -303,11 +289,9 @@ func Deploy(
 		deployName,
 		deployLabel,
 		aeeSpec)
-
-	if err != nil || !status.Conditions.IsTrue(readyCondition) {
-		return ctrl.Result{}, err
+	if err != nil || result.RequeueAfter > 0 {
+		return result, err
 	}
-	log.Info(fmt.Sprintf("Condition %s ready", readyCondition))
 
 	// RunOpenStack
 	readyCondition = dataplanev1beta1.RunOpenStackReadyCondition
@@ -317,7 +301,7 @@ func Deploy(
 	deployFunc = RunOpenStack
 	deployName = "RunOpenStack"
 	deployLabel = RunOpenStackLabel
-	err = ConditionalDeploy(
+	result, err = ConditionalDeploy(
 		ctx,
 		helper,
 		obj,
@@ -332,11 +316,9 @@ func Deploy(
 		deployName,
 		deployLabel,
 		aeeSpec)
-
-	if err != nil || !status.Conditions.IsTrue(readyCondition) {
-		return ctrl.Result{}, err
+	if err != nil || result.RequeueAfter > 0 {
+		return result, err
 	}
-	log.Info(fmt.Sprintf("Condition %s ready", readyCondition))
 
 	return ctrl.Result{}, nil
 
@@ -359,7 +341,7 @@ func ConditionalDeploy(
 	deployName string,
 	deployLabel string,
 	aeeSpec dataplanev1beta1.AnsibleEESpec,
-) error {
+) (ctrl.Result, error) {
 
 	var err error
 	log := helper.GetLogger()
@@ -369,7 +351,7 @@ func ConditionalDeploy(
 		err = deployFunc(ctx, helper, obj, sshKeySecret, inventoryConfigMap, aeeSpec)
 		if err != nil {
 			util.LogErrorForObject(helper, err, fmt.Sprintf("Unable to %s for %s", deployName, obj.GetName()), obj)
-			return err
+			return ctrl.Result{}, err
 		}
 
 		status.Conditions.Set(condition.FalseCondition(
@@ -378,14 +360,14 @@ func ConditionalDeploy(
 			condition.SeverityInfo,
 			readyWaitingMessage))
 
-		log.Info(fmt.Sprintf("Condition %s unknown", readyCondition))
-		return nil
+		log.Info(fmt.Sprintf("%s not yet ready, requeueing", readyCondition))
+		return ctrl.Result{RequeueAfter: time.Second * 2}, nil
 
 	} else if status.Conditions.IsFalse(readyCondition) {
 		ansibleEEJob, err := dataplaneutil.GetAnsibleExecutionJob(ctx, helper, obj, deployLabel)
 		if err != nil && k8s_errors.IsNotFound(err) {
-			log.Info(fmt.Sprintf("%s OpenStackAnsibleEE Job not yet found", readyCondition))
-			return nil
+			log.Info(fmt.Sprintf("%s not yet ready, requeueing", readyCondition))
+			return ctrl.Result{RequeueAfter: time.Second * 2}, nil
 		} else if err != nil {
 			log.Error(err, fmt.Sprintf("Error getting ansibleEE job for %s", deployName))
 			status.Conditions.Set(condition.FalseCondition(
@@ -394,14 +376,14 @@ func ConditionalDeploy(
 				condition.SeverityWarning,
 				readyErrorMessage,
 				err.Error()))
-			return err
+			return ctrl.Result{}, err
 		} else if ansibleEEJob.Status.Succeeded > 0 {
-			log.Info(fmt.Sprintf("Condition %s ready", readyCondition))
+			log.Info(fmt.Sprintf("%s ready", readyCondition))
 			status.Conditions.Set(condition.TrueCondition(
 				readyCondition,
 				readyMessage))
 		} else if ansibleEEJob.Status.Failed > 0 {
-			log.Info(fmt.Sprintf("Condition %s error", readyCondition))
+			log.Info(fmt.Sprintf("%s error", readyCondition))
 			err = fmt.Errorf("failed: job.name %s job.namespace %s", ansibleEEJob.Name, ansibleEEJob.Namespace)
 			status.Conditions.Set(condition.FalseCondition(
 				readyCondition,
@@ -409,14 +391,16 @@ func ConditionalDeploy(
 				condition.SeverityError,
 				readyErrorMessage,
 				err.Error()))
-			return err
+			return ctrl.Result{}, err
 		} else {
-			log.Info(fmt.Sprintf("Condition %s not yet ready", readyCondition))
-			return nil
+			log.Info(fmt.Sprintf("%s not yet ready, requeueing", readyCondition))
+			return ctrl.Result{RequeueAfter: time.Second * 2}, nil
 		}
 
+	} else if status.Conditions.IsTrue(readyCondition) {
+		log.Info(fmt.Sprintf("%s already ready", readyCondition))
 	}
 
-	return err
+	return ctrl.Result{}, err
 
 }


### PR DESCRIPTION
This reverts commit 217c77a9b62c8dfa1f85295c57b227633644a726.

Commit had an unwanted side effect of NovaExternalCompute CRs being created before the roles from deployment.go completed their execution.

Closes: [OSP-24527](https://issues.redhat.com//browse/OSP-24527)