### PR TITLE
Bump growvols_args: /var to 80%

### DIFF
--- a/config/samples/dataplane_v1beta1_openstackdataplane_baremetal.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplane_baremetal.yaml
@@ -64,7 +64,7 @@ spec:
             nova_libvirt_network: internal_api
           edpm_chrony_ntp_servers:
             - clock.redhat.com
-          growvols_args: '/var=100%'
+          growvols_args: '/var=80%'
           # edpm_network_config
           # Default nic config template for a EDPM compute node
           # These vars are edpm_network_config role vars


### PR DESCRIPTION
https://github.com/openstack-k8s-operators/install_yamls/pull/350 reduces the growvols_args /var to 80% to fix swap issue.

The same needs to be updated in default sample config.