### PR TITLE
Renaming network related variables to align with edpm naming scheme

### DIFF
--- a/config/samples/dataplane_v1beta1_openstackdataplane.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplane.yaml
@@ -69,8 +69,8 @@ spec:
           #
           # These vars are for the network config templates themselves and are
           # considered EDPM network defaults.
-          neutron_physical_bridge_name: br-ex
-          neutron_public_interface_name: eth0
+          edpm_network_config_bridge_name: br-ex
+          edpm_network_config_interface_name: eth0
           ctlplane_mtu: 1500
           ctlplane_subnet_cidr: 24
           ctlplane_gateway_ip: 192.168.122.1

--- a/config/samples/dataplane_v1beta1_openstackdataplane_baremetal.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplane_baremetal.yaml
@@ -68,8 +68,8 @@ spec:
 
           # These vars are for the network config templates themselves and are
           # considered EDPM network defaults.
-          neutron_physical_bridge_name: br-ex
-          neutron_public_interface_name: eth0
+          edpm_network_config_bridge_name: br-ex
+          edpm_network_config_interface_name: eth0
           ctlplane_mtu: 1500
           ctlplane_subnet_cidr: 24
           ctlplane_gateway_ip: 192.168.111.1

--- a/config/samples/dataplane_v1beta1_openstackdataplane_baremetal_with_ipam.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplane_baremetal_with_ipam.yaml
@@ -64,8 +64,8 @@ spec:
           edpm_network_config_hide_sensitive_logs: false
           # These vars are for the network config templates themselves and are
           # considered EDPM network defaults.
-          neutron_physical_bridge_name: br-ex
-          neutron_public_interface_name: eth0
+          edpm_network_config_bridge_name: br-ex
+          edpm_network_config_interface_name: eth0
           role_networks:
           - InternalApi
           - Storage

--- a/config/samples/dataplane_v1beta1_openstackdataplane_ceph.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplane_ceph.yaml
@@ -102,8 +102,8 @@ spec:
           #
           # These vars are for the network config templates themselves and are
           # considered EDPM network defaults.
-          neutron_physical_bridge_name: br-ex
-          neutron_public_interface_name: eth0
+          edpm_network_config_bridge_name: br-ex
+          edpm_network_config_interface_name: eth0
           ctlplane_mtu: 1500
           ctlplane_subnet_cidr: 24
           ctlplane_gateway_ip: 192.168.122.1

--- a/config/samples/dataplane_v1beta1_openstackdataplane_customnetworks.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplane_customnetworks.yaml
@@ -52,7 +52,7 @@ spec:
                 - ip_netmask:
                     {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
             - type: ovs_bridge
-              name: {{ neutron_physical_bridge_name }}
+              name: {{ edpm_network_config_bridge_name }}
               mtu: 1500
               use_dhcp: false
               dns_servers: {{ ctlplane_dns_nameservers }}
@@ -97,8 +97,8 @@ spec:
           #
           # These vars are for the network config templates themselves and are
           # considered EDPM network defaults.
-          neutron_physical_bridge_name: br-ex
-          neutron_public_interface_name: enp7s0
+          edpm_network_config_bridge_name: br-ex
+          edpm_network_config_interface_name: enp7s0
           ctlplane_mtu: 1500
           ctlplane_subnet_cidr: 24
           ctlplane_gateway_ip: 192.168.1.254

--- a/config/samples/dataplane_v1beta1_openstackdataplanenode_edpm_compute_0_full.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenode_edpm_compute_0_full.yaml
@@ -15,8 +15,8 @@ spec:
       tenant_ip: 192.168.24.100
       edpm_network_config_template: templates/net_config_bridge.j2
       edpm_network_config_hide_sensitive_logs: false
-      neutron_physical_bridge_name: br-ex
-      neutron_public_interface_name: eth0
+      edpm_network_config_bridge_name: br-ex
+      edpm_network_config_interface_name: eth0
       ctlplane_dns_nameservers:
       - 192.168.122.1
       dns_search_domains: []

--- a/config/samples/dataplane_v1beta1_openstackdataplanerole_edpm_compute.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanerole_edpm_compute.yaml
@@ -19,8 +19,8 @@ spec:
     ansibleVars:
       edpm_network_config_template: templates/net_config_bridge.j2
       edpm_network_config_hide_sensitive_logs: false
-      neutron_physical_bridge_name: br-ex
-      neutron_public_interface_name: eth0
+      edpm_network_config_bridge_name: br-ex
+      edpm_network_config_interface_name: eth0
       ctlplane_dns_nameservers:
       - 192.168.122.1
       dns_search_domains: []

--- a/docs/inheritance.md
+++ b/docs/inheritance.md
@@ -134,7 +134,7 @@ metadata:
 spec:
   nodeTemplate:
     ansibleVars:
-      neutron_public_interface_name: eth0
+      edpm_network_config_interface_name: eth0
       edpm_chrony_ntp_servers:
         - clock.redhat.com
         - clock2.redhat.com
@@ -157,7 +157,7 @@ The `ConfigMap` containing the inventory would have the following
 vars:
 
 ```yaml
-      neutron_public_interface_name: eth0
+      edpm_network_config_interface_name: eth0
       tenant_ip: 192.168.24.100
       edpm_chrony_ntp_servers:
         - clock.redhat.com

--- a/tests/kuttl/tests/dataplane-create-test/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-create-test/00-assert.yaml
@@ -61,8 +61,8 @@ spec:
       #
       # These vars are for the network config templates themselves and are
       # considered EDPM network defaults.
-      neutron_physical_bridge_name: br-ex
-      neutron_public_interface_name: eth0
+      edpm_network_config_bridge_name: br-ex
+      edpm_network_config_interface_name: eth0
       ctlplane_mtu: 1500
       ctlplane_subnet_cidr: 24
       ctlplane_gateway_ip: 192.168.122.1
@@ -310,8 +310,8 @@ data:
                 InternalApi: internal_api
                 Storage: storage
                 Tenant: tenant
-            neutron_physical_bridge_name: br-ex
-            neutron_public_interface_name: eth0
+            edpm_network_config_bridge_name: br-ex
+            edpm_network_config_interface_name: eth0
             registry_url: quay.io/podified-antelope-centos9
             role_networks:
                 - InternalApi
@@ -413,8 +413,8 @@ data:
                     InternalApi: internal_api
                     Storage: storage
                     Tenant: tenant
-                neutron_physical_bridge_name: br-ex
-                neutron_public_interface_name: eth0
+                edpm_network_config_bridge_name: br-ex
+                edpm_network_config_interface_name: eth0
                 registry_url: quay.io/podified-antelope-centos9
                 role_networks:
                     - InternalApi
@@ -503,8 +503,8 @@ data:
                     InternalApi: internal_api
                     Storage: storage
                     Tenant: tenant
-                neutron_physical_bridge_name: br-ex
-                neutron_public_interface_name: eth0
+                edpm_network_config_bridge_name: br-ex
+                edpm_network_config_interface_name: eth0
                 registry_url: quay.io/podified-antelope-centos9
                 role_networks:
                     - InternalApi


### PR DESCRIPTION
The variables `neutron_public_interface_name` and `neutron_physical_bridge_name` have been renamed in edpm-ansible collection. This change hasn't been propagated correctly however. Therefore all the other occurrences have to be changed, to make sure that the role will affect deployment as requested.  
 
Please exercise caution while reviewing this PR. There is a considerable chance of new bugs being introduced as side effects.

Depends-On: https://github.com/openstack-k8s-operators/edpm-ansible/pull/201 