### PR TITLE
Make AnsibleSSHPrivateKeySecret validation Optional

### DIFF
--- a/api/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
@@ -935,8 +935,6 @@ spec:
                         type: string
                     type: object
                     x-kubernetes-map-type: atomic
-                required:
-                - ansibleSSHPrivateKeySecret
                 type: object
               role:
                 type: string

--- a/api/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
@@ -1084,8 +1084,6 @@ spec:
                         type: string
                     type: object
                     x-kubernetes-map-type: atomic
-                required:
-                - ansibleSSHPrivateKeySecret
                 type: object
               preProvisioned:
                 type: boolean

--- a/api/bases/dataplane.openstack.org_openstackdataplanes.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplanes.yaml
@@ -954,8 +954,6 @@ spec:
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
-                      required:
-                      - ansibleSSHPrivateKeySecret
                       type: object
                     role:
                       type: string
@@ -2009,8 +2007,6 @@ spec:
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
-                      required:
-                      - ansibleSSHPrivateKeySecret
                       type: object
                     preProvisioned:
                       type: boolean

--- a/api/v1beta1/common.go
+++ b/api/v1beta1/common.go
@@ -53,13 +53,13 @@ type NodeSection struct {
 	// AnsibleVars for configuring ansible
 	AnsibleVars string `json:"ansibleVars,omitempty"`
 
-	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:io.kubernetes:Secret"}
 	// AnsibleSSHPrivateKeySecret Private SSH Key secret containing private SSH
 	// key for connecting to node. Must be of the form:
 	// Secret.data.ssh-privatekey: <base64 encoded private key contents>
 	// https://kubernetes.io/docs/concepts/configuration/secret/#ssh-authentication-secrets
-	AnsibleSSHPrivateKeySecret string `json:"ansibleSSHPrivateKeySecret"`
+	AnsibleSSHPrivateKeySecret string `json:"ansibleSSHPrivateKeySecret,omitempty"`
 
 	// ExtraMounts containing files which can be mounted into an Ansible Execution Pod
 	// +kubebuilder:validation:Optional

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanenodes.yaml
@@ -935,8 +935,6 @@ spec:
                         type: string
                     type: object
                     x-kubernetes-map-type: atomic
-                required:
-                - ansibleSSHPrivateKeySecret
                 type: object
               role:
                 type: string

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
@@ -1084,8 +1084,6 @@ spec:
                         type: string
                     type: object
                     x-kubernetes-map-type: atomic
-                required:
-                - ansibleSSHPrivateKeySecret
                 type: object
               preProvisioned:
                 type: boolean

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanes.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanes.yaml
@@ -954,8 +954,6 @@ spec:
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
-                      required:
-                      - ansibleSSHPrivateKeySecret
                       type: object
                     role:
                       type: string
@@ -2009,8 +2007,6 @@ spec:
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
-                      required:
-                      - ansibleSSHPrivateKeySecret
                       type: object
                     preProvisioned:
                       type: boolean

--- a/docs/openstack_dataplanenode.md
+++ b/docs/openstack_dataplanenode.md
@@ -64,7 +64,7 @@ NodeSection is a specification of the node attributes
 | ansibleUser | AnsibleUser SSH user for Ansible connection | string | true |
 | ansiblePort | AnsiblePort SSH port for Ansible connection | int | false |
 | ansibleVars | AnsibleVars for configuring ansible | string | false |
-| ansibleSSHPrivateKeySecret | AnsibleSSHPrivateKeySecret Private SSH Key secret containing private SSH key for connecting to node. Must be of the form: Secret.data.ssh-privatekey: <base64 encoded private key contents> https://kubernetes.io/docs/concepts/configuration/secret/#ssh-authentication-secrets | string | true |
+| ansibleSSHPrivateKeySecret | AnsibleSSHPrivateKeySecret Private SSH Key secret containing private SSH key for connecting to node. Must be of the form: Secret.data.ssh-privatekey: <base64 encoded private key contents> https://kubernetes.io/docs/concepts/configuration/secret/#ssh-authentication-secrets | string | false |
 | extraMounts | ExtraMounts containing files which can be mounted into an Ansible Execution Pod | []storage.VolMounts | true |
 | userData | UserData  node specific user-data | *corev1.SecretReference | false |
 | networkData | NetworkData  node specific network-data | *corev1.SecretReference | false |

--- a/docs/openstack_dataplanerole.md
+++ b/docs/openstack_dataplanerole.md
@@ -64,7 +64,7 @@ NodeSection is a specification of the node attributes
 | ansibleUser | AnsibleUser SSH user for Ansible connection | string | true |
 | ansiblePort | AnsiblePort SSH port for Ansible connection | int | false |
 | ansibleVars | AnsibleVars for configuring ansible | string | false |
-| ansibleSSHPrivateKeySecret | AnsibleSSHPrivateKeySecret Private SSH Key secret containing private SSH key for connecting to node. Must be of the form: Secret.data.ssh-privatekey: <base64 encoded private key contents> https://kubernetes.io/docs/concepts/configuration/secret/#ssh-authentication-secrets | string | true |
+| ansibleSSHPrivateKeySecret | AnsibleSSHPrivateKeySecret Private SSH Key secret containing private SSH key for connecting to node. Must be of the form: Secret.data.ssh-privatekey: <base64 encoded private key contents> https://kubernetes.io/docs/concepts/configuration/secret/#ssh-authentication-secrets | string | false |
 | extraMounts | ExtraMounts containing files which can be mounted into an Ansible Execution Pod | []storage.VolMounts | true |
 | userData | UserData  node specific user-data | *corev1.SecretReference | false |
 | networkData | NetworkData  node specific network-data | *corev1.SecretReference | false |

--- a/docs/openstack_dataplaneservice.md
+++ b/docs/openstack_dataplaneservice.md
@@ -65,7 +65,7 @@ NodeSection is a specification of the node attributes
 | ansibleUser | AnsibleUser SSH user for Ansible connection | string | true |
 | ansiblePort | AnsiblePort SSH port for Ansible connection | int | false |
 | ansibleVars | AnsibleVars for configuring ansible | string | false |
-| ansibleSSHPrivateKeySecret | AnsibleSSHPrivateKeySecret Private SSH Key secret containing private SSH key for connecting to node. Must be of the form: Secret.data.ssh-privatekey: <base64 encoded private key contents> https://kubernetes.io/docs/concepts/configuration/secret/#ssh-authentication-secrets | string | true |
+| ansibleSSHPrivateKeySecret | AnsibleSSHPrivateKeySecret Private SSH Key secret containing private SSH key for connecting to node. Must be of the form: Secret.data.ssh-privatekey: <base64 encoded private key contents> https://kubernetes.io/docs/concepts/configuration/secret/#ssh-authentication-secrets | string | false |
 | extraMounts | ExtraMounts containing files which can be mounted into an Ansible Execution Pod | []storage.VolMounts | true |
 | userData | UserData  node specific user-data | *corev1.SecretReference | false |
 | networkData | NetworkData  node specific network-data | *corev1.SecretReference | false |


### PR DESCRIPTION
It can be specified either for the nodes or in `nodeTemplate` of the role. Keeping it `Required` means we have to specify it at all the places.

Let's make this optional. We can add a validationwebhook later to verify either or both can be specified for role/node combination.