### PR TITLE
Always define image_base in content provider job

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -7,6 +7,7 @@
       cifmw_operator_build_operators:
         - name: "openstack-operator"
           src: "~/src/github.com/{{ cifmw_operator_build_org }}/openstack-operator"
+          image_base: dataplane
 
 - job:
     name: dataplane-operator-crc-podified-edpm-deployment


### PR DESCRIPTION
When renovate bot proposes the pull request against openstack-k8s-operators/dataplane-operator repo that time GH user is openstack-k8s-operators.

During meta operator make bundle process, pin-custom-bundle-dockerfile.sh tries to set quay registry and look for that ee oprator pr hash on quay registry. That hash does not exist because ee operator bundle image is pushed on local registry.

Setting the image_base during make build process fixes the issue.