### PR TITLE
Removing imports of tasks from main, as that is the default behavior

### DIFF
--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_configure_network.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_configure_network.yaml
@@ -19,7 +19,6 @@ spec:
       - name: "Grow volumes"
         import_role:
           name: "osp.edpm.edpm_growvols"
-          tasks_from: "main.yml"
         tags:
           - "edpm_growvols"
       - name: "Install edpm_bootstrap"
@@ -31,13 +30,11 @@ spec:
       - name: "Install edpm_kernel"
         import_role:
           name: "osp.edpm.edpm_kernel"
-          tasks_from: "main.yml"
         tags:
           - "edpm_kernel"
       - name: "Import edpm_tuned"
         import_role:
           name: "osp.edpm.edpm_tuned"
-          tasks_from: "main.yml"
         tags:
           - "edpm_tuned"
       - name: "Configure Kernel Args"
@@ -49,6 +46,5 @@ spec:
       - name: "import edpm_network_config"
         import_role:
           name: "osp.edpm.edpm_network_config"
-          tasks_from: "main.yml"
         tags:
           - "edpm_network_config"

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_configure_os.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_configure_os.yaml
@@ -55,7 +55,6 @@ spec:
       - name: "Configure edpm_ssh_known_hosts"
         import_role:
           name: "osp.edpm.edpm_ssh_known_hosts"
-          tasks_from: "main.yml"
         tags:
           - "edpm_ssh_known_hosts"
       - name: "Configure edpm_logrotate_crond"

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_install_os.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_install_os.yaml
@@ -19,7 +19,6 @@ spec:
       - name: "Install edpm_kernel"
         import_role:
           name: "osp.edpm.edpm_kernel"
-          tasks_from: "main.yml"
         tags:
           - "edpm_kernel"
       - name: "Install edpm_podman"

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_validate_network.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_validate_network.yaml
@@ -18,6 +18,5 @@ spec:
       - name: "import edpm_nodes_validation"
         import_role:
           name: "osp.edpm.edpm_nodes_validation"
-          tasks_from: "main.yml"
         tags:
           - "edpm_nodes_validation"

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/01-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/01-assert.yaml
@@ -144,7 +144,6 @@ spec:
     tasks:
     - import_role:
         name: osp.edpm.edpm_growvols
-        tasks_from: main.yml
       name: Grow volumes
       tags:
       - edpm_growvols
@@ -156,13 +155,11 @@ spec:
       - edpm_bootstrap
     - import_role:
         name: osp.edpm.edpm_kernel
-        tasks_from: main.yml
       name: Install edpm_kernel
       tags:
       - edpm_kernel
     - import_role:
         name: osp.edpm.edpm_tuned
-        tasks_from: main.yml
       name: Import edpm_tuned
       tags:
       - edpm_tuned
@@ -174,7 +171,6 @@ spec:
       - edpm_kernel
     - import_role:
         name: osp.edpm.edpm_network_config
-        tasks_from: main.yml
       name: import edpm_network_config
       tags:
       - edpm_network_config
@@ -243,7 +239,6 @@ spec:
     tasks:
     - import_role:
         name: osp.edpm.edpm_nodes_validation
-        tasks_from: main.yml
       name: import edpm_nodes_validation
   uid: 1001
 status:
@@ -316,7 +311,6 @@ spec:
       - edpm_bootstrap
     - import_role:
         name: osp.edpm.edpm_kernel
-        tasks_from: main.yml
       name: Install edpm_kernel
       tags:
       - edpm_kernel
@@ -465,7 +459,6 @@ spec:
     - name: Configure edpm_ssh_known_hosts
       import_role:
         name: osp.edpm.edpm_ssh_known_hosts
-        tasks_from: main.yml
       tags:
         - edpm_ssh_known_hosts
     - name: Configure edpm_logrotate_crond


### PR DESCRIPTION
The import_role module uses "main" as a default for the tasks_from parameter. Therefore there is not need to explicitly request it.

https://docs.ansible.com/ansible/latest/collections/ansible/builtin/include_role_module.html#parameter-tasks_from