### PR TITLE
OpenStackDataPlane sample CR for Nova Ceph Config

### DIFF
--- a/config/samples/dataplane_v1beta1_openstackdataplane_ceph.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplane_ceph.yaml
@@ -1,0 +1,184 @@
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlane
+metadata:
+  name: openstack-edpm
+spec:
+  deployStrategy:
+      deploy: false
+  nodes:
+    edpm-compute-0:
+      role: edpm-compute
+      hostName: edpm-compute-0
+      ansibleHost: 192.168.122.100
+      node:
+        ansibleVars: |
+          ctlplane_ip: 192.168.122.100
+          internal_api_ip: 172.17.0.100
+          storage_ip: 172.18.0.100
+          tenant_ip: 172.19.0.100
+          fqdn_internal_api: edpm-compute-0.example.com
+        ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
+      deployStrategy:
+        deploy: false
+    edpm-compute-1:
+      role: edpm-compute
+      hostName: edpm-compute-1
+      ansibleHost: 192.168.122.101
+      node:
+        ansibleVars: |
+          ctlplane_ip: 192.168.122.101
+          internal_api_ip: 172.17.0.101
+          storage_ip: 172.18.0.101
+          tenant_ip: 172.19.0.101
+          fqdn_internal_api: edpm-compute-1.example.com
+        ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
+      deployStrategy:
+        deploy: false
+  roles:
+    edpm-compute:
+      env:
+        - name: ANSIBLE_FORCE_COLOR
+          value: "True"
+        - name: ANSIBLE_ENABLE_TASK_DEBUGGER
+          value: "True"
+        - name: ANSIBLE_VERBOSITY
+          value: "2"
+      baremetalSetTemplate:
+        deploymentSSHSecret: dataplane-ansible-ssh-private-key-secret
+        ctlplaneInterface: enp1s0
+        provisionServerName: openstackprovisionserver
+        ctlplaneGateway: 172.22.0.3
+        ctlplaneNetmask: 255.255.255.0
+        bmhNamespace: openstack
+        domainName: osptest.openstack.org
+      preProvisioned: true
+      nodeTemplate:
+        services:
+          - configure-network
+          - validate-network
+          - install-os
+          - configure-os
+          - run-os
+        # Defining the novaTemplate here means the nodes in this role are
+        # computes and they will have Ceph RBD config overrides
+        nova:
+          cellName: cell1
+          customServiceConfig: |
+            [libvirt]
+            images_type=rbd
+            images_rbd_pool=vms
+            images_rbd_ceph_conf=/etc/ceph/ceph.conf
+            images_rbd_glance_store_name=default_backend
+            images_rbd_glance_copy_poll_interval=15
+            images_rbd_glance_copy_timeout=600
+            rbd_user=openstack
+            rbd_secret_uuid=$FSID
+          # Replace the $FSID with an actual Ceph FSID
+          deploy: true
+          novaInstance: nova
+        # The Ansible Pod will mount these files and copy them to nodes in role
+        extraMounts:
+        - extraVolType: Ceph
+          mounts:
+          - mountPath: /etc/ceph
+            name: ceph
+            readOnly: true
+          volumes:
+          - name: ceph
+            secret:
+              secretName: ceph-conf-files
+        managementNetwork: ctlplane
+        ansibleUser: root
+        ansiblePort: 22
+        ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
+        ansibleVars: |
+          service_net_map:
+            nova_api_network: internal_api
+            nova_libvirt_network: internal_api
+
+          # edpm_network_config
+          # Default nic config template for a EDPM compute node
+          # These vars are edpm_network_config role vars
+          edpm_network_config_template: templates/single_nic_vlans/single_nic_vlans.j2
+          edpm_network_config_hide_sensitive_logs: false
+          #
+          # These vars are for the network config templates themselves and are
+          # considered EDPM network defaults.
+          neutron_physical_bridge_name: br-ex
+          neutron_public_interface_name: eth0
+          ctlplane_mtu: 1500
+          ctlplane_subnet_cidr: 24
+          ctlplane_gateway_ip: 192.168.122.1
+          ctlplane_host_routes:
+          - ip_netmask: 0.0.0.0/0
+            next_hop: 192.168.122.1
+          external_mtu: 1500
+          external_vlan_id: 44
+          external_cidr: '24'
+          external_host_routes: []
+          internal_api_mtu: 1500
+          internal_api_vlan_id: 20
+          internal_api_cidr: '24'
+          internal_api_host_routes: []
+          storage_mtu: 1500
+          storage_vlan_id: 21
+          storage_cidr: '24'
+          storage_host_routes: []
+          tenant_mtu: 1500
+          tenant_vlan_id: 22
+          tenant_cidr: '24'
+          tenant_host_routes: []
+          role_networks:
+          - InternalApi
+          - Storage
+          - Tenant
+          networks_lower:
+            External: external
+            InternalApi: internal_api
+            Storage: storage
+            Tenant: tenant
+
+          # edpm_nodes_validation
+          edpm_nodes_validation_validate_controllers_icmp: false
+          edpm_nodes_validation_validate_gateway_icmp: false
+
+          edpm_ovn_metadata_agent_default_transport_url: rabbit://default_user@rabbitmq.openstack.svc:5672
+          edpm_ovn_metadata_agent_metadata_agent_ovn_ovn_sb_connection: tcp:10.217.5.121:6642
+          edpm_ovn_metadata_agent_metadata_agent_default_nova_metadata_host: 127.0.0.1
+          edpm_ovn_metadata_agent_metadata_agent_default_metadata_proxy_shared_secret: 12345678
+          edpm_ovn_metadata_agent_default_bind_host: 127.0.0.1
+          edpm_chrony_ntp_servers:
+          - clock.redhat.com
+          - clock2.redhat.com
+
+          ctlplane_dns_nameservers:
+          - 192.168.122.1
+          dns_search_domains: []
+          edpm_ovn_dbs:
+          - 192.168.24.1
+
+          edpm_ovn_controller_agent_image: quay.io/podified-antelope-centos9/openstack-ovn-controller:current-podified
+          edpm_iscsid_image: quay.io/podified-antelope-centos9/openstack-iscsid:current-podified
+          edpm_logrotate_crond_image: quay.io/podified-antelope-centos9/openstack-cron:current-podified
+          edpm_nova_compute_container_image: quay.io/podified-antelope-centos9/openstack-nova-compute:current-podified
+          edpm_nova_libvirt_container_image: quay.io/podified-antelope-centos9/openstack-nova-libvirt:current-podified
+          edpm_ovn_metadata_agent_image: quay.io/podified-antelope-centos9/openstack-neutron-metadata-agent-ovn:current-podified
+
+          gather_facts: false
+          enable_debug: false
+          # edpm firewall, change the allowed CIDR if needed
+          edpm_sshd_configure_firewall: true
+          edpm_sshd_allowed_ranges: ['192.168.122.0/24']
+          # SELinux module
+          edpm_selinux_mode: enforcing
+          edpm_hosts_entries_undercloud_hosts_entries: []
+          # edpm_hosts_entries role
+          edpm_hosts_entries_extra_hosts_entries:
+          - 172.17.0.80 glance-internal.openstack.svc neutron-internal.openstack.svc cinder-internal.openstack.svc nova-internal.openstack.svc placement-internal.openstack.svc keystone-internal.openstack.svc
+          - 172.17.0.85 rabbitmq.openstack.svc
+          - 172.17.0.86 rabbitmq-cell1.openstack.svc
+          edpm_hosts_entries_vip_hosts_entries: []
+          hosts_entries: []
+          hosts_entry: []
+      deployStrategy:
+        deploy: false


### PR DESCRIPTION
Add dataplane_v1beta1_openstackdataplane_ceph.yaml based on dataplane_v1beta1_openstackdataplane.yaml but also has extraMounts and a customServiceConfig for nova. These parameters have been confirmed to configure an EDPM compute node which can store its ephemeral data in a Ceph RBD pool. This will also be an example referenced from the documentation [1].

[1] https://github.com/openstack-k8s-operators/docs/pull/36