### PR TITLE
Use AEE instead of the Job to set status

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,11 @@
 repos:
 - repo: local
   hooks:
+    - id: gotidy
+      name: gotidy
+      language: system
+      entry: make
+      args: ["tidy"]
     - id: make-manifests
       name: make-manifests
       language: system

--- a/pkg/util/ansible_execution.go
+++ b/pkg/util/ansible_execution.go
@@ -22,11 +22,9 @@ import (
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
-	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -206,23 +204,4 @@ func GetAnsibleExecution(ctx context.Context, helper *helper.Helper, obj client.
 
 	return ansibleEE, nil
 
-}
-
-// GetAnsibleExecutionJob returns OpenStackAnsibleEE Job for given label
-func GetAnsibleExecutionJob(ctx context.Context, helper *helper.Helper, obj client.Object, label string) (*batchv1.Job, error) {
-
-	foundJob := &batchv1.Job{}
-	ansibleEE, err := GetAnsibleExecution(ctx, helper, obj, label)
-	if err != nil {
-		return foundJob, err
-	} else if ansibleEE == nil {
-		return foundJob, fmt.Errorf("OpenStackAnsibleEE not found with label %s=%s", label, obj.GetUID())
-	}
-
-	err = helper.GetClient().Get(ctx, types.NamespacedName{Name: ansibleEE.Name, Namespace: ansibleEE.Namespace}, foundJob)
-	if err != nil {
-		return foundJob, err
-	}
-
-	return foundJob, nil
 }


### PR DESCRIPTION
This change uses the AnsibleEE object rather than the job to determine the status of the deployment. This ensures that we can still set the status even if the jobs are cleaned up after execution and prevents us from being stuck in an unknown state.