### PR TITLE
Use HostName in BaremetalSet Spec

### DIFF
--- a/pkg/deployment/ipam.go
+++ b/pkg/deployment/ipam.go
@@ -87,8 +87,7 @@ func createOrPatchDNSData(ctx context.Context, helper *helper.Helper,
 					dnsRecord := infranetworkv1.DNSHost{}
 					dnsRecord.IP = res.Address
 					var fqdnNames []string
-					fqdnName := strings.Join([]string{hostName,
-						strings.ToLower(string(res.Network)), res.DNSDomain}, ".")
+					fqdnName := strings.Join([]string{hostName, res.DNSDomain}, ".")
 					fqdnNames = append(fqdnNames, fqdnName)
 					dnsRecord.Hostnames = fqdnNames
 					allDNSRecords = append(allDNSRecords, dnsRecord)


### PR DESCRIPTION
node.Name and node.Spec.HostName could be different with HostName
being the fqdn. This changes to use HostName consistently.

This fixes a few additional things:

- Removes network from fqdn as we seem to define dnsDomain
for every network which has to be unique.
- Sets ansible_host to ctlplane ip as the ansible runner pod
  currently can't resolve the hostnames from the DNS Server.