### PR TITLE
Set preProvosioned: true in sample

### DIFF
--- a/config/samples/dataplane_v1beta1_openstackdataplane.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplane.yaml
@@ -53,8 +53,8 @@ spec:
         ctlplaneNetmask: 255.255.255.0
         bmhNamespace: openstack
         domainName: osptest.openstack.org
+      preProvisioned: true
       nodeTemplate:
-        managed: false
         managementNetwork: ctlplane
         ansibleUser: root
         ansiblePort: 22


### PR DESCRIPTION
The kuttl tests uses the sample datalane. Set the preProvosioned flag to
true in the sample so that the tests don't require baremetal
provisioning.

Signed-off-by: James Slagle <jslagle@redhat.com>
