### PR TITLE
Selective BaremetalSetTemplate

### DIFF
--- a/controllers/openstackdataplane_controller.go
+++ b/controllers/openstackdataplane_controller.go
@@ -362,10 +362,10 @@ func createOrPatchDataPlaneRoles(ctx context.Context,
 			role.Spec.OpenStackAnsibleEERunnerImage = roleSpec.OpenStackAnsibleEERunnerImage
 			role.Spec.Env = roleSpec.Env
 			role.Spec.Services = roleSpec.Services
-			role.Spec.BaremetalSetTemplate = roleSpec.BaremetalSetTemplate
 			hostMap, ok := roleManagedHostMap[roleName]
 			if ok {
 				role.Spec.BaremetalSetTemplate.BaremetalHosts = hostMap
+				role.Spec.BaremetalSetTemplate = roleSpec.BaremetalSetTemplate
 			}
 			err := controllerutil.SetControllerReference(instance, role, helper.GetScheme())
 			if err != nil {


### PR DESCRIPTION
Only copy `roleSpec.BaremetalSetTemplate` if we have BaremetalHosts. This change moves the `role.Spec.BaremetalSetTemplate` to ensure it's only copied when baremetal nodes exist. Else we need to define the required paramaters of this Spec during deployment.

Since it can be ommitted in the DataplaneNodeSpec [1], we should respect that in the Controller code and not set it unless we expect to have baremetal managed nodes included in the deployment [2].

1: https://github.com/openstack-k8s-operators/dataplane-operator/blob/main/api/v1beta1/openstackdataplanerole_types.go#L40
2: https://github.com/openstack-k8s-operators/dataplane-operator/blob/main/controllers/openstackdataplane_controller.go#L250