### PR TITLE
Raise kuttl test timeout to 10m

### DIFF
--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -19,7 +19,7 @@ kind: TestSuite
 reportFormat: JSON
 reportName: kuttl-test-dataplane
 namespace: openstack
-timeout: 180
+timeout: 600
 parallel: 1
 suppress:
   - events                     # Remove spammy event logs


### PR DESCRIPTION
kuttl tests are timing out in CI[1]. Raise the timeout to 600s (10m)
which is reasonable for a resource constrained CI environment.

Signed-off-by: James Slagle <jslagle@redhat.com>
