### PR TITLE
Fix some issues that delay deployment

### DIFF
--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_configure_network.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_configure_network.yaml
@@ -16,18 +16,18 @@ spec:
     hosts: "all"
     strategy: "linear"
     tasks:
-      - name: "Install edpm_bootstrap"
-        import_role:
-          name: "osp.edpm.edpm_bootstrap"
-          tasks_from: "bootstrap.yml"
-        tags:
-          - "edpm_bootstrap"
       - name: "Grow volumes"
         import_role:
           name: "osp.edpm.edpm_growvols"
           tasks_from: "main.yml"
         tags:
           - "edpm_growvols"
+      - name: "Install edpm_bootstrap"
+        import_role:
+          name: "osp.edpm.edpm_bootstrap"
+          tasks_from: "bootstrap.yml"
+        tags:
+          - "edpm_bootstrap"
       - name: "Install edpm_kernel"
         import_role:
           name: "osp.edpm.edpm_kernel"

--- a/pkg/deployment/baremetal.go
+++ b/pkg/deployment/baremetal.go
@@ -63,6 +63,7 @@ func DeployBaremetalSet(
 						instanceSpec.CtlPlaneIP = res.Address
 						baremetalSet.Spec.CtlplaneGateway = *res.Gateway
 						baremetalSet.Spec.BootstrapDNS = dnsAddresses
+						baremetalSet.Spec.DNSSearchDomains = []string{res.DNSDomain}
 						_, ipNet, err := net.ParseCIDR(res.Cidr)
 						if err == nil {
 							baremetalSet.Spec.CtlplaneNetmask = net.IP(ipNet.Mask).String()

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/01-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/01-assert.yaml
@@ -143,17 +143,17 @@ spec:
     strategy: linear
     tasks:
     - import_role:
-        name: osp.edpm.edpm_bootstrap
-        tasks_from: bootstrap.yml
-      name: Install edpm_bootstrap
-      tags:
-      - edpm_bootstrap
-    - import_role:
         name: osp.edpm.edpm_growvols
         tasks_from: main.yml
       name: Grow volumes
       tags:
       - edpm_growvols
+    - import_role:
+        name: osp.edpm.edpm_bootstrap
+        tasks_from: bootstrap.yml
+      name: Install edpm_bootstrap
+      tags:
+      - edpm_bootstrap
     - import_role:
         name: osp.edpm.edpm_kernel
         tasks_from: main.yml


### PR DESCRIPTION
This fixes a few things:

- Moves edpm_growvols before edpm_bootstrap as we configure swap in edpm_bootstrap and with default volumes there is normally no space left for the 1GB swap needed.
- Use dns search domain from IPSet.