### PR TITLE
Don't keep CtlPlaneNetwork in pre-provisioned IPSet

### DIFF
--- a/pkg/deployment/ipam.go
+++ b/pkg/deployment/ipam.go
@@ -201,6 +201,14 @@ func reserveIPs(ctx context.Context, helper *helper.Helper,
 		if len(nets) == 0 {
 			nets = instance.Spec.NodeTemplate.Networks
 		}
+		if instance.Spec.PreProvisioned {
+			// Drop CtlPlaneNetwork
+			for i, v := range nets {
+				if v.Name == CtlPlaneNetwork {
+					nets = append(nets[:i], nets[i+1:]...)
+				}
+			}
+		}
 		if len(nets) > 0 {
 			util.LogForObject(helper, "Reconciling IPSet", instance)
 			ipSet := &infranetworkv1.IPSet{


### PR DESCRIPTION
For pre-provisioned nodes ignore CtlPlaneNetwork when creating IPSet.