### PR TITLE
Revert "Move services under NodeSection."

### DIFF
--- a/api/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
@@ -917,16 +917,6 @@ spec:
                         default: nova
                         type: string
                     type: object
-                  services:
-                    default:
-                    - configure-network
-                    - validate-network
-                    - install-os
-                    - configure-os
-                    - run-os
-                    items:
-                      type: string
-                    type: array
                   userData:
                     properties:
                       name:

--- a/api/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
@@ -1068,16 +1068,6 @@ spec:
                         default: nova
                         type: string
                     type: object
-                  services:
-                    default:
-                    - configure-network
-                    - validate-network
-                    - install-os
-                    - configure-os
-                    - run-os
-                    items:
-                      type: string
-                    type: array
                   userData:
                     properties:
                       name:
@@ -1089,6 +1079,16 @@ spec:
                 type: object
               preProvisioned:
                 type: boolean
+              services:
+                default:
+                - configure-network
+                - validate-network
+                - install-os
+                - configure-os
+                - run-os
+                items:
+                  type: string
+                type: array
             type: object
           status:
             properties:

--- a/api/bases/dataplane.openstack.org_openstackdataplanes.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplanes.yaml
@@ -936,16 +936,6 @@ spec:
                               default: nova
                               type: string
                           type: object
-                        services:
-                          default:
-                          - configure-network
-                          - validate-network
-                          - install-os
-                          - configure-os
-                          - run-os
-                          items:
-                            type: string
-                          type: array
                         userData:
                           properties:
                             name:
@@ -1991,16 +1981,6 @@ spec:
                               default: nova
                               type: string
                           type: object
-                        services:
-                          default:
-                          - configure-network
-                          - validate-network
-                          - install-os
-                          - configure-os
-                          - run-os
-                          items:
-                            type: string
-                          type: array
                         userData:
                           properties:
                             name:
@@ -2012,6 +1992,16 @@ spec:
                       type: object
                     preProvisioned:
                       type: boolean
+                    services:
+                      default:
+                      - configure-network
+                      - validate-network
+                      - install-os
+                      - configure-os
+                      - run-os
+                      items:
+                        type: string
+                      type: array
                   type: object
                 type: object
             type: object

--- a/api/v1beta1/common.go
+++ b/api/v1beta1/common.go
@@ -73,11 +73,6 @@ type NodeSection struct {
 	// +kubebuilder:validation:Optional
 	NetworkData *corev1.SecretReference `json:"networkData,omitempty"`
 
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={configure-network,validate-network,install-os,configure-os,run-os}
-	// Services list
-	Services *[]string `json:"services"`
-
 	// NovaTemplate specifies the parameters for the compute service deployment
 	// on the EDPM node. If it is specified both in OpenstackDataPlaneRole and
 	// the OpenstackDataPlaneNode for the same EDPM node then the configuration

--- a/api/v1beta1/openstackdataplanenode_types.go
+++ b/api/v1beta1/openstackdataplanenode_types.go
@@ -99,15 +99,8 @@ func (instance *OpenStackDataPlaneNode) InitConditions(instanceRole *OpenStackDa
 		condition.UnknownCondition(SetupReadyCondition, condition.InitReason, condition.InitReason),
 	)
 
-	var services *[]string
-	if instance.Spec.Node.Services != nil {
-		services = instance.Spec.Node.Services
-	} else {
-		services = instanceRole.Spec.NodeTemplate.Services
-	}
-
-	if services != nil {
-		for _, service := range *services {
+	if instanceRole.Spec.Services != nil {
+		for _, service := range instanceRole.Spec.Services {
 			readyCondition := condition.Type(fmt.Sprintf(ServiceReadyCondition, service))
 			cl = append(cl, *condition.UnknownCondition(readyCondition, condition.InitReason, condition.InitReason))
 		}

--- a/api/v1beta1/openstackdataplanerole_types.go
+++ b/api/v1beta1/openstackdataplanerole_types.go
@@ -61,6 +61,11 @@ type OpenStackDataPlaneRoleSpec struct {
 	// NetworkAttachments is a list of NetworkAttachment resource names to pass to the ansibleee resource
 	// which allows to connect the ansibleee runner to the given network
 	NetworkAttachments []string `json:"networkAttachments"`
+
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default={configure-network,validate-network,install-os,configure-os,run-os}
+	// Services list
+	Services []string `json:"services"`
 }
 
 //+kubebuilder:object:root=true
@@ -107,8 +112,8 @@ func (instance *OpenStackDataPlaneRole) InitConditions() {
 		condition.UnknownCondition(RoleBareMetalProvisionReadyCondition, condition.InitReason, condition.InitReason),
 	)
 
-	if instance.Spec.NodeTemplate.Services != nil {
-		for _, service := range *instance.Spec.NodeTemplate.Services {
+	if instance.Spec.Services != nil {
+		for _, service := range instance.Spec.Services {
 			readyCondition := condition.Type(fmt.Sprintf(ServiceReadyCondition, service))
 			cl = append(cl, *condition.UnknownCondition(readyCondition, condition.InitReason, condition.InitReason))
 		}

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -134,15 +134,6 @@ func (in *NodeSection) DeepCopyInto(out *NodeSection) {
 		*out = new(v1.SecretReference)
 		**out = **in
 	}
-	if in.Services != nil {
-		in, out := &in.Services, &out.Services
-		*out = new([]string)
-		if **in != nil {
-			in, out := *in, *out
-			*out = make([]string, len(*in))
-			copy(*out, *in)
-		}
-	}
 	if in.Nova != nil {
 		in, out := &in.Nova, &out.Nova
 		*out = new(NovaTemplate)
@@ -401,6 +392,11 @@ func (in *OpenStackDataPlaneRoleSpec) DeepCopyInto(out *OpenStackDataPlaneRoleSp
 	out.DeployStrategy = in.DeployStrategy
 	if in.NetworkAttachments != nil {
 		in, out := &in.NetworkAttachments, &out.NetworkAttachments
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.Services != nil {
+		in, out := &in.Services, &out.Services
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
@@ -917,16 +917,6 @@ spec:
                         default: nova
                         type: string
                     type: object
-                  services:
-                    default:
-                    - configure-network
-                    - validate-network
-                    - install-os
-                    - configure-os
-                    - run-os
-                    items:
-                      type: string
-                    type: array
                   userData:
                     properties:
                       name:

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
@@ -1068,16 +1068,6 @@ spec:
                         default: nova
                         type: string
                     type: object
-                  services:
-                    default:
-                    - configure-network
-                    - validate-network
-                    - install-os
-                    - configure-os
-                    - run-os
-                    items:
-                      type: string
-                    type: array
                   userData:
                     properties:
                       name:
@@ -1089,6 +1079,16 @@ spec:
                 type: object
               preProvisioned:
                 type: boolean
+              services:
+                default:
+                - configure-network
+                - validate-network
+                - install-os
+                - configure-os
+                - run-os
+                items:
+                  type: string
+                type: array
             type: object
           status:
             properties:

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanes.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanes.yaml
@@ -936,16 +936,6 @@ spec:
                               default: nova
                               type: string
                           type: object
-                        services:
-                          default:
-                          - configure-network
-                          - validate-network
-                          - install-os
-                          - configure-os
-                          - run-os
-                          items:
-                            type: string
-                          type: array
                         userData:
                           properties:
                             name:
@@ -1991,16 +1981,6 @@ spec:
                               default: nova
                               type: string
                           type: object
-                        services:
-                          default:
-                          - configure-network
-                          - validate-network
-                          - install-os
-                          - configure-os
-                          - run-os
-                          items:
-                            type: string
-                          type: array
                         userData:
                           properties:
                             name:
@@ -2012,6 +1992,16 @@ spec:
                       type: object
                     preProvisioned:
                       type: boolean
+                    services:
+                      default:
+                      - configure-network
+                      - validate-network
+                      - install-os
+                      - configure-os
+                      - run-os
+                      items:
+                        type: string
+                      type: array
                   type: object
                 type: object
             type: object

--- a/config/samples/dataplane_v1beta1_openstackdataplane.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplane.yaml
@@ -52,13 +52,13 @@ spec:
         bmhNamespace: openstack
         domainName: osptest.openstack.org
       preProvisioned: true
+      services:
+        - configure-network
+        - validate-network
+        - install-os
+        - configure-os
+        - run-os
       nodeTemplate:
-        services:
-          - configure-network
-          - validate-network
-          - install-os
-          - configure-os
-          - run-os
         # Defining the novaTemplate here means the nodes in this role are
         # computes
         nova: {}

--- a/config/samples/dataplane_v1beta1_openstackdataplane_ceph.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplane_ceph.yaml
@@ -52,13 +52,13 @@ spec:
         bmhNamespace: openstack
         domainName: osptest.openstack.org
       preProvisioned: true
+      services:
+        - configure-network
+        - validate-network
+        - install-os
+        - configure-os
+        - run-os
       nodeTemplate:
-        services:
-          - configure-network
-          - validate-network
-          - install-os
-          - configure-os
-          - run-os
         # Defining the novaTemplate here means the nodes in this role are
         # computes and they will have Ceph RBD config overrides
         nova:

--- a/config/samples/dataplane_v1beta1_openstackdataplanenode.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenode.yaml
@@ -7,12 +7,6 @@ spec:
   hostName: openstackdataplanenode-sample.localdomain
   ansibleHost: 192.168.122.18
   node:
-    services:
-      - configure-network
-      - validate-network
-      - install-os
-      - configure-os
-      - run-os
     networks:
       - network: ctlplane
         fixedIP: 192.168.122.18

--- a/config/samples/dataplane_v1beta1_openstackdataplanenode_edpm_compute_0.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenode_edpm_compute_0.yaml
@@ -7,12 +7,6 @@ spec:
   hostName: edpm-compute-0
   ansibleHost: 192.168.122.100
   node:
-    services:
-      - configure-network
-      - validate-network
-      - install-os
-      - configure-os
-      - run-os
     nova: {}
     ansibleVars: |
       tenant_ip: 192.168.24.100

--- a/config/samples/dataplane_v1beta1_openstackdataplanenode_edpm_compute_0_full.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenode_edpm_compute_0_full.yaml
@@ -7,12 +7,6 @@ spec:
   ansibleHost: 192.168.122.100
   ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
   node:
-    services:
-      - configure-network
-      - validate-network
-      - install-os
-      - configure-os
-      - run-os
     nova: {}
     ansibleUser: root
     ansiblePort: 22

--- a/config/samples/dataplane_v1beta1_openstackdataplanenode_edpm_compute_1.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenode_edpm_compute_1.yaml
@@ -7,12 +7,6 @@ spec:
   hostName: edpm-compute-1
   ansibleHost: 192.168.122.101
   node:
-    services:
-      - configure-network
-      - validate-network
-      - install-os
-      - configure-os
-      - run-os
     nova: {}
     ansibleVars: |
       tenant_ip: 192.168.24.101

--- a/config/samples/dataplane_v1beta1_openstackdataplanerole.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanerole.yaml
@@ -3,13 +3,13 @@ kind: OpenStackDataPlaneRole
 metadata:
   name: openstackdataplanerole-sample
 spec:
+  services:
+    - configure-network
+    - validate-network
+    - install-os
+    - configure-os
+    - run-os
   nodeTemplate:
-    services:
-      - configure-network
-      - validate-network
-      - install-os
-      - configure-os
-      - run-os
     networkConfig:
       template: templates/net_config_bridge.j2
     managed: false

--- a/config/samples/dataplane_v1beta1_openstackdataplanerole_edpm_compute.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanerole_edpm_compute.yaml
@@ -3,13 +3,13 @@ kind: OpenStackDataPlaneRole
 metadata:
   name: edpm-compute
 spec:
+  services:
+    - configure-network
+    - validate-network
+    - install-os
+    - configure-os
+    - run-os
   nodeTemplate:
-    services:
-      - configure-network
-      - validate-network
-      - install-os
-      - configure-os
-      - run-os
     nova: {}
     managed: false
     managementNetwork: ctlplane

--- a/controllers/openstackdataplane_controller.go
+++ b/controllers/openstackdataplane_controller.go
@@ -366,7 +366,7 @@ func createOrPatchDataPlaneRoles(ctx context.Context,
 			role.Spec.NodeTemplate = roleSpec.NodeTemplate
 			role.Spec.NetworkAttachments = roleSpec.NetworkAttachments
 			role.Spec.Env = roleSpec.Env
-			role.Spec.NodeTemplate.Services = roleSpec.NodeTemplate.Services
+			role.Spec.Services = roleSpec.Services
 			hostMap, ok := roleManagedHostMap[roleName]
 			if ok {
 				bmsTemplate := roleSpec.BaremetalSetTemplate.DeepCopy()

--- a/controllers/openstackdataplanenode_controller.go
+++ b/controllers/openstackdataplanenode_controller.go
@@ -212,7 +212,7 @@ func (r *OpenStackDataPlaneNodeReconciler) Reconcile(ctx context.Context, req ct
 		nodes := &dataplanev1beta1.OpenStackDataPlaneNodeList{
 			Items: []dataplanev1beta1.OpenStackDataPlaneNode{*instance},
 		}
-		deployResult, err := deployment.Deploy(ctx, helper, instance, nodes, ansibleSSHPrivateKeySecret, nodeConfigMap, &instance.Status, instance.GetAnsibleEESpec(*instanceRole), *r.GetServices(instance, instanceRole), instanceRole)
+		deployResult, err := deployment.Deploy(ctx, helper, instance, nodes, ansibleSSHPrivateKeySecret, nodeConfigMap, &instance.Status, instance.GetAnsibleEESpec(*instanceRole), r.GetServices(instance, instanceRole), instanceRole)
 		if err != nil {
 			util.LogErrorForObject(helper, err, fmt.Sprintf("Unable to deploy %s", instance.Name), instance)
 			instance.Status.Conditions.Set(condition.FalseCondition(
@@ -465,9 +465,7 @@ func (r *OpenStackDataPlaneNodeReconciler) GetAnsibleSSHPrivateKeySecret(instanc
 }
 
 // GetServices returns the list of services for the node's role
-func (r *OpenStackDataPlaneNodeReconciler) GetServices(instance *dataplanev1beta1.OpenStackDataPlaneNode, instanceRole *dataplanev1beta1.OpenStackDataPlaneRole) *[]string {
-	if instance.Spec.Node.Services != nil {
-		return instance.Spec.Node.Services
-	}
-	return instanceRole.Spec.NodeTemplate.Services
+// Note that these are not inherited from NodeTemplate.
+func (r *OpenStackDataPlaneNodeReconciler) GetServices(instance *dataplanev1beta1.OpenStackDataPlaneNode, instanceRole *dataplanev1beta1.OpenStackDataPlaneRole) []string {
+	return instanceRole.Spec.Services
 }

--- a/controllers/openstackdataplanerole_controller.go
+++ b/controllers/openstackdataplanerole_controller.go
@@ -216,7 +216,7 @@ func (r *OpenStackDataPlaneRoleReconciler) Reconcile(ctx context.Context, req ct
 		r.Log.Info("Set DeploymentReadyCondition false", "instance", instance)
 		instance.Status.Conditions.Set(condition.FalseCondition(condition.DeploymentReadyCondition, condition.RequestedReason, condition.SeverityInfo, condition.DeploymentReadyRunningMessage))
 
-		deployResult, err := deployment.Deploy(ctx, helper, instance, nodes, ansibleSSHPrivateKeySecret, roleConfigMap, &instance.Status, instance.GetAnsibleEESpec(), *instance.Spec.NodeTemplate.Services, instance)
+		deployResult, err := deployment.Deploy(ctx, helper, instance, nodes, ansibleSSHPrivateKeySecret, roleConfigMap, &instance.Status, instance.GetAnsibleEESpec(), instance.Spec.Services, instance)
 		if err != nil {
 			util.LogErrorForObject(helper, err, fmt.Sprintf("Unable to deploy %s", instance.Name), instance)
 			instance.Status.Conditions.Set(condition.FalseCondition(

--- a/docs/openstack_dataplanenode.md
+++ b/docs/openstack_dataplanenode.md
@@ -80,7 +80,6 @@ NodeSection is a specification of the node attributes
 | extraMounts | ExtraMounts containing files which can be mounted into an Ansible Execution Pod | []storage.VolMounts | true |
 | userData | UserData  node specific user-data | *corev1.SecretReference | false |
 | networkData | NetworkData  node specific network-data | *corev1.SecretReference | false |
-| services | Services list | *[]string | true |
 | nova | NovaTemplate specifies the parameters for the compute service deployment on the EDPM node. If it is specified both in OpenstackDataPlaneRole and the OpenstackDataPlaneNode for the same EDPM node then the configuration in OpenstackDataPlaneNode will be used and the configuration in the OpenstackDataPlaneRole will be ignored. If this is defined in neither then compute service(s) will not be deployed on the EDPM node. | *[NovaTemplate](#novatemplate) | true |
 
 [Back to Custom Resources](#custom-resources)

--- a/docs/openstack_dataplanerole.md
+++ b/docs/openstack_dataplanerole.md
@@ -80,7 +80,6 @@ NodeSection is a specification of the node attributes
 | extraMounts | ExtraMounts containing files which can be mounted into an Ansible Execution Pod | []storage.VolMounts | true |
 | userData | UserData  node specific user-data | *corev1.SecretReference | false |
 | networkData | NetworkData  node specific network-data | *corev1.SecretReference | false |
-| services | Services list | *[]string | true |
 | nova | NovaTemplate specifies the parameters for the compute service deployment on the EDPM node. If it is specified both in OpenstackDataPlaneRole and the OpenstackDataPlaneNode for the same EDPM node then the configuration in OpenstackDataPlaneNode will be used and the configuration in the OpenstackDataPlaneRole will be ignored. If this is defined in neither then compute service(s) will not be deployed on the EDPM node. | *[NovaTemplate](#novatemplate) | true |
 
 [Back to Custom Resources](#custom-resources)
@@ -134,5 +133,6 @@ OpenStackDataPlaneRoleSpec defines the desired state of OpenStackDataPlaneRole
 | env | Env is a list containing the environment variables to pass to the pod | []corev1.EnvVar | false |
 | deployStrategy | DeployStrategy section to control how the node is deployed | [DeployStrategySection](#deploystrategysection) | false |
 | networkAttachments | NetworkAttachments is a list of NetworkAttachment resource names to pass to the ansibleee resource which allows to connect the ansibleee runner to the given network | []string | true |
+| services | Services list | []string | true |
 
 [Back to Custom Resources](#custom-resources)

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -26,9 +26,9 @@ func DefaultDataplaneNoNodesTemplate(name types.NamespacedName) *dataplanev1.Ope
 			},
 			Roles: map[string]dataplanev1.OpenStackDataPlaneRoleSpec{
 				"edpm-compute-no-nodes": {
+					Services: []string{"configure-network", "validate-network", "install-os", "configure-os", "run-os"},
 					NodeTemplate: dataplanev1.NodeSection{
 						AnsibleSSHPrivateKeySecret: "dataplane-ansible-ssh-private-key-secret",
-						Services:                   &[]string{"configure-network", "validate-network", "install-os", "configure-os", "run-os"},
 					},
 				},
 			},

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/00-assert.yaml
@@ -11,12 +11,12 @@ spec:
     edpm-compute-no-nodes:
       nodeTemplate:
         ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
-        services:
-          - configure-network
-          - validate-network
-          - install-os
-          - configure-os
-          - run-os
+      services:
+        - configure-network
+        - validate-network
+        - install-os
+        - configure-os
+        - run-os
 status:
   conditions:
   - message: Deployment not started

--- a/tests/kuttl/tests/dataplane-service-custom-image/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-service-custom-image/00-assert.yaml
@@ -11,8 +11,8 @@ spec:
     edpm-compute-no-nodes:
       nodeTemplate:
         ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
-        services:
-        - custom-image-service
+      services:
+      - custom-image-service
 status:
   conditions:
   - message: Deployment in progress
@@ -48,11 +48,11 @@ spec:
   dataPlane: openstack-edpm-no-nodes
   deployStrategy:
     deploy: true
+  services:
+  - custom-image-service
   nodeTemplate:
     ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
     networkConfig: {}
-    services:
-    - custom-image-service
 status:
   conditions:
   - message: custom-image-service service not yet ready

--- a/tests/kuttl/tests/dataplane-service-custom-image/00-dataplane-create.yaml
+++ b/tests/kuttl/tests/dataplane-service-custom-image/00-dataplane-create.yaml
@@ -24,7 +24,7 @@ spec:
   roles:
     edpm-compute-no-nodes:
       nodeTemplate:
-        services:
-          - custom-image-service
         ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
+      services:
+        - custom-image-service
 ---


### PR DESCRIPTION
This reverts commit df9df7c8ee524c7c149ab9ec63186d5ed36548ca.

There is not a straightforward way to implement the services list with
role inheritance given the current deployment design. The issue is that
a role deployment does not take a nodes customized list of services into
account.

The role would have to look for the services list on each node and come
up with a deployment order on the fly, and the right list of nodes to
run for each service. Services could also be in different orders on
different nodes. That is too complex to implement at the moment.

This also partially reverts commit
0b7007e14bb09c4957f88358d4b6fa44178cdc08. That commit added the default
services list to the samples. The list needs to be moved out from under
the nodeTemplate and node sections to being under the spec directly
instead.

Depends-On: https://github.com/openstack-k8s-operators/install_yamls/pull/313
