### PR TITLE
Move OpenStackAnsibleEEImage field to OpenStackDataPlaneService

### DIFF
--- a/api/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
@@ -936,9 +936,6 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                 type: object
-              openStackAnsibleEERunnerImage:
-                default: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
-                type: string
               role:
                 type: string
             type: object

--- a/api/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
@@ -1087,9 +1087,6 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                 type: object
-              openStackAnsibleEERunnerImage:
-                default: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
-                type: string
               preProvisioned:
                 type: boolean
             type: object

--- a/api/bases/dataplane.openstack.org_openstackdataplanes.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplanes.yaml
@@ -955,9 +955,6 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                       type: object
-                    openStackAnsibleEERunnerImage:
-                      default: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
-                      type: string
                     role:
                       type: string
                   type: object
@@ -2013,9 +2010,6 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                       type: object
-                    openStackAnsibleEERunnerImage:
-                      default: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
-                      type: string
                     preProvisioned:
                       type: boolean
                   type: object

--- a/api/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
@@ -32,6 +32,9 @@ spec:
             properties:
               label:
                 type: string
+              openStackAnsibleEERunnerImage:
+                default: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
+                type: string
               play:
                 type: string
               role:

--- a/api/v1beta1/common.go
+++ b/api/v1beta1/common.go
@@ -131,7 +131,7 @@ type NetworksSection struct {
 }
 
 // UniqueSpecFields - the array of fields that must be unique between role and nodes
-var UniqueSpecFields = []string{"OpenStackAnsibleEERunnerImage", "NetworkAttachments"}
+var UniqueSpecFields = []string{"NetworkAttachments"}
 
 // AssertUniquenessBetween - compare specs for uniqueness
 func AssertUniquenessBetween(spec interface{}, otherSpec interface{}, suffix string) []string {

--- a/api/v1beta1/openstackdataplanenode_types.go
+++ b/api/v1beta1/openstackdataplanenode_types.go
@@ -54,11 +54,6 @@ type OpenStackDataPlaneNodeSpec struct {
 	// NetworkAttachments is a list of NetworkAttachment resource names to pass to the ansibleee resource
 	// which allows to connect the ansibleee runner to the given network
 	NetworkAttachments []string `json:"networkAttachments"`
-
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest"
-	// OpenStackAnsibleEERunnerImage image to use as the ansibleEE runner image
-	OpenStackAnsibleEERunnerImage string `json:"openStackAnsibleEERunnerImage"`
 }
 
 //+kubebuilder:object:root=true
@@ -177,11 +172,6 @@ func (instance OpenStackDataPlaneNode) GetAnsibleEESpec(role OpenStackDataPlaneR
 		aee.Env = instance.Spec.Env
 	} else {
 		aee.Env = role.Spec.Env
-	}
-	if len(instance.Spec.OpenStackAnsibleEERunnerImage) > 0 {
-		aee.OpenStackAnsibleEERunnerImage = instance.Spec.OpenStackAnsibleEERunnerImage
-	} else {
-		aee.OpenStackAnsibleEERunnerImage = role.Spec.OpenStackAnsibleEERunnerImage
 	}
 	return aee
 }

--- a/api/v1beta1/openstackdataplanerole_types.go
+++ b/api/v1beta1/openstackdataplanerole_types.go
@@ -61,11 +61,6 @@ type OpenStackDataPlaneRoleSpec struct {
 	// NetworkAttachments is a list of NetworkAttachment resource names to pass to the ansibleee resource
 	// which allows to connect the ansibleee runner to the given network
 	NetworkAttachments []string `json:"networkAttachments"`
-
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest"
-	// OpenStackAnsibleEERunnerImage image to use as the ansibleEE runner image
-	OpenStackAnsibleEERunnerImage string `json:"openStackAnsibleEERunnerImage"`
 }
 
 //+kubebuilder:object:root=true
@@ -181,12 +176,11 @@ func (instance OpenStackDataPlaneRole) Validate(nodes []OpenStackDataPlaneNode) 
 // GetAnsibleEESpec - get the fields that will be passed to AEE
 func (instance OpenStackDataPlaneRole) GetAnsibleEESpec() AnsibleEESpec {
 	return AnsibleEESpec{
-		NetworkAttachments:            instance.Spec.NetworkAttachments,
-		OpenStackAnsibleEERunnerImage: instance.Spec.OpenStackAnsibleEERunnerImage,
-		AnsibleTags:                   instance.Spec.DeployStrategy.AnsibleTags,
-		AnsibleLimit:                  instance.Spec.DeployStrategy.AnsibleLimit,
-		AnsibleSkipTags:               instance.Spec.DeployStrategy.AnsibleSkipTags,
-		ExtraMounts:                   instance.Spec.NodeTemplate.ExtraMounts,
-		Env:                           instance.Spec.Env,
+		NetworkAttachments: instance.Spec.NetworkAttachments,
+		AnsibleTags:        instance.Spec.DeployStrategy.AnsibleTags,
+		AnsibleLimit:       instance.Spec.DeployStrategy.AnsibleLimit,
+		AnsibleSkipTags:    instance.Spec.DeployStrategy.AnsibleSkipTags,
+		ExtraMounts:        instance.Spec.NodeTemplate.ExtraMounts,
+		Env:                instance.Spec.Env,
 	}
 }

--- a/api/v1beta1/openstackdataplaneservice_types.go
+++ b/api/v1beta1/openstackdataplaneservice_types.go
@@ -36,6 +36,11 @@ type OpenStackDataPlaneServiceSpec struct {
 	// Role is the description of an Ansible Role
 	// +kubebuilder:validation:Optional
 	Role *ansibleeev1alpha1.Role `json:"role,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default="quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest"
+	// OpenStackAnsibleEERunnerImage image to use as the ansibleEE runner image
+	OpenStackAnsibleEERunnerImage string `json:"openStackAnsibleEERunnerImage"`
 }
 
 // OpenStackDataPlaneServiceStatus defines the observed state of OpenStackDataPlaneService

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
@@ -936,9 +936,6 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                 type: object
-              openStackAnsibleEERunnerImage:
-                default: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
-                type: string
               role:
                 type: string
             type: object

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
@@ -1087,9 +1087,6 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                 type: object
-              openStackAnsibleEERunnerImage:
-                default: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
-                type: string
               preProvisioned:
                 type: boolean
             type: object

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanes.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanes.yaml
@@ -955,9 +955,6 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                       type: object
-                    openStackAnsibleEERunnerImage:
-                      default: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
-                      type: string
                     role:
                       type: string
                   type: object
@@ -2013,9 +2010,6 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                       type: object
-                    openStackAnsibleEERunnerImage:
-                      default: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
-                      type: string
                     preProvisioned:
                       type: boolean
                   type: object

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
@@ -32,6 +32,9 @@ spec:
             properties:
               label:
                 type: string
+              openStackAnsibleEERunnerImage:
+                default: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
+                type: string
               play:
                 type: string
               role:

--- a/controllers/openstackdataplane_controller.go
+++ b/controllers/openstackdataplane_controller.go
@@ -123,6 +123,9 @@ func (r *OpenStackDataPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 		instance.Status.Conditions.MarkFalse(dataplanev1beta1.SetupReadyCondition, condition.RequestedReason, condition.SeverityInfo, condition.ReadyInitMessage)
 	}
 
+	// all setup tasks complete, mark SetupReadyCondition True
+	instance.Status.Conditions.MarkTrue(dataplanev1beta1.SetupReadyCondition, condition.ReadyMessage)
+
 	ctrlResult, err := createOrPatchDataPlaneResources(ctx, instance, helper)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -231,8 +234,6 @@ func (r *OpenStackDataPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 		r.Log.Info("Set DeploymentReadyCondition false")
 		instance.Status.Conditions.Set(condition.FalseCondition(condition.DeploymentReadyCondition, condition.NotRequestedReason, condition.SeverityInfo, condition.DeploymentReadyInitMessage))
 	}
-
-	instance.Status.Conditions.MarkTrue(dataplanev1beta1.SetupReadyCondition, condition.ReadyMessage)
 
 	return ctrl.Result{}, nil
 }
@@ -364,7 +365,6 @@ func createOrPatchDataPlaneRoles(ctx context.Context,
 			role.Spec.DataPlane = instance.Name
 			role.Spec.NodeTemplate = roleSpec.NodeTemplate
 			role.Spec.NetworkAttachments = roleSpec.NetworkAttachments
-			role.Spec.OpenStackAnsibleEERunnerImage = roleSpec.OpenStackAnsibleEERunnerImage
 			role.Spec.Env = roleSpec.Env
 			role.Spec.NodeTemplate.Services = roleSpec.NodeTemplate.Services
 			hostMap, ok := roleManagedHostMap[roleName]

--- a/controllers/openstackdataplanenode_controller.go
+++ b/controllers/openstackdataplanenode_controller.go
@@ -197,6 +197,9 @@ func (r *OpenStackDataPlaneNodeReconciler) Reconcile(ctx context.Context, req ct
 		return ctrl.Result{}, err
 	}
 
+	// all setup tasks complete, mark SetupReadyCondition True
+	instance.Status.Conditions.MarkTrue(dataplanev1beta1.SetupReadyCondition, condition.ReadyMessage)
+
 	r.Log.Info("Node", "DeployStrategy", instance.Spec.DeployStrategy.Deploy, "Node.Namespace", instance.Namespace, "Node.Name", instance.Name)
 	if instance.Spec.DeployStrategy.Deploy {
 		r.Log.Info("Starting DataPlaneNode deploy")
@@ -240,8 +243,6 @@ func (r *OpenStackDataPlaneNodeReconciler) Reconcile(ctx context.Context, req ct
 		r.Log.Info("Set DeploymentReadyCondition false")
 		instance.Status.Conditions.Set(condition.FalseCondition(condition.DeploymentReadyCondition, condition.NotRequestedReason, condition.SeverityInfo, condition.DeploymentReadyInitMessage))
 	}
-
-	instance.Status.Conditions.MarkTrue(dataplanev1beta1.SetupReadyCondition, condition.ReadyMessage)
 
 	return result, nil
 }

--- a/controllers/openstackdataplanerole_controller.go
+++ b/controllers/openstackdataplanerole_controller.go
@@ -207,6 +207,9 @@ func (r *OpenStackDataPlaneRoleReconciler) Reconcile(ctx context.Context, req ct
 		return result, err
 	}
 
+	// all setup tasks complete, mark SetupReadyCondition True
+	instance.Status.Conditions.MarkTrue(dataplanev1beta1.SetupReadyCondition, condition.ReadyMessage)
+
 	r.Log.Info("Role", "DeployStrategy", instance.Spec.DeployStrategy.Deploy, "Role.Namespace", instance.Namespace, "Role.Name", instance.Name)
 	if instance.Spec.DeployStrategy.Deploy {
 		r.Log.Info("Starting DataPlaneRole deploy")
@@ -261,8 +264,6 @@ func (r *OpenStackDataPlaneRoleReconciler) Reconcile(ctx context.Context, req ct
 		r.Log.Info("Set DeploymentReadyCondition false")
 		instance.Status.Conditions.Set(condition.FalseCondition(condition.DeploymentReadyCondition, condition.NotRequestedReason, condition.SeverityInfo, condition.DeploymentReadyInitMessage))
 	}
-
-	instance.Status.Conditions.MarkTrue(dataplanev1beta1.SetupReadyCondition, condition.ReadyMessage)
 
 	return ctrl.Result{}, nil
 }

--- a/docs/openstack_dataplanenode.md
+++ b/docs/openstack_dataplanenode.md
@@ -134,6 +134,5 @@ OpenStackDataPlaneNodeSpec defines the desired state of OpenStackDataPlaneNode
 | env | Env is a list containing the environment variables to pass to the pod | []corev1.EnvVar | false |
 | deployStrategy | DeployStrategy section to control how the node is deployed | [DeployStrategySection](#deploystrategysection) | false |
 | networkAttachments | NetworkAttachments is a list of NetworkAttachment resource names to pass to the ansibleee resource which allows to connect the ansibleee runner to the given network | []string | true |
-| openStackAnsibleEERunnerImage | OpenStackAnsibleEERunnerImage image to use as the ansibleEE runner image | string | true |
 
 [Back to Custom Resources](#custom-resources)

--- a/docs/openstack_dataplanerole.md
+++ b/docs/openstack_dataplanerole.md
@@ -134,6 +134,5 @@ OpenStackDataPlaneRoleSpec defines the desired state of OpenStackDataPlaneRole
 | env | Env is a list containing the environment variables to pass to the pod | []corev1.EnvVar | false |
 | deployStrategy | DeployStrategy section to control how the node is deployed | [DeployStrategySection](#deploystrategysection) | false |
 | networkAttachments | NetworkAttachments is a list of NetworkAttachment resource names to pass to the ansibleee resource which allows to connect the ansibleee runner to the given network | []string | true |
-| openStackAnsibleEERunnerImage | OpenStackAnsibleEERunnerImage image to use as the ansibleEE runner image | string | true |
 
 [Back to Custom Resources](#custom-resources)

--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -76,6 +76,7 @@ func Deploy(
 		readyWaitingMessage = fmt.Sprintf(dataplanev1beta1.ServiceReadyWaitingMessage, deployName)
 		readyMessage = fmt.Sprintf(dataplanev1beta1.ServiceReadyMessage, deployName)
 		readyErrorMessage = dataplanev1beta1.ServiceErrorMessage
+		aeeSpec.OpenStackAnsibleEERunnerImage = foundService.Spec.OpenStackAnsibleEERunnerImage
 		err = ConditionalDeploy(
 			ctx,
 			helper,

--- a/tests/kuttl/tests/dataplane-create-test/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-create-test/00-assert.yaml
@@ -141,7 +141,6 @@ spec:
       hosts_entry: []
     managementNetwork: ctlplane
     networkConfig: {}
-  openStackAnsibleEERunnerImage: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
 status:
   conditions:
   - message: Deployment not started
@@ -210,7 +209,6 @@ spec:
       tenant_ip: 172.19.0.100
       fqdn_internal_api: edpm-compute-0.example.com
     networkConfig: {}
-  openStackAnsibleEERunnerImage: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
   role: edpm-compute
 status:
   conditions:
@@ -276,7 +274,6 @@ spec:
       tenant_ip: 172.19.0.101
       fqdn_internal_api: edpm-compute-1.example.com
     networkConfig: {}
-  openStackAnsibleEERunnerImage: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
   role: edpm-compute
 status:
   conditions:

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/00-assert.yaml
@@ -9,7 +9,14 @@ spec:
     deploy: false
   roles:
     edpm-compute-no-nodes:
-      openStackAnsibleEERunnerImage: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
+      nodeTemplate:
+        ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
+        services:
+          - configure-network
+          - validate-network
+          - install-os
+          - configure-os
+          - run-os
 status:
   conditions:
   - message: Deployment not started

--- a/tests/kuttl/tests/dataplane-service-custom-image/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-service-custom-image/00-assert.yaml
@@ -1,0 +1,148 @@
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlane
+metadata:
+  name: openstack-edpm-no-nodes
+  namespace: openstack
+spec:
+  deployStrategy:
+    deploy: true
+  roles:
+    edpm-compute-no-nodes:
+      nodeTemplate:
+        ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
+        services:
+        - custom-image-service
+status:
+  conditions:
+  - message: Deployment in progress
+    reason: Requested
+    severity: Info
+    status: "False"
+    type: Ready
+  - message: Deployment in progress
+    reason: Requested
+    severity: Info
+    status: "False"
+    type: DeploymentReady
+  - message: Setup complete
+    reason: Ready
+    status: "True"
+    type: SetupReady
+  deployed: true
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneRole
+metadata:
+  labels:
+    openstackdataplane: openstack-edpm-no-nodes
+  name: edpm-compute-no-nodes
+  namespace: openstack
+  ownerReferences:
+  - apiVersion: dataplane.openstack.org/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: OpenStackDataPlane
+    name: openstack-edpm-no-nodes
+spec:
+  dataPlane: openstack-edpm-no-nodes
+  deployStrategy:
+    deploy: true
+  nodeTemplate:
+    ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
+    networkConfig: {}
+    services:
+    - custom-image-service
+status:
+  conditions:
+  - message: custom-image-service service not yet ready
+    reason: Requested
+    severity: Info
+    status: "False"
+    type: Ready
+  - message: Deployment in progress
+    reason: Requested
+    severity: Info
+    status: "False"
+    type: DeploymentReady
+  - message: Init
+    reason: Init
+    status: Unknown
+    type: RoleBaremetalProvisionReady
+  - message: Setup complete
+    reason: Ready
+    status: "True"
+    type: SetupReady
+  - message: custom-image-service service not yet ready
+    reason: Requested
+    severity: Info
+    status: "False"
+    type: custom-image-service service ready
+---
+apiVersion: ansibleee.openstack.org/v1alpha1
+kind: OpenStackAnsibleEE
+metadata:
+  name: dataplane-deployment-custom-image-service-edpm-compute-no-nodes
+  namespace: openstack
+  ownerReferences:
+  - apiVersion: dataplane.openstack.org/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: OpenStackDataPlaneRole
+    name: edpm-compute-no-nodes
+spec:
+  backoffLimit: 6
+  extraMounts:
+  - mounts:
+    - mountPath: /runner/env/ssh_key
+      name: ssh-key
+      subPath: ssh_key
+    - mountPath: /runner/inventory/hosts
+      name: inventory
+      subPath: inventory
+    - mountPath: /runner/network/nic-config-template
+      name: inventory
+      subPath: network
+    volumes:
+    - name: ssh-key
+      secret:
+        items:
+        - key: ssh-privatekey
+          path: ssh_key
+        secretName: dataplane-ansible-ssh-private-key-secret
+    - configMap:
+        items:
+        - key: inventory
+          path: inventory
+        - key: network
+          path: network
+        name: dataplanerole-edpm-compute-no-nodes
+      name: inventory
+  image: example.com/repo/runner-image:latest
+  name: openstackansibleee
+  restartPolicy: Never
+  roles:
+    any_errors_fatal: true
+    become: false
+    gather_facts: false
+    hosts: all
+    name: test role
+    strategy: linear
+    tasks:
+    - import_role:
+        name: test role
+      name: test task
+  uid: 1001
+status:
+  JobStatus: Running
+  conditions:
+  - message: AnsibleExecutionJob is running
+    reason: Requested
+    severity: Info
+    status: "False"
+    type: Ready
+  - message: AnsibleExecutionJob is running
+    reason: Requested
+    severity: Info
+    status: "False"
+    type: AnsibleExecutionJobReady

--- a/tests/kuttl/tests/dataplane-service-custom-image/00-dataplane-create.yaml
+++ b/tests/kuttl/tests/dataplane-service-custom-image/00-dataplane-create.yaml
@@ -1,0 +1,30 @@
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneService
+metadata:
+  name: custom-image-service
+spec:
+  label: dataplane-deployment-custom-image-service
+  openStackAnsibleEERunnerImage: example.com/repo/runner-image:latest
+  role:
+    name: "test role"
+    hosts: "all"
+    strategy: "linear"
+    tasks:
+      - name: "test task"
+        import_role:
+          name: "test role"
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlane
+metadata:
+  name: openstack-edpm-no-nodes
+spec:
+  deployStrategy:
+      deploy: true
+  roles:
+    edpm-compute-no-nodes:
+      nodeTemplate:
+        services:
+          - custom-image-service
+        ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
+---


### PR DESCRIPTION
The image used by ansible-runner needs to be service specific. The
default value remains the same, and that value will be used when an
image is not specified.

For custom services enabled with the composable service interface that
may need custom ansible content, a different value can be specified for
the image.

Adds a kuttl test with a custom service using a custom image. The tests
expects an OpenStackAnsibleEE resource that never succeeds since the
custom image does not actually exist.

Signed-off-by: James Slagle <jslagle@redhat.com>

Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/328
Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/222
Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/223