### PR TITLE
fix tenant net ips for bmaas

### DIFF
--- a/config/samples/dataplane_v1beta1_openstackdataplane.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplane.yaml
@@ -15,7 +15,7 @@ spec:
           ctlplane_ip: 192.168.122.100
           internal_api_ip: 172.17.0.100
           storage_ip: 172.18.0.100
-          tenant_ip: 172.10.0.100
+          tenant_ip: 172.19.0.100
           fqdn_internal_api: edpm-compute-0.example.com
         ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
       deployStrategy:
@@ -29,7 +29,7 @@ spec:
           ctlplane_ip: 192.168.122.101
           internal_api_ip: 172.17.0.101
           storage_ip: 172.18.0.101
-          tenant_ip: 172.10.0.101
+          tenant_ip: 172.19.0.101
           fqdn_internal_api: edpm-compute-1.example.com
         ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
       deployStrategy:

--- a/config/samples/dataplane_v1beta1_openstackdataplane_customnetworks.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplane_customnetworks.yaml
@@ -15,7 +15,7 @@ spec:
           ctlplane_ip: 192.168.1.5
           internal_api_ip: 172.17.0.101
           storage_ip: 172.18.0.101
-          tenant_ip: 172.10.0.101
+          tenant_ip: 172.19.0.101
           external_ip: 172.20.12.76
           fqdn_internal_api: edpm-compute-1.example.com
           ansible_ssh_transfer_method: scp
@@ -85,7 +85,7 @@ spec:
                 vlan_id: 22
                 addresses:
                 - ip_netmask:
-                    172.10.0.101/24
+                    172.19.0.101/24
                 routes: []
         ansibleVars: |
           # edpm_network_config

--- a/tests/kuttl/tests/dataplane-create-test/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-create-test/00-assert.yaml
@@ -215,7 +215,7 @@ spec:
       ctlplane_ip: 192.168.122.100
       internal_api_ip: 172.17.0.100
       storage_ip: 172.18.0.100
-      tenant_ip: 172.10.0.100
+      tenant_ip: 172.19.0.100
       fqdn_internal_api: edpm-compute-0.example.com
     networkConfig: {}
   openStackAnsibleEERunnerImage: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
@@ -289,7 +289,7 @@ spec:
       ctlplane_ip: 192.168.122.101
       internal_api_ip: 172.17.0.101
       storage_ip: 172.18.0.101
-      tenant_ip: 172.10.0.101
+      tenant_ip: 172.19.0.101
       fqdn_internal_api: edpm-compute-1.example.com
     networkConfig: {}
   openStackAnsibleEERunnerImage: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
@@ -432,14 +432,14 @@ data:
                 fqdn_internal_api: edpm-compute-0.example.com
                 internal_api_ip: 172.17.0.100
                 storage_ip: 172.18.0.100
-                tenant_ip: 172.10.0.100
+                tenant_ip: 172.19.0.100
             edpm-compute-1:
                 ansible_host: 192.168.122.101
                 ctlplane_ip: 192.168.122.101
                 fqdn_internal_api: edpm-compute-1.example.com
                 internal_api_ip: 172.17.0.101
                 storage_ip: 172.18.0.101
-                tenant_ip: 172.10.0.101
+                tenant_ip: 172.19.0.101
   network: ""
 ---
 apiVersion: v1
@@ -533,7 +533,7 @@ data:
                 storage_vlan_id: 21
                 tenant_cidr: "24"
                 tenant_host_routes: []
-                tenant_ip: 172.10.0.100
+                tenant_ip: 172.19.0.100
                 tenant_mtu: 1500
                 tenant_vlan_id: 22
   network: ""
@@ -629,7 +629,7 @@ data:
                 storage_vlan_id: 21
                 tenant_cidr: "24"
                 tenant_host_routes: []
-                tenant_ip: 172.10.0.101
+                tenant_ip: 172.19.0.101
                 tenant_mtu: 1500
                 tenant_vlan_id: 22
   network: ""


### PR DESCRIPTION
in [1] the tenant IPs were synced for edpm and ctlplane, also change it here.

[1] https://github.com/openstack-k8s-operators/install_yamls/pull/227