### PR TITLE
Remove openstack from workflow name

### DIFF
--- a/.github/workflows/build-dataplane-operator.yaml
+++ b/.github/workflows/build-dataplane-operator.yaml
@@ -1,4 +1,4 @@
-name: OpenStackDataPlane Operator image builder
+name: DataPlane Operator image builder
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release-dataplane-operator.yaml
+++ b/.github/workflows/release-dataplane-operator.yaml
@@ -1,4 +1,4 @@
-name: Release OpenStackDataPlane Operator
+name: Release DataPlane Operator
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
The image name/repo name for dataplane doesn't have openstack in its name.
Removing openstack name so that we sort github status correctly [1]

[1] https://github.com/gibizer/openstack-k8s-status/pull/1