### PR TITLE
Update Role sample for networkConfig template

### DIFF
--- a/config/samples/dataplane_v1beta1_openstackdataplanerole.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanerole.yaml
@@ -11,7 +11,51 @@ spec:
     - run-os
   nodeTemplate:
     networkConfig:
-      template: templates/net_config_bridge.j2
+      template: |
+        ---
+        network_config:
+        - type: interface
+          name: nic2
+          mtu: 1500
+          addresses:
+            - ip_netmask:
+                {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+        - type: ovs_bridge
+          name: {{ neutron_physical_bridge_name }}
+          mtu: 1500
+          use_dhcp: false
+          dns_servers: {{ ctlplane_dns_nameservers }}
+          domain: []
+          addresses:
+          - ip_netmask: {{ lookup('vars', networks_lower["External"] ~ '_ip') }}/{{ lookup('vars', networks_lower["External"] ~ '_cidr') }}
+          routes: [{'ip_netmask': '0.0.0.0/0', 'next_hop': '192.168.1.254'}]
+          members:
+          - type: interface
+            name: nic1
+            mtu: 1500
+            # force the MAC address of the bridge to this interface
+            primary: true
+          - type: vlan
+            mtu: 1500
+            vlan_id: 20
+            addresses:
+            - ip_netmask:
+                172.17.0.101/24
+            routes: []
+          - type: vlan
+            mtu: 1500
+            vlan_id: 25
+            addresses:
+            - ip_netmask:
+                172.18.0.101/24
+            routes: []
+          - type: vlan
+            mtu: 1500
+            vlan_id: 22
+            addresses:
+            - ip_netmask:
+                172.19.0.101/24
+            routes: []
     managed: false
     managementNetwork: ctlplane
     ansibleUser: root


### PR DESCRIPTION
We changed the way we handle networkConfig to allow for users to provide a jinja2 formatted template in the spec:
https://github.com/openstack-k8s-operators/dataplane-operator/commit/5c635f6e18b22455887c38661a46c8db15d096a8

This change is updating the role sample file to correct the usage of the networkConfig.template section.