### PR TITLE
Fix edpm_ovn related variable names in example CRs

### DIFF
--- a/config/samples/dataplane_v1beta1_openstackdataplane.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplane.yaml
@@ -117,11 +117,11 @@ spec:
           edpm_nodes_validation_validate_controllers_icmp: false
           edpm_nodes_validation_validate_gateway_icmp: false
 
-          edpm_ovn_metadata_agent_default_transport_url: rabbit://default_user@rabbitmq.openstack.svc:5672
+          edpm_ovn_metadata_agent_DEFAULT_transport_url: rabbit://default_user@rabbitmq.openstack.svc:5672
           edpm_ovn_metadata_agent_metadata_agent_ovn_ovn_sb_connection: tcp:10.217.5.121:6642
-          edpm_ovn_metadata_agent_metadata_agent_default_nova_metadata_host: 127.0.0.1
-          edpm_ovn_metadata_agent_metadata_agent_default_metadata_proxy_shared_secret: 12345678
-          edpm_ovn_metadata_agent_default_bind_host: 127.0.0.1
+          edpm_ovn_metadata_agent_metadata_agent_DEFAULT_nova_metadata_host: 127.0.0.1
+          edpm_ovn_metadata_agent_metadata_agent_DEFAULT_metadata_proxy_shared_secret: 12345678
+          edpm_ovn_metadata_agent_DEFAULT_bind_host: 127.0.0.1
           edpm_chrony_ntp_servers:
           - clock.redhat.com
           - clock2.redhat.com

--- a/config/samples/dataplane_v1beta1_openstackdataplane_baremetal.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplane_baremetal.yaml
@@ -116,11 +116,11 @@ spec:
           edpm_nodes_validation_validate_controllers_icmp: false
           edpm_nodes_validation_validate_gateway_icmp: false
 
-          edpm_ovn_metadata_agent_default_transport_url: rabbit://default_user@rabbitmq.openstack.svc:5672
+          edpm_ovn_metadata_agent_DEFAULT_transport_url: rabbit://default_user@rabbitmq.openstack.svc:5672
           edpm_ovn_metadata_agent_metadata_agent_ovn_ovn_sb_connection: tcp:10.217.5.121:6642
-          edpm_ovn_metadata_agent_metadata_agent_default_nova_metadata_host: 127.0.0.1
-          edpm_ovn_metadata_agent_metadata_agent_default_metadata_proxy_shared_secret: 12345678
-          edpm_ovn_metadata_agent_default_bind_host: 127.0.0.1
+          edpm_ovn_metadata_agent_metadata_agent_DEFAULT_nova_metadata_host: 127.0.0.1
+          edpm_ovn_metadata_agent_metadata_agent_DEFAULT_metadata_proxy_shared_secret: 12345678
+          edpm_ovn_metadata_agent_DEFAULT_bind_host: 127.0.0.1
           ctlplane_dns_nameservers:
           - 192.168.111.1
           dns_search_domains: []

--- a/config/samples/dataplane_v1beta1_openstackdataplane_ceph.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplane_ceph.yaml
@@ -142,11 +142,11 @@ spec:
           edpm_nodes_validation_validate_controllers_icmp: false
           edpm_nodes_validation_validate_gateway_icmp: false
 
-          edpm_ovn_metadata_agent_default_transport_url: rabbit://default_user@rabbitmq.openstack.svc:5672
+          edpm_ovn_metadata_agent_DEFAULT_transport_url: rabbit://default_user@rabbitmq.openstack.svc:5672
           edpm_ovn_metadata_agent_metadata_agent_ovn_ovn_sb_connection: tcp:10.217.5.121:6642
-          edpm_ovn_metadata_agent_metadata_agent_default_nova_metadata_host: 127.0.0.1
-          edpm_ovn_metadata_agent_metadata_agent_default_metadata_proxy_shared_secret: 12345678
-          edpm_ovn_metadata_agent_default_bind_host: 127.0.0.1
+          edpm_ovn_metadata_agent_metadata_agent_DEFAULT_nova_metadata_host: 127.0.0.1
+          edpm_ovn_metadata_agent_metadata_agent_DEFAULT_metadata_proxy_shared_secret: 12345678
+          edpm_ovn_metadata_agent_DEFAULT_bind_host: 127.0.0.1
           edpm_chrony_ntp_servers:
           - clock.redhat.com
           - clock2.redhat.com

--- a/config/samples/dataplane_v1beta1_openstackdataplane_customnetworks.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplane_customnetworks.yaml
@@ -136,11 +136,11 @@ spec:
           edpm_nodes_validation_validate_controllers_icmp: false
           edpm_nodes_validation_validate_gateway_icmp: false
 
-          edpm_ovn_metadata_agent_default_transport_url: rabbit://default_user@rabbitmq.openstack.svc:5672
+          edpm_ovn_metadata_agent_DEFAULT_transport_url: rabbit://default_user@rabbitmq.openstack.svc:5672
           edpm_ovn_metadata_agent_metadata_agent_ovn_ovn_sb_connection: tcp:10.217.5.121:6642
-          edpm_ovn_metadata_agent_metadata_agent_default_nova_metadata_host: 127.0.0.1
-          edpm_ovn_metadata_agent_metadata_agent_default_metadata_proxy_shared_secret: 12345678
-          edpm_ovn_metadata_agent_default_bind_host: 127.0.0.1
+          edpm_ovn_metadata_agent_metadata_agent_DEFAULT_nova_metadata_host: 127.0.0.1
+          edpm_ovn_metadata_agent_metadata_agent_DEFAULT_metadata_proxy_shared_secret: 12345678
+          edpm_ovn_metadata_agent_DEFAULT_bind_host: 127.0.0.1
 
           ctlplane_dns_nameservers:
           - 192.168.1.254

--- a/tests/kuttl/tests/dataplane-create-test/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-create-test/00-assert.yaml
@@ -101,11 +101,11 @@ spec:
       edpm_nodes_validation_validate_controllers_icmp: false
       edpm_nodes_validation_validate_gateway_icmp: false
 
-      edpm_ovn_metadata_agent_default_transport_url: rabbit://default_user@rabbitmq.openstack.svc:5672
+      edpm_ovn_metadata_agent_DEFAULT_transport_url: rabbit://default_user@rabbitmq.openstack.svc:5672
       edpm_ovn_metadata_agent_metadata_agent_ovn_ovn_sb_connection: tcp:10.217.5.121:6642
-      edpm_ovn_metadata_agent_metadata_agent_default_nova_metadata_host: 127.0.0.1
-      edpm_ovn_metadata_agent_metadata_agent_default_metadata_proxy_shared_secret: 12345678
-      edpm_ovn_metadata_agent_default_bind_host: 127.0.0.1
+      edpm_ovn_metadata_agent_metadata_agent_DEFAULT_nova_metadata_host: 127.0.0.1
+      edpm_ovn_metadata_agent_metadata_agent_DEFAULT_metadata_proxy_shared_secret: 12345678
+      edpm_ovn_metadata_agent_DEFAULT_bind_host: 127.0.0.1
       edpm_chrony_ntp_servers:
       - clock.redhat.com
       - clock2.redhat.com
@@ -353,11 +353,11 @@ data:
             edpm_ovn_controller_agent_image: quay.io/podified-antelope-centos9/openstack-ovn-controller:current-podified
             edpm_ovn_dbs:
                 - 192.168.24.1
-            edpm_ovn_metadata_agent_default_bind_host: 127.0.0.1
-            edpm_ovn_metadata_agent_default_transport_url: rabbit://default_user@rabbitmq.openstack.svc:5672
+            edpm_ovn_metadata_agent_DEFAULT_bind_host: 127.0.0.1
+            edpm_ovn_metadata_agent_DEFAULT_transport_url: rabbit://default_user@rabbitmq.openstack.svc:5672
             edpm_ovn_metadata_agent_image: quay.io/podified-antelope-centos9/openstack-neutron-metadata-agent-ovn:current-podified
-            edpm_ovn_metadata_agent_metadata_agent_default_metadata_proxy_shared_secret: 12345678
-            edpm_ovn_metadata_agent_metadata_agent_default_nova_metadata_host: 127.0.0.1
+            edpm_ovn_metadata_agent_metadata_agent_DEFAULT_metadata_proxy_shared_secret: 12345678
+            edpm_ovn_metadata_agent_metadata_agent_DEFAULT_nova_metadata_host: 127.0.0.1
             edpm_ovn_metadata_agent_metadata_agent_ovn_ovn_sb_connection: tcp:10.217.5.121:6642
             edpm_selinux_mode: enforcing
             edpm_sshd_allowed_ranges:
@@ -459,11 +459,11 @@ data:
                 edpm_ovn_controller_agent_image: quay.io/podified-antelope-centos9/openstack-ovn-controller:current-podified
                 edpm_ovn_dbs:
                     - 192.168.24.1
-                edpm_ovn_metadata_agent_default_bind_host: 127.0.0.1
-                edpm_ovn_metadata_agent_default_transport_url: rabbit://default_user@rabbitmq.openstack.svc:5672
+                edpm_ovn_metadata_agent_DEFAULT_bind_host: 127.0.0.1
+                edpm_ovn_metadata_agent_DEFAULT_transport_url: rabbit://default_user@rabbitmq.openstack.svc:5672
                 edpm_ovn_metadata_agent_image: quay.io/podified-antelope-centos9/openstack-neutron-metadata-agent-ovn:current-podified
-                edpm_ovn_metadata_agent_metadata_agent_default_metadata_proxy_shared_secret: 12345678
-                edpm_ovn_metadata_agent_metadata_agent_default_nova_metadata_host: 127.0.0.1
+                edpm_ovn_metadata_agent_metadata_agent_DEFAULT_metadata_proxy_shared_secret: 12345678
+                edpm_ovn_metadata_agent_metadata_agent_DEFAULT_nova_metadata_host: 127.0.0.1
                 edpm_ovn_metadata_agent_metadata_agent_ovn_ovn_sb_connection: tcp:10.217.5.121:6642
                 edpm_selinux_mode: enforcing
                 edpm_sshd_allowed_ranges:
@@ -555,11 +555,11 @@ data:
                 edpm_ovn_controller_agent_image: quay.io/podified-antelope-centos9/openstack-ovn-controller:current-podified
                 edpm_ovn_dbs:
                     - 192.168.24.1
-                edpm_ovn_metadata_agent_default_bind_host: 127.0.0.1
-                edpm_ovn_metadata_agent_default_transport_url: rabbit://default_user@rabbitmq.openstack.svc:5672
+                edpm_ovn_metadata_agent_DEFAULT_bind_host: 127.0.0.1
+                edpm_ovn_metadata_agent_DEFAULT_transport_url: rabbit://default_user@rabbitmq.openstack.svc:5672
                 edpm_ovn_metadata_agent_image: quay.io/podified-antelope-centos9/openstack-neutron-metadata-agent-ovn:current-podified
-                edpm_ovn_metadata_agent_metadata_agent_default_metadata_proxy_shared_secret: 12345678
-                edpm_ovn_metadata_agent_metadata_agent_default_nova_metadata_host: 127.0.0.1
+                edpm_ovn_metadata_agent_metadata_agent_DEFAULT_metadata_proxy_shared_secret: 12345678
+                edpm_ovn_metadata_agent_metadata_agent_DEFAULT_nova_metadata_host: 127.0.0.1
                 edpm_ovn_metadata_agent_metadata_agent_ovn_ovn_sb_connection: tcp:10.217.5.121:6642
                 edpm_selinux_mode: enforcing
                 edpm_sshd_allowed_ranges:


### PR DESCRIPTION
The variables names for edpm_ovn role were incorrect (`default` vs `DEFAULT`) and this led to neutron.conf file on compute nodes being rendered incorrectly (e.g. empty `transport_url`) so ovn_metadata_agent container kept restarting.

See [here](https://github.com/openstack-k8s-operators/edpm-ansible/blob/6c9c626bc357c325a6201dd8ff0d7db4b8eec46f/roles/edpm_ovn/defaults/main.yml#L94-L113) for correct variable naming.