### PR TITLE
Fix 00-dataplane-create.yaml symlink

### DIFF
--- a/tests/kuttl/tests/dataplane-create-test/00-dataplane-create.yaml
+++ b/tests/kuttl/tests/dataplane-create-test/00-dataplane-create.yaml
@@ -1,1 +1,1 @@
-../../../config/samples/dataplane_v1beta1_openstackdataplane.yaml
+../../../../config/samples/dataplane_v1beta1_openstackdataplane.yaml


### PR DESCRIPTION
Symlink needs to be updated to account for the kuttl tests dir move in
commit 904d94060e1f7a44b85931dea85a3aa614583ec8.

Signed-off-by: James Slagle <jslagle@redhat.com>
