### PR TITLE
Add deployProtection annotation

### DIFF
--- a/api/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
@@ -49,11 +49,6 @@ spec:
                     type: string
                   ansibleTags:
                     type: string
-                  deploy:
-                    default: true
-                    type: boolean
-                required:
-                - deploy
                 type: object
               env:
                 items:

--- a/api/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
@@ -200,11 +200,6 @@ spec:
                     type: string
                   ansibleTags:
                     type: string
-                  deploy:
-                    default: true
-                    type: boolean
-                required:
-                - deploy
                 type: object
               env:
                 items:

--- a/api/bases/dataplane.openstack.org_openstackdataplanes.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplanes.yaml
@@ -49,11 +49,6 @@ spec:
                     type: string
                   ansibleTags:
                     type: string
-                  deploy:
-                    default: true
-                    type: boolean
-                required:
-                - deploy
                 type: object
               nodes:
                 additionalProperties:
@@ -68,11 +63,6 @@ spec:
                           type: string
                         ansibleTags:
                           type: string
-                        deploy:
-                          default: true
-                          type: boolean
-                      required:
-                      - deploy
                       type: object
                     env:
                       items:
@@ -1124,11 +1114,6 @@ spec:
                           type: string
                         ansibleTags:
                           type: string
-                        deploy:
-                          default: true
-                          type: boolean
-                      required:
-                      - deploy
                       type: object
                     env:
                       items:

--- a/api/v1beta1/common.go
+++ b/api/v1beta1/common.go
@@ -85,12 +85,6 @@ type NodeSection struct {
 
 // DeployStrategySection for fields controlling the deployment
 type DeployStrategySection struct {
-
-	// +kubebuilder:default=true
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
-	// Deploy boolean to trigger ansible execution
-	Deploy bool `json:"deploy"`
-
 	// +kubebuilder:validation:Optional
 	// AnsibleTags for ansible execution
 	AnsibleTags string `json:"ansibleTags,omitempty"`

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
@@ -49,11 +49,6 @@ spec:
                     type: string
                   ansibleTags:
                     type: string
-                  deploy:
-                    default: true
-                    type: boolean
-                required:
-                - deploy
                 type: object
               env:
                 items:

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
@@ -200,11 +200,6 @@ spec:
                     type: string
                   ansibleTags:
                     type: string
-                  deploy:
-                    default: true
-                    type: boolean
-                required:
-                - deploy
                 type: object
               env:
                 items:

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanes.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanes.yaml
@@ -49,11 +49,6 @@ spec:
                     type: string
                   ansibleTags:
                     type: string
-                  deploy:
-                    default: true
-                    type: boolean
-                required:
-                - deploy
                 type: object
               nodes:
                 additionalProperties:
@@ -68,11 +63,6 @@ spec:
                           type: string
                         ansibleTags:
                           type: string
-                        deploy:
-                          default: true
-                          type: boolean
-                      required:
-                      - deploy
                       type: object
                     env:
                       items:
@@ -1124,11 +1114,6 @@ spec:
                           type: string
                         ansibleTags:
                           type: string
-                        deploy:
-                          default: true
-                          type: boolean
-                      required:
-                      - deploy
                       type: object
                     env:
                       items:

--- a/controllers/openstackdataplanerole_controller.go
+++ b/controllers/openstackdataplanerole_controller.go
@@ -37,6 +37,7 @@ import (
 	"github.com/go-logr/logr"
 	dataplanev1 "github.com/openstack-k8s-operators/dataplane-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/dataplane-operator/pkg/deployment"
+	dataplaneutil "github.com/openstack-k8s-operators/dataplane-operator/pkg/util"
 	infranetworkv1 "github.com/openstack-k8s-operators/infra-operator/apis/network/v1beta1"
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
@@ -248,59 +249,60 @@ func (r *OpenStackDataPlaneRoleReconciler) Reconcile(ctx context.Context, req ct
 	// all setup tasks complete, mark SetupReadyCondition True
 	instance.Status.Conditions.MarkTrue(dataplanev1.SetupReadyCondition, condition.ReadyMessage)
 
-	r.Log.Info("Role", "DeployStrategy", instance.Spec.DeployStrategy.Deploy,
-		"Role.Namespace", instance.Namespace, "Role.Name", instance.Name)
-	if instance.Spec.DeployStrategy.Deploy {
-		r.Log.Info("Starting DataPlaneRole deploy")
-		r.Log.Info("Set DeploymentReadyCondition false", "instance", instance)
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.DeploymentReadyCondition, condition.RequestedReason,
-			condition.SeverityInfo, condition.DeploymentReadyRunningMessage))
-		ansibleEESpec := instance.GetAnsibleEESpec()
-		if dnsAddresses != nil && ctlplaneSearchDomain != "" {
-			ansibleEESpec.DNSConfig = &corev1.PodDNSConfig{
-				Nameservers: dnsAddresses,
-				Searches:    []string{ctlplaneSearchDomain},
-			}
-		}
-		deployResult, err := deployment.Deploy(
-			ctx, helper, instance, nodes, ansibleSSHPrivateKeySecret,
-			roleConfigMap, &instance.Status, ansibleEESpec,
-			instance.Spec.Services, instance)
-		if err != nil {
-			util.LogErrorForObject(helper, err, fmt.Sprintf("Unable to deploy %s", instance.Name), instance)
-			instance.Status.Conditions.Set(condition.FalseCondition(
-				condition.ReadyCondition,
-				condition.ErrorReason,
-				condition.SeverityWarning,
-				dataplanev1.DataPlaneRoleErrorMessage,
-				err.Error()))
-			return ctrl.Result{}, err
-		}
-		if deployResult != nil {
-			result = *deployResult
-			return result, nil
-		}
-
-		instance.Status.Deployed = true
-		r.Log.Info("Set DeploymentReadyCondition true", "instance", instance)
-		instance.Status.Conditions.Set(condition.TrueCondition(condition.DeploymentReadyCondition, condition.DeploymentReadyMessage))
-
-		// Explicitly set instance.Spec.Deploy = false
-		// We don't want another deploy triggered by any reconcile request, it should
-		// only be triggered when the user (or another controller) specifically
-		// sets it to true.
-		r.Log.Info("Set DeployStrategy.Deploy to false")
-		instance.Spec.DeployStrategy.Deploy = false
-
+	_, unsafeToExecute := dataplaneutil.CheckDeployProtectionAnnotation(instance, redeployProtectionAnnotation)
+	if unsafeToExecute {
+		r.Log.Info("This OpenStackDataPlaneRole object currently has the deployProtection annotation, which will prevent further task execution")
+		return ctrl.Result{Requeue: false}, nil
 	}
 
+	r.Log.Info("Starting DataPlaneRole deploy")
+	r.Log.Info("Set DeploymentReadyCondition false", "instance", instance)
+	instance.Status.Conditions.Set(condition.FalseCondition(condition.DeploymentReadyCondition, condition.RequestedReason, condition.SeverityInfo, condition.DeploymentReadyRunningMessage))
+
+	ansibleEESpec := instance.GetAnsibleEESpec()
+	if dnsAddresses != nil && ctlplaneSearchDomain != "" {
+		ansibleEESpec.DNSConfig = &corev1.PodDNSConfig{
+			Nameservers: dnsAddresses,
+			Searches:    []string{ctlplaneSearchDomain},
+		}
+	}
+
+	deployResult, err := deployment.Deploy(ctx, helper, instance, nodes, ansibleSSHPrivateKeySecret, roleConfigMap, &instance.Status, ansibleEESpec, instance.Spec.Services, instance)
+	if err != nil {
+		util.LogErrorForObject(helper, err, fmt.Sprintf("Unable to deploy %s", instance.Name), instance)
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			condition.ReadyCondition,
+			condition.ErrorReason,
+			condition.SeverityWarning,
+			dataplanev1.DataPlaneRoleErrorMessage,
+			err.Error()))
+		return ctrl.Result{}, err
+	}
+	if deployResult != nil {
+		result = *deployResult
+		return result, nil
+	}
+
+	instance.Status.Deployed = true
+	r.Log.Info("Set DeploymentReadyCondition true", "instance", instance)
+	instance.Status.Conditions.Set(condition.TrueCondition(condition.DeploymentReadyCondition, condition.DeploymentReadyMessage))
+
 	// Set DeploymentReadyCondition to False if it was unknown.
-	// Handles the case where the Role is created with
-	// DeployStrategy.Deploy=false.
+	// Handles the case where the Node is created with
+	// If the status is Unknown at this point. We will return to avoid setting the
+	// redeployProtectionAnnotaton
 	if instance.Status.Conditions.IsUnknown(condition.DeploymentReadyCondition) {
 		r.Log.Info("Set DeploymentReadyCondition false")
 		instance.Status.Conditions.Set(condition.FalseCondition(condition.DeploymentReadyCondition, condition.NotRequestedReason, condition.SeverityInfo, condition.DeploymentReadyInitMessage))
+		return ctrl.Result{}, nil
+	}
+
+	// We don't want another deploy triggered by any reconcile request, it
+	// should only be triggered when the user (or another controller)
+	// specifically clears this annotation and requests it.
+	if instance.Status.Conditions.AllSubConditionIsTrue() {
+		r.Log.Info("Setting deploy protection annotation")
+		instance.ObjectMeta.SetAnnotations(redeployProtectionAnnotation)
 	}
 
 	return ctrl.Result{}, nil

--- a/docs/openstack_dataplane.md
+++ b/docs/openstack_dataplane.md
@@ -37,7 +37,6 @@ DeployStrategySection for fields controlling the deployment
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| deploy | Deploy boolean to trigger ansible execution | bool | true |
 | ansibleTags | AnsibleTags for ansible execution | string | false |
 | ansibleLimit | AnsibleLimit for ansible execution | string | false |
 | ansibleSkipTags | AnsibleSkipTags for ansible execution | string | false |

--- a/docs/openstack_dataplanenode.md
+++ b/docs/openstack_dataplanenode.md
@@ -36,7 +36,6 @@ DeployStrategySection for fields controlling the deployment
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| deploy | Deploy boolean to trigger ansible execution | bool | true |
 | ansibleTags | AnsibleTags for ansible execution | string | false |
 | ansibleLimit | AnsibleLimit for ansible execution | string | false |
 | ansibleSkipTags | AnsibleSkipTags for ansible execution | string | false |

--- a/docs/openstack_dataplanerole.md
+++ b/docs/openstack_dataplanerole.md
@@ -36,7 +36,6 @@ DeployStrategySection for fields controlling the deployment
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| deploy | Deploy boolean to trigger ansible execution | bool | true |
 | ansibleTags | AnsibleTags for ansible execution | string | false |
 | ansibleLimit | AnsibleLimit for ansible execution | string | false |
 | ansibleSkipTags | AnsibleSkipTags for ansible execution | string | false |

--- a/docs/openstack_dataplaneservice.md
+++ b/docs/openstack_dataplaneservice.md
@@ -37,7 +37,6 @@ DeployStrategySection for fields controlling the deployment
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| deploy | Deploy boolean to trigger ansible execution | bool | true |
 | ansibleTags | AnsibleTags for ansible execution | string | false |
 | ansibleLimit | AnsibleLimit for ansible execution | string | false |
 | ansibleSkipTags | AnsibleSkipTags for ansible execution | string | false |

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -1,0 +1,16 @@
+package util
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// CheckDeployProtectionAnnotation checks to see if the node has the deploy protection annotation set. If this is set,
+// we will block the execution of Ansible tasks until it is cleared.
+func CheckDeployProtectionAnnotation(instance client.Object, annotation map[string]string) (annotations map[string]string, keyExists bool) {
+	annotations = instance.GetAnnotations()
+	for k := range annotations {
+		_, keyExists := annotation[k]
+		return annotations, keyExists
+	}
+	return annotations, false
+}

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -21,9 +21,6 @@ func DefaultDataplaneNoNodesTemplate(name types.NamespacedName) *dataplanev1.Ope
 			Namespace: name.Namespace,
 		},
 		Spec: dataplanev1.OpenStackDataPlaneSpec{
-			DeployStrategy: dataplanev1.DeployStrategySection{
-				Deploy: false,
-			},
 			Roles: map[string]dataplanev1.OpenStackDataPlaneRoleSpec{
 				"edpm-compute-no-nodes": {
 					Services: []string{"configure-network", "validate-network", "install-os", "configure-os", "run-os"},
@@ -53,11 +50,6 @@ func DefaultDataplaneRoleNoNodesTemplate(name types.NamespacedName) *dataplanev1
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "edpm-compute-no-nodes",
 			Namespace: name.Namespace,
-		},
-		Spec: dataplanev1.OpenStackDataPlaneRoleSpec{
-			DeployStrategy: dataplanev1.DeployStrategySection{
-				Deploy: false,
-			},
 		},
 	}
 }

--- a/tests/functional/openstackdataplane_controller_test.go
+++ b/tests/functional/openstackdataplane_controller_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Dataplane Test", func() {
 		})
 		It("should have the Spec fields initialized", func() {
 			dataplaneInstance := GetDataplane(dataplaneName)
-			Expect(dataplaneInstance.Spec.DeployStrategy.Deploy).Should(BeFalse())
+			Expect(dataplaneInstance.Spec.DeployStrategy.AnsibleTags).Should(Equal(""))
 		})
 
 		It("should have the Status fields initialized", func() {
@@ -57,7 +57,6 @@ var _ = Describe("Dataplane Test", func() {
 		It("Should have created a OpenStackDataplaneRole", func() {
 			dataplaneRoleInstance := GetDataplaneRole(dataplaneRoleName)
 			Expect(dataplaneRoleInstance).NotTo(BeNil())
-			Expect(dataplaneRoleInstance.Spec.DeployStrategy.Deploy).Should(BeFalse())
 			Expect(dataplaneRoleInstance.Spec.NodeTemplate.AnsibleSSHPrivateKeySecret).Should(Equal("dataplane-ansible-ssh-private-key-secret"))
 		})
 	})

--- a/tests/functional/openstackdataplanerole_controller_test.go
+++ b/tests/functional/openstackdataplanerole_controller_test.go
@@ -26,7 +26,7 @@ import (
 
 var _ = Describe("Dataplane Role Test", func() {
 	var dataplaneRoleName types.NamespacedName
-
+	var serviceList []string = []string{"configure-network", "validate-network", "install-os", "configure-os", "run-os"}
 	BeforeEach(func() {
 		dataplaneRoleName = types.NamespacedName{
 			Name:      "edpm-compute-no-nodes",
@@ -42,7 +42,7 @@ var _ = Describe("Dataplane Role Test", func() {
 		})
 		It("should have the Spec fields initialized", func() {
 			dataplaneRoleInstance := GetDataplaneRole(dataplaneRoleName)
-			Expect(dataplaneRoleInstance.Spec.DeployStrategy.Deploy).Should(BeFalse())
+			Expect(dataplaneRoleInstance.Spec.Services).Should(Equal(serviceList))
 		})
 
 		It("should have the Status fields initialized", func() {


### PR DESCRIPTION
When a node is already deployed, we need to protect against eroneous Ansible executions. This is essential to ensure predictability in our deployments and ensure nodes are only being touched when there is explicit intent to do so.

This change annotates the OpenStackDataPlaneNode at the end of the deployment.