### PR TITLE
Remove default OpenStackAnsibleEERunnerImage

### DIFF
--- a/api/v1beta1/common.go
+++ b/api/v1beta1/common.go
@@ -144,9 +144,8 @@ type AnsibleEESpec struct {
 	// which allows to connect the ansibleee runner to the given network
 	NetworkAttachments []string `json:"networkAttachments"`
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest"
 	// OpenStackAnsibleEERunnerImage image to use as the ansibleEE runner image
-	OpenStackAnsibleEERunnerImage string `json:"openStackAnsibleEERunnerImage"`
+	OpenStackAnsibleEERunnerImage string `json:"openStackAnsibleEERunnerImage,omitempty"`
 	// +kubebuilder:validation:Optional
 	// AnsibleTags for ansible execution
 	AnsibleTags string `json:"ansibleTags,omitempty"`

--- a/docs/openstack_dataplanenode.md
+++ b/docs/openstack_dataplanenode.md
@@ -20,7 +20,7 @@ AnsibleEESpec is a specification of the ansible EE attributes
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | networkAttachments | NetworkAttachments is a list of NetworkAttachment resource names to pass to the ansibleee resource which allows to connect the ansibleee runner to the given network | []string | true |
-| openStackAnsibleEERunnerImage | OpenStackAnsibleEERunnerImage image to use as the ansibleEE runner image | string | true |
+| openStackAnsibleEERunnerImage | OpenStackAnsibleEERunnerImage image to use as the ansibleEE runner image | string | false |
 | ansibleTags | AnsibleTags for ansible execution | string | false |
 | ansibleLimit | AnsibleLimit for ansible execution | string | false |
 | ansibleSkipTags | AnsibleSkipTags for ansible execution | string | false |

--- a/docs/openstack_dataplanerole.md
+++ b/docs/openstack_dataplanerole.md
@@ -20,7 +20,7 @@ AnsibleEESpec is a specification of the ansible EE attributes
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | networkAttachments | NetworkAttachments is a list of NetworkAttachment resource names to pass to the ansibleee resource which allows to connect the ansibleee runner to the given network | []string | true |
-| openStackAnsibleEERunnerImage | OpenStackAnsibleEERunnerImage image to use as the ansibleEE runner image | string | true |
+| openStackAnsibleEERunnerImage | OpenStackAnsibleEERunnerImage image to use as the ansibleEE runner image | string | false |
 | ansibleTags | AnsibleTags for ansible execution | string | false |
 | ansibleLimit | AnsibleLimit for ansible execution | string | false |
 | ansibleSkipTags | AnsibleSkipTags for ansible execution | string | false |

--- a/docs/openstack_dataplaneservice.md
+++ b/docs/openstack_dataplaneservice.md
@@ -21,7 +21,7 @@ AnsibleEESpec is a specification of the ansible EE attributes
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | networkAttachments | NetworkAttachments is a list of NetworkAttachment resource names to pass to the ansibleee resource which allows to connect the ansibleee runner to the given network | []string | true |
-| openStackAnsibleEERunnerImage | OpenStackAnsibleEERunnerImage image to use as the ansibleEE runner image | string | true |
+| openStackAnsibleEERunnerImage | OpenStackAnsibleEERunnerImage image to use as the ansibleEE runner image | string | false |
 | ansibleTags | AnsibleTags for ansible execution | string | false |
 | ansibleLimit | AnsibleLimit for ansible execution | string | false |
 | ansibleSkipTags | AnsibleSkipTags for ansible execution | string | false |

--- a/pkg/util/ansible_execution.go
+++ b/pkg/util/ansible_execution.go
@@ -71,7 +71,6 @@ func AnsibleExecution(
 	}
 
 	_, err = controllerutil.CreateOrPatch(ctx, helper.GetClient(), ansibleEE, func() error {
-		ansibleEE.Spec = ansibleeev1alpha1.NewOpenStackAnsibleEE("openstackansibleee")
 		ansibleEE.Spec.NetworkAttachments = aeeSpec.NetworkAttachments
 		if len(aeeSpec.OpenStackAnsibleEERunnerImage) > 0 {
 			ansibleEE.Spec.Image = aeeSpec.OpenStackAnsibleEERunnerImage


### PR DESCRIPTION
This would help use the ENV var by patching the ansibleee-operator CSV.

