### PR TITLE
[envtest]Enhance test make target

### DIFF
--- a/tests/functional/suite_test.go
+++ b/tests/functional/suite_test.go
@@ -127,6 +127,10 @@ var _ = BeforeSuite(func() {
 	// Start the controller-manager if goroutine
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme.Scheme,
+		// NOTE(gibi): disable metrics reporting in test to allow
+		// parallel test execution. Otherwise each instance would like to
+		// bind to the same port
+		MetricsBindAddress: "0",
 	})
 	Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
I switched to ginkgo cli to execute the env test. This allows better configurability of the execution. To still run the existing unit test there is a separate go test call and a ginkgo call in make test target.

Added GINKGO_ARGS so that we can pass parameters to the test runner, e.g.
```
  make test GINKGO_ARGS="-v --focus 'Should have created a OpenStackDataplaneRole'"
```
will run a single test case with verbose logging.

Also added parallel test execution and for that disabled the metrics service as that wants to bind to the same port (8080) from each parallel tests.