### PR TITLE
Use '~' instead of ansible_user_dir

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -5,11 +5,8 @@
     vars:
       cifmw_operator_build_org: openstack-k8s-operators
       cifmw_operator_build_operators:
-        - name: "dataplane-operator"
-          src: "{{ ansible_user_dir }}/src/github.com/{{ cifmw_operator_build_org }}/dataplane-operator"
         - name: "openstack-operator"
-          src: "{{ ansible_user_dir }}/src/github.com/{{ cifmw_operator_build_org }}/openstack-operator"
-          image_base: dataplane
+          src: "~/src/github.com/{{ cifmw_operator_build_org }}/openstack-operator"
 
 - job:
     name: dataplane-operator-crc-podified-edpm-deployment


### PR DESCRIPTION
The user on content_provider is different from edpm zuul job. When edpm zuul job receives data from content provider. The operator data git_src looks for zuul user on edpm job which does not exists. The user on edpm job is zuul-worker.

Using `~` instead of ansible_user_dir fixes the issue.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/211