### PR TITLE
Replace TripleO images by TCIB images

### DIFF
--- a/config/samples/dataplane_v1beta1_openstackdataplane.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplane.yaml
@@ -115,12 +115,12 @@ spec:
           edpm_ovn_dbs:
           - 192.168.24.1
 
-          edpm_ovn_controller_agent_image: quay.io/tripleozedcentos9/openstack-ovn-controller:current-tripleo
-          edpm_iscsid_image: quay.io/tripleozedcentos9/openstack-iscsid:current-tripleo
-          edpm_logrotate_crond_image: quay.io/tripleozedcentos9/openstack-cron:current-tripleo
-          edpm_nova_compute_container_image: quay.io/tripleozedcentos9/openstack-nova-compute:current-tripleo
-          edpm_nova_libvirt_container_image: quay.io/tripleozedcentos9/openstack-nova-libvirt:current-tripleo
-          edpm_ovn_metadata_agent_image: quay.io/tripleozedcentos9/openstack-neutron-metadata-agent-ovn:current-tripleo
+          edpm_ovn_controller_agent_image: quay.io/podified-antelope-centos9/openstack-ovn-controller:current-podified
+          edpm_iscsid_image: quay.io/podified-antelope-centos9/openstack-iscsid:current-podified
+          edpm_logrotate_crond_image: quay.io/podified-antelope-centos9/openstack-cron:current-podified
+          edpm_nova_compute_container_image: quay.io/podified-antelope-centos9/openstack-nova-compute:current-podified
+          edpm_nova_libvirt_container_image: quay.io/podified-antelope-centos9/openstack-nova-libvirt:current-podified
+          edpm_ovn_metadata_agent_image: quay.io/podified-antelope-centos9/openstack-neutron-metadata-agent-ovn:current-podified
 
           gather_facts: false
           enable_debug: false

--- a/config/samples/dataplane_v1beta1_openstackdataplane_customnetworks.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplane_customnetworks.yaml
@@ -147,12 +147,12 @@ spec:
           edpm_ovn_dbs:
           - 192.168.24.1
 
-          edpm_ovn_controller_agent_image: quay.io/tripleozedcentos9/openstack-ovn-controller:current-tripleo
-          edpm_iscsid_image: quay.io/tripleozedcentos9/openstack-iscsid:current-tripleo
-          edpm_logrotate_crond_image: quay.io/tripleozedcentos9/openstack-cron:current-tripleo
-          edpm_nova_compute_container_image: quay.io/tripleozedcentos9/openstack-nova-compute:current-tripleo
-          edpm_nova_libvirt_container_image: quay.io/tripleozedcentos9/openstack-nova-libvirt:current-tripleo
-          edpm_ovn_metadata_agent_image: quay.io/tripleozedcentos9/openstack-neutron-metadata-agent-ovn:current-tripleo
+          edpm_ovn_controller_agent_image: quay.io/podified-antelope-centos9/openstack-ovn-controller:current-podified
+          edpm_iscsid_image: quay.io/podified-antelope-centos9/openstack-iscsid:current-podified
+          edpm_logrotate_crond_image: quay.io/podified-antelope-centos9/openstack-cron:current-podified
+          edpm_nova_compute_container_image: quay.io/podified-antelope-centos9/openstack-nova-compute:current-podified
+          edpm_nova_libvirt_container_image: quay.io/podified-antelope-centos9/openstack-nova-libvirt:current-podified
+          edpm_ovn_metadata_agent_image: quay.io/podified-antelope-centos9/openstack-neutron-metadata-agent-ovn:current-podified
 
           gather_facts: false
           enable_debug: false

--- a/config/samples/dataplane_v1beta1_openstackdataplanenode_edpm_compute_0_full.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenode_edpm_compute_0_full.yaml
@@ -24,8 +24,8 @@ spec:
         - clock.redhat.com
         - clock2.redhat.com
       registry_name: "quay.io"
-      registry_namespace: "tripleozedcentos9"
-      image_tag: "current-tripleo"
+      registry_namespace: "podified-antelope-centos9"
+      image_tag: "current-podified"
       edpm_ovn_controller_agent_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-ovn-controller:{{ image_tag }}"
       edpm_iscsid_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-iscsid:{{ image_tag }}"
       edpm_logrotate_crond_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-cron:{{ image_tag }}"

--- a/config/samples/dataplane_v1beta1_openstackdataplanerole_edpm_compute.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanerole_edpm_compute.yaml
@@ -22,8 +22,8 @@ spec:
         - clock.redhat.com
         - clock2.redhat.com
       registry_name: "quay.io"
-      registry_namespace: "tripleozedcentos9"
-      image_tag: "current-tripleo"
+      registry_namespace: "podified-antelope-centos9"
+      image_tag: "current-podified"
       edpm_ovn_controller_agent_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-ovn-controller:{{ image_tag }}"
       edpm_iscsid_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-iscsid:{{ image_tag }}"
       edpm_logrotate_crond_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-cron:{{ image_tag }}"

--- a/tests/kuttl/dataplane-create-test/00-assert.yaml
+++ b/tests/kuttl/dataplane-create-test/00-assert.yaml
@@ -100,12 +100,12 @@ spec:
       edpm_ovn_dbs:
       - 192.168.24.1
 
-      edpm_ovn_controller_agent_image: quay.io/tripleozedcentos9/openstack-ovn-controller:current-tripleo
-      edpm_iscsid_image: quay.io/tripleozedcentos9/openstack-iscsid:current-tripleo
-      edpm_logrotate_crond_image: quay.io/tripleozedcentos9/openstack-cron:current-tripleo
-      edpm_nova_compute_container_image: quay.io/tripleozedcentos9/openstack-nova-compute:current-tripleo
-      edpm_nova_libvirt_container_image: quay.io/tripleozedcentos9/openstack-nova-libvirt:current-tripleo
-      edpm_ovn_metadata_agent_image: quay.io/tripleozedcentos9/openstack-neutron-metadata-agent-ovn:current-tripleo
+      edpm_ovn_controller_agent_image: quay.io/podified-antelope-centos9/openstack-ovn-controller:current-podified
+      edpm_iscsid_image: quay.io/podified-antelope-centos9/openstack-iscsid:current-podified
+      edpm_logrotate_crond_image: quay.io/podified-antelope-centos9/openstack-cron:current-podified
+      edpm_nova_compute_container_image: quay.io/podified-antelope-centos9/openstack-nova-compute:current-podified
+      edpm_nova_libvirt_container_image: quay.io/podified-antelope-centos9/openstack-nova-libvirt:current-podified
+      edpm_ovn_metadata_agent_image: quay.io/podified-antelope-centos9/openstack-neutron-metadata-agent-ovn:current-podified
 
       gather_facts: false
       enable_debug: false
@@ -343,20 +343,20 @@ data:
                 - 172.17.0.86 rabbitmq-cell1.openstack.svc
             edpm_hosts_entries_undercloud_hosts_entries: []
             edpm_hosts_entries_vip_hosts_entries: []
-            edpm_iscsid_image: quay.io/tripleozedcentos9/openstack-iscsid:current-tripleo
-            edpm_logrotate_crond_image: quay.io/tripleozedcentos9/openstack-cron:current-tripleo
+            edpm_iscsid_image: quay.io/podified-antelope-centos9/openstack-iscsid:current-podified
+            edpm_logrotate_crond_image: quay.io/podified-antelope-centos9/openstack-cron:current-podified
             edpm_network_config_hide_sensitive_logs: false
             edpm_network_config_template: templates/single_nic_vlans/single_nic_vlans.j2
             edpm_nodes_validation_validate_controllers_icmp: false
             edpm_nodes_validation_validate_gateway_icmp: false
-            edpm_nova_compute_container_image: quay.io/tripleozedcentos9/openstack-nova-compute:current-tripleo
-            edpm_nova_libvirt_container_image: quay.io/tripleozedcentos9/openstack-nova-libvirt:current-tripleo
-            edpm_ovn_controller_agent_image: quay.io/tripleozedcentos9/openstack-ovn-controller:current-tripleo
+            edpm_nova_compute_container_image: quay.io/podified-antelope-centos9/openstack-nova-compute:current-podified
+            edpm_nova_libvirt_container_image: quay.io/podified-antelope-centos9/openstack-nova-libvirt:current-podified
+            edpm_ovn_controller_agent_image: quay.io/podified-antelope-centos9/openstack-ovn-controller:current-podified
             edpm_ovn_dbs:
                 - 192.168.24.1
             edpm_ovn_metadata_agent_default_bind_host: 127.0.0.1
             edpm_ovn_metadata_agent_default_transport_url: rabbit://default_user@rabbitmq.openstack.svc:5672
-            edpm_ovn_metadata_agent_image: quay.io/tripleozedcentos9/openstack-neutron-metadata-agent-ovn:current-tripleo
+            edpm_ovn_metadata_agent_image: quay.io/podified-antelope-centos9/openstack-neutron-metadata-agent-ovn:current-podified
             edpm_ovn_metadata_agent_metadata_agent_default_metadata_proxy_shared_secret: 12345678
             edpm_ovn_metadata_agent_metadata_agent_default_nova_metadata_host: 127.0.0.1
             edpm_ovn_metadata_agent_metadata_agent_ovn_ovn_sb_connection: tcp:10.217.5.121:6642
@@ -449,20 +449,20 @@ data:
                     - 172.17.0.86 rabbitmq-cell1.openstack.svc
                 edpm_hosts_entries_undercloud_hosts_entries: []
                 edpm_hosts_entries_vip_hosts_entries: []
-                edpm_iscsid_image: quay.io/tripleozedcentos9/openstack-iscsid:current-tripleo
-                edpm_logrotate_crond_image: quay.io/tripleozedcentos9/openstack-cron:current-tripleo
+                edpm_iscsid_image: quay.io/podified-antelope-centos9/openstack-iscsid:current-podified
+                edpm_logrotate_crond_image: quay.io/podified-antelope-centos9/openstack-cron:current-podified
                 edpm_network_config_hide_sensitive_logs: false
                 edpm_network_config_template: templates/single_nic_vlans/single_nic_vlans.j2
                 edpm_nodes_validation_validate_controllers_icmp: false
                 edpm_nodes_validation_validate_gateway_icmp: false
-                edpm_nova_compute_container_image: quay.io/tripleozedcentos9/openstack-nova-compute:current-tripleo
-                edpm_nova_libvirt_container_image: quay.io/tripleozedcentos9/openstack-nova-libvirt:current-tripleo
-                edpm_ovn_controller_agent_image: quay.io/tripleozedcentos9/openstack-ovn-controller:current-tripleo
+                edpm_nova_compute_container_image: quay.io/podified-antelope-centos9/openstack-nova-compute:current-podified
+                edpm_nova_libvirt_container_image: quay.io/podified-antelope-centos9/openstack-nova-libvirt:current-podified
+                edpm_ovn_controller_agent_image: quay.io/podified-antelope-centos9/openstack-ovn-controller:current-podified
                 edpm_ovn_dbs:
                     - 192.168.24.1
                 edpm_ovn_metadata_agent_default_bind_host: 127.0.0.1
                 edpm_ovn_metadata_agent_default_transport_url: rabbit://default_user@rabbitmq.openstack.svc:5672
-                edpm_ovn_metadata_agent_image: quay.io/tripleozedcentos9/openstack-neutron-metadata-agent-ovn:current-tripleo
+                edpm_ovn_metadata_agent_image: quay.io/podified-antelope-centos9/openstack-neutron-metadata-agent-ovn:current-podified
                 edpm_ovn_metadata_agent_metadata_agent_default_metadata_proxy_shared_secret: 12345678
                 edpm_ovn_metadata_agent_metadata_agent_default_nova_metadata_host: 127.0.0.1
                 edpm_ovn_metadata_agent_metadata_agent_ovn_ovn_sb_connection: tcp:10.217.5.121:6642
@@ -546,20 +546,20 @@ data:
                     - 172.17.0.86 rabbitmq-cell1.openstack.svc
                 edpm_hosts_entries_undercloud_hosts_entries: []
                 edpm_hosts_entries_vip_hosts_entries: []
-                edpm_iscsid_image: quay.io/tripleozedcentos9/openstack-iscsid:current-tripleo
-                edpm_logrotate_crond_image: quay.io/tripleozedcentos9/openstack-cron:current-tripleo
+                edpm_iscsid_image: quay.io/podified-antelope-centos9/openstack-iscsid:current-podified
+                edpm_logrotate_crond_image: quay.io/podified-antelope-centos9/openstack-cron:current-podified
                 edpm_network_config_hide_sensitive_logs: false
                 edpm_network_config_template: templates/single_nic_vlans/single_nic_vlans.j2
                 edpm_nodes_validation_validate_controllers_icmp: false
                 edpm_nodes_validation_validate_gateway_icmp: false
-                edpm_nova_compute_container_image: quay.io/tripleozedcentos9/openstack-nova-compute:current-tripleo
-                edpm_nova_libvirt_container_image: quay.io/tripleozedcentos9/openstack-nova-libvirt:current-tripleo
-                edpm_ovn_controller_agent_image: quay.io/tripleozedcentos9/openstack-ovn-controller:current-tripleo
+                edpm_nova_compute_container_image: quay.io/podified-antelope-centos9/openstack-nova-compute:current-podified
+                edpm_nova_libvirt_container_image: quay.io/podified-antelope-centos9/openstack-nova-libvirt:current-podified
+                edpm_ovn_controller_agent_image: quay.io/podified-antelope-centos9/openstack-ovn-controller:current-podified
                 edpm_ovn_dbs:
                     - 192.168.24.1
                 edpm_ovn_metadata_agent_default_bind_host: 127.0.0.1
                 edpm_ovn_metadata_agent_default_transport_url: rabbit://default_user@rabbitmq.openstack.svc:5672
-                edpm_ovn_metadata_agent_image: quay.io/tripleozedcentos9/openstack-neutron-metadata-agent-ovn:current-tripleo
+                edpm_ovn_metadata_agent_image: quay.io/podified-antelope-centos9/openstack-neutron-metadata-agent-ovn:current-podified
                 edpm_ovn_metadata_agent_metadata_agent_default_metadata_proxy_shared_secret: 12345678
                 edpm_ovn_metadata_agent_metadata_agent_default_nova_metadata_host: 127.0.0.1
                 edpm_ovn_metadata_agent_metadata_agent_ovn_ovn_sb_connection: tcp:10.217.5.121:6642


### PR DESCRIPTION
We imported container build tools from TripleO as TCIB[1]. Now we are retiring TripleO and should complete the migration.

Note that the openstack-tripleoclient container was replaced by the openstack-openstackclient container during migration to TCIB.

[1] https://github.com/openstack-k8s-operators/tcib