### PR TITLE
Add irrelevant-files list in zuul-jobs

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -8,13 +8,31 @@
         - name: "openstack-operator"
           src: "~/src/github.com/{{ cifmw_operator_build_org }}/openstack-operator"
           image_base: dataplane
+    irrelevant-files: &openstack_if
+      - tests/kuttl
+      - docs
+      - containers/ci
+      - .github/workflows
+      - .ci-operator.yaml
+      - .dockerignore
+      - .gitignore
+      - .golangci.yaml
+      - .pre-commit-config.yaml
+      - LICENSE
+      - OWNERS*
+      - PROJECT
+      - .*/*.md
+      - kuttl-test.yaml
+      - renovate.json
 
 - job:
     name: dataplane-operator-crc-podified-edpm-deployment
     parent: cifmw-crc-podified-edpm-deployment
     vars:
       bmo_setup: true
+    irrelevant-files: *openstack_if
 
 - job:
     name: dataplane-operator-crc-podified-edpm-baremetal
     parent: cifmw-crc-podified-edpm-baremetal
+    irrelevant-files: *openstack_if


### PR DESCRIPTION
It will help to avoid running zuul ci jobs on
irrelevant-files changes.