### PR TITLE
Use NewOpenStackAnsibleEE

### DIFF
--- a/api/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
@@ -33,7 +33,6 @@ spec:
               label:
                 type: string
               openStackAnsibleEERunnerImage:
-                default: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
                 type: string
               play:
                 type: string

--- a/api/go.mod
+++ b/api/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20230601090817-30a4a761a756
 	github.com/openstack-k8s-operators/lib-common/modules/storage v0.0.0-20230601090817-30a4a761a756
-	github.com/openstack-k8s-operators/openstack-ansibleee-operator/api v0.0.0-20230602163853-caf143e55ca3
+	github.com/openstack-k8s-operators/openstack-ansibleee-operator/api v0.0.0-20230607204311-ef5f0ccf77e7
 	github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.0.0-20230524141327-a53b273227de
 	k8s.io/api v0.26.3
 	k8s.io/apimachinery v0.26.3

--- a/api/go.sum
+++ b/api/go.sum
@@ -228,8 +228,7 @@ github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-202306010908
 github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20230601090817-30a4a761a756/go.mod h1:r8cMUoS+gnBTrGbmLLECafzhZBh6P9rMwgnrGVspbqE=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.0.0-20230601090817-30a4a761a756 h1:2qBaepC3G4LSq6mD7GqgvQEsBTzstTbqYGEO15DzEYg=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.0.0-20230601090817-30a4a761a756/go.mod h1:7sbo6DydOwpl8Ex1atTbXIrWYvZ++eSOJ0Z6RphJJ44=
-github.com/openstack-k8s-operators/openstack-ansibleee-operator/api v0.0.0-20230602163853-caf143e55ca3 h1:paBbvEbP0QU5Gc5ycVTzmCxsB8qEd2skI0k7TEEsPdU=
-github.com/openstack-k8s-operators/openstack-ansibleee-operator/api v0.0.0-20230602163853-caf143e55ca3/go.mod h1:iUXX9I7in4X/wlbrQyPEHdxhXW8glToHsmi9R/XJyEk=
+github.com/openstack-k8s-operators/openstack-ansibleee-operator/api v0.0.0-20230607204311-ef5f0ccf77e7 h1:NSRBcS+fBNVf20q94HgJyyiltmu/eHXIzo/ZmIe8euM=
 github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.0.0-20230524141327-a53b273227de h1:k1KIvOYZboCp57r++YLom3y3a693nqHkQSfiP4Fe8X8=
 github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.0.0-20230524141327-a53b273227de/go.mod h1:FOwZQb1fb5Wzfo2O+PD4zXc9qIZ0co3Dqu40xkzmd8Q=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/api/v1beta1/openstackdataplaneservice_types.go
+++ b/api/v1beta1/openstackdataplaneservice_types.go
@@ -38,9 +38,8 @@ type OpenStackDataPlaneServiceSpec struct {
 	Role *ansibleeev1alpha1.Role `json:"role,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest"
 	// OpenStackAnsibleEERunnerImage image to use as the ansibleEE runner image
-	OpenStackAnsibleEERunnerImage string `json:"openStackAnsibleEERunnerImage"`
+	OpenStackAnsibleEERunnerImage string `json:"openStackAnsibleEERunnerImage,omitempty"`
 }
 
 // OpenStackDataPlaneServiceStatus defines the observed state of OpenStackDataPlaneService

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
@@ -33,7 +33,6 @@ spec:
               label:
                 type: string
               openStackAnsibleEERunnerImage:
-                default: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
                 type: string
               play:
                 type: string

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/openstack-k8s-operators/lib-common/modules/storage v0.0.0-20230601090817-30a4a761a756
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.0.0-20230601090817-30a4a761a756
 	github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20230602160508-608af8fcbb9b
-	github.com/openstack-k8s-operators/openstack-ansibleee-operator/api v0.0.0-20230602163853-caf143e55ca3
+	github.com/openstack-k8s-operators/openstack-ansibleee-operator/api v0.0.0-20230607204311-ef5f0ccf77e7
 	github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.0.0-20230524141327-a53b273227de
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.26.3

--- a/go.sum
+++ b/go.sum
@@ -245,8 +245,8 @@ github.com/openstack-k8s-operators/lib-common/modules/test v0.0.0-20230601090817
 github.com/openstack-k8s-operators/lib-common/modules/test v0.0.0-20230601090817-30a4a761a756/go.mod h1:lZeuyHRYpGyl1pYIs0xuq8KP35tNUy2E83hSToxduq4=
 github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20230602160508-608af8fcbb9b h1:Ig692K8kSFwK9KB+4m8JTliUnG+9PoNZg0xI09qZDMw=
 github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20230602160508-608af8fcbb9b/go.mod h1:TbcUAMNQV2FkXR99nNV6v+coMb/UUu34eNaLPLQlsEQ=
-github.com/openstack-k8s-operators/openstack-ansibleee-operator/api v0.0.0-20230602163853-caf143e55ca3 h1:paBbvEbP0QU5Gc5ycVTzmCxsB8qEd2skI0k7TEEsPdU=
-github.com/openstack-k8s-operators/openstack-ansibleee-operator/api v0.0.0-20230602163853-caf143e55ca3/go.mod h1:iUXX9I7in4X/wlbrQyPEHdxhXW8glToHsmi9R/XJyEk=
+github.com/openstack-k8s-operators/openstack-ansibleee-operator/api v0.0.0-20230607204311-ef5f0ccf77e7 h1:NSRBcS+fBNVf20q94HgJyyiltmu/eHXIzo/ZmIe8euM=
+github.com/openstack-k8s-operators/openstack-ansibleee-operator/api v0.0.0-20230607204311-ef5f0ccf77e7/go.mod h1:iUXX9I7in4X/wlbrQyPEHdxhXW8glToHsmi9R/XJyEk=
 github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.0.0-20230524141327-a53b273227de h1:k1KIvOYZboCp57r++YLom3y3a693nqHkQSfiP4Fe8X8=
 github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.0.0-20230524141327-a53b273227de/go.mod h1:FOwZQb1fb5Wzfo2O+PD4zXc9qIZ0co3Dqu40xkzmd8Q=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/pkg/util/ansible_execution.go
+++ b/pkg/util/ansible_execution.go
@@ -71,8 +71,11 @@ func AnsibleExecution(
 	}
 
 	_, err = controllerutil.CreateOrPatch(ctx, helper.GetClient(), ansibleEE, func() error {
-		ansibleEE.Spec.Image = aeeSpec.OpenStackAnsibleEERunnerImage
+		ansibleEE.Spec = ansibleeev1alpha1.NewOpenStackAnsibleEE("openstackansibleee")
 		ansibleEE.Spec.NetworkAttachments = aeeSpec.NetworkAttachments
+		if len(aeeSpec.OpenStackAnsibleEERunnerImage) > 0 {
+			ansibleEE.Spec.Image = aeeSpec.OpenStackAnsibleEERunnerImage
+		}
 		if len(aeeSpec.AnsibleTags) > 0 {
 			fmt.Fprintf(&cmdLineArguments, "--tags %s ", aeeSpec.AnsibleTags)
 		}


### PR DESCRIPTION
Using NewOpenStackAnsibleEE function from openstack-ansibleee-operator
sets the proper defaults. A default value no longer needs to be set for
OpenStackAnsibleEERunnerImage on OpenStackDataPlaneServic since the
default value will be gotten from NewOpenStackAnsibleEE.

Signed-off-by: James Slagle <jslagle@redhat.com>
Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/273