### PR TITLE
Allow to set custom runner image for default services

### DIFF
--- a/api/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
@@ -1086,6 +1086,8 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                 type: object
+              openStackAnsibleEERunnerImage:
+                type: string
               preProvisioned:
                 type: boolean
               services:

--- a/api/bases/dataplane.openstack.org_openstackdataplanes.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplanes.yaml
@@ -2010,6 +2010,8 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                       type: object
+                    openStackAnsibleEERunnerImage:
+                      type: string
                     preProvisioned:
                       type: boolean
                     services:

--- a/api/v1beta1/openstackdataplanerole_types.go
+++ b/api/v1beta1/openstackdataplanerole_types.go
@@ -63,6 +63,10 @@ type OpenStackDataPlaneRoleSpec struct {
 	// +kubebuilder:default={configure-network,validate-network,install-os,configure-os,run-os}
 	// Services list
 	Services []string `json:"services"`
+
+	// +kubebuilder:validation:Optional
+	// OpenStackAnsibleEERunnerImage image to use as the ansibleEE runner image
+	OpenStackAnsibleEERunnerImage string `json:"openStackAnsibleEERunnerImage,omitempty"`
 }
 
 //+kubebuilder:object:root=true
@@ -180,11 +184,12 @@ func (instance OpenStackDataPlaneRole) Validate(nodes []OpenStackDataPlaneNode) 
 // GetAnsibleEESpec - get the fields that will be passed to AEE
 func (instance OpenStackDataPlaneRole) GetAnsibleEESpec() AnsibleEESpec {
 	return AnsibleEESpec{
-		NetworkAttachments: instance.Spec.NetworkAttachments,
-		AnsibleTags:        instance.Spec.DeployStrategy.AnsibleTags,
-		AnsibleLimit:       instance.Spec.DeployStrategy.AnsibleLimit,
-		AnsibleSkipTags:    instance.Spec.DeployStrategy.AnsibleSkipTags,
-		ExtraMounts:        instance.Spec.NodeTemplate.ExtraMounts,
-		Env:                instance.Spec.Env,
+		NetworkAttachments:            instance.Spec.NetworkAttachments,
+		OpenStackAnsibleEERunnerImage: instance.Spec.OpenStackAnsibleEERunnerImage,
+		AnsibleTags:                   instance.Spec.DeployStrategy.AnsibleTags,
+		AnsibleLimit:                  instance.Spec.DeployStrategy.AnsibleLimit,
+		AnsibleSkipTags:               instance.Spec.DeployStrategy.AnsibleSkipTags,
+		ExtraMounts:                   instance.Spec.NodeTemplate.ExtraMounts,
+		Env:                           instance.Spec.Env,
 	}
 }

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
@@ -1086,6 +1086,8 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                 type: object
+              openStackAnsibleEERunnerImage:
+                type: string
               preProvisioned:
                 type: boolean
               services:

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanes.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanes.yaml
@@ -2010,6 +2010,8 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                       type: object
+                    openStackAnsibleEERunnerImage:
+                      type: string
                     preProvisioned:
                       type: boolean
                     services:

--- a/controllers/openstackdataplane_controller.go
+++ b/controllers/openstackdataplane_controller.go
@@ -375,6 +375,7 @@ func createOrPatchDataPlaneRoles(ctx context.Context,
 			role.Spec.DataPlane = instance.Name
 			role.Spec.NodeTemplate = roleSpec.NodeTemplate
 			role.Spec.NetworkAttachments = roleSpec.NetworkAttachments
+			role.Spec.OpenStackAnsibleEERunnerImage = roleSpec.OpenStackAnsibleEERunnerImage
 			role.Spec.Env = roleSpec.Env
 			role.Spec.Services = roleSpec.Services
 			hostMap, ok := roleManagedHostMap[roleName]

--- a/docs/openstack_dataplanerole.md
+++ b/docs/openstack_dataplanerole.md
@@ -122,5 +122,6 @@ OpenStackDataPlaneRoleSpec defines the desired state of OpenStackDataPlaneRole
 | deployStrategy | DeployStrategy section to control how the node is deployed | [DeployStrategySection](#deploystrategysection) | false |
 | networkAttachments | NetworkAttachments is a list of NetworkAttachment resource names to pass to the ansibleee resource which allows to connect the ansibleee runner to the given network | []string | false |
 | services | Services list | []string | true |
+| openStackAnsibleEERunnerImage | OpenStackAnsibleEERunnerImage image to use as the ansibleEE runner image | string | false |
 
 [Back to Custom Resources](#custom-resources)

--- a/pkg/deployment/service.go
+++ b/pkg/deployment/service.go
@@ -148,6 +148,9 @@ func EnsureServices(ctx context.Context, helper *helper.Helper, instance *datapl
 			},
 		}
 		_, err = controllerutil.CreateOrPatch(ctx, helper.GetClient(), ensureService, func() error {
+			if len(instance.Spec.OpenStackAnsibleEERunnerImage) > 0 {
+				serviceObjSpec.OpenStackAnsibleEERunnerImage = instance.Spec.OpenStackAnsibleEERunnerImage
+			}
 			ensureService.Spec = *serviceObjSpec
 			return nil
 		})


### PR DESCRIPTION
With [1] default Services are automatically created as part of role reconcile and since then the only way to use custom runner image for these default Services is by patching openstack-ansibleee-operator csv and that applies default settings globally.

This patch allows the default services to use custom runner image per role.

[1] https://github.com/openstack-k8s-operators/dataplane-operator/pull/236