### PR TITLE
Enable service play

### DIFF
--- a/api/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
@@ -29,6 +29,8 @@ spec:
             properties:
               label:
                 type: string
+              play:
+                type: string
               role:
                 properties:
                   any_errors_fatal:

--- a/api/v1beta1/openstackdataplaneservice_types.go
+++ b/api/v1beta1/openstackdataplaneservice_types.go
@@ -29,6 +29,10 @@ type OpenStackDataPlaneServiceSpec struct {
 	// +kubebuilder:validation:Optional
 	Label string `json:"label,omitempty"`
 
+	// Play is the playbook contents that ansible will run on execution.
+	// If both Play and Role are specified, Play takes precedence
+	Play string `json:"play,omitempty"`
+
 	// Role is the description of an Ansible Role
 	// +kubebuilder:validation:Optional
 	Role *ansibleeev1alpha1.Role `json:"role,omitempty"`

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
@@ -29,6 +29,8 @@ spec:
             properties:
               label:
                 type: string
+              play:
+                type: string
               role:
                 properties:
                   any_errors_fatal:

--- a/config/manifests/bases/dataplane-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/dataplane-operator.clusterserviceversion.yaml
@@ -33,12 +33,6 @@ spec:
         path: node.ansibleSSHPrivateKeySecret
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes:Secret
-      - description: Managed - Whether the node is actually provisioned (True) or
-          should be treated as preprovisioned (False)
-        displayName: Managed
-        path: node.managed
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       statusDescriptors:
       - description: Conditions
         displayName: Conditions
@@ -74,10 +68,10 @@ spec:
         path: nodeTemplate.ansibleSSHPrivateKeySecret
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes:Secret
-      - description: Managed - Whether the node is actually provisioned (True) or
-          should be treated as preprovisioned (False)
-        displayName: Managed
-        path: nodeTemplate.managed
+      - description: PreProvisioned - Whether the nodes are actually pre-provisioned
+          (True) or should be preprovisioned (False)
+        displayName: Pre Provisioned
+        path: preProvisioned
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       statusDescriptors:
@@ -119,12 +113,6 @@ spec:
         path: nodes.node.ansibleSSHPrivateKeySecret
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes:Secret
-      - description: Managed - Whether the node is actually provisioned (True) or
-          should be treated as preprovisioned (False)
-        displayName: Managed
-        path: nodes.node.managed
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Deploy boolean to trigger ansible execution
         displayName: Deploy
         path: roles.deployStrategy.deploy
@@ -142,10 +130,10 @@ spec:
         path: roles.nodeTemplate.ansibleSSHPrivateKeySecret
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes:Secret
-      - description: Managed - Whether the node is actually provisioned (True) or
-          should be treated as preprovisioned (False)
-        displayName: Managed
-        path: roles.nodeTemplate.managed
+      - description: PreProvisioned - Whether the nodes are actually pre-provisioned
+          (True) or should be preprovisioned (False)
+        displayName: Pre Provisioned
+        path: roles.preProvisioned
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       statusDescriptors:
@@ -159,6 +147,18 @@ spec:
         path: deployed
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      version: v1beta1
+    - description: OpenStackDataPlaneService is the Schema for the openstackdataplaneservices
+        API
+      displayName: Open Stack Data Plane Service
+      kind: OpenStackDataPlaneService
+      name: openstackdataplaneservices.dataplane.openstack.org
+      statusDescriptors:
+      - description: Conditions
+        displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
       version: v1beta1
   description: The OpenStack DataPlane Operator
   displayName: OpenStack DataPlane Operator

--- a/pkg/deployment/service.go
+++ b/pkg/deployment/service.go
@@ -30,7 +30,7 @@ import (
 
 // DeployService service deployment
 func DeployService(ctx context.Context, helper *helper.Helper, obj client.Object, sshKeySecret string, inventoryConfigMap string, aeeSpec dataplanev1beta1.AnsibleEESpec, foundService dataplanev1beta1.OpenStackDataPlaneService) error {
-	err := dataplaneutil.AnsibleExecution(ctx, helper, obj, foundService.Spec.Label, sshKeySecret, inventoryConfigMap, "", *foundService.Spec.Role, aeeSpec)
+	err := dataplaneutil.AnsibleExecution(ctx, helper, obj, foundService.Spec.Label, sshKeySecret, inventoryConfigMap, foundService.Spec.Play, *foundService.Spec.Role, aeeSpec)
 	if err != nil {
 		helper.GetLogger().Error(err, fmt.Sprintf("Unable to execute Ansible for %s", foundService.Name))
 		return err

--- a/pkg/util/ansible_execution.go
+++ b/pkg/util/ansible_execution.go
@@ -86,7 +86,9 @@ func AnsibleExecution(
 			ansibleEE.Spec.CmdLine = strings.TrimSpace(cmdLineArguments.String())
 		}
 
-		// TODO(slagle): Handle either play or role being specified
+		if len(play) > 0 {
+			ansibleEE.Spec.Play = play
+		}
 		ansibleEE.Spec.Role = &role
 
 		ansibleEEMounts := storage.VolMounts{}


### PR DESCRIPTION
I'm working on https://github.com/openstack-k8s-operators/install_yamls/pull/277
and it would be interesting to have a service for installing tripleo repos instead of calling `make edpm_compute_repos` N times