### PR TITLE
Add finalizers for controllers

### DIFF
--- a/controllers/openstackdataplanerole_controller.go
+++ b/controllers/openstackdataplanerole_controller.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -139,6 +140,13 @@ func (r *OpenStackDataPlaneRoleReconciler) Reconcile(ctx context.Context, req ct
 		}
 	}()
 
+	// If the service object doesn't have our finalizer, add it.
+	controllerutil.AddFinalizer(instance, helper.GetFinalizer())
+	// Register the finalizer immediately to avoid orphaning resources on delete
+	if err := r.Update(ctx, instance); err != nil {
+		return ctrl.Result{}, err
+	}
+
 	// Initialize Status
 	if instance.Status.Conditions == nil {
 		instance.InitConditions()
@@ -149,6 +157,11 @@ func (r *OpenStackDataPlaneRoleReconciler) Reconcile(ctx context.Context, req ct
 
 	if instance.Status.Conditions.IsUnknown(dataplanev1.SetupReadyCondition) {
 		instance.Status.Conditions.MarkFalse(dataplanev1.SetupReadyCondition, condition.RequestedReason, condition.SeverityInfo, condition.ReadyInitMessage)
+	}
+
+	// Handle service delete
+	if !instance.DeletionTimestamp.IsZero() {
+		return r.reconcileDelete(ctx, instance, helper)
 	}
 
 	// Ensure Services
@@ -351,4 +364,14 @@ func (r *OpenStackDataPlaneRoleReconciler) SetupWithManager(mgr ctrl.Manager) er
 		Watches(&source.Kind{Type: &infranetworkv1.DNSMasq{}},
 			reconcileFunction).
 		Complete(r)
+}
+
+func (r *OpenStackDataPlaneRoleReconciler) reconcileDelete(ctx context.Context, instance *dataplanev1.OpenStackDataPlaneRole, helper *helper.Helper) (ctrl.Result, error) {
+	r.Log.Info("Reconciling Service delete")
+
+	// Service is deleted so remove the finalizer.
+	controllerutil.RemoveFinalizer(instance, helper.GetFinalizer())
+	r.Log.Info("Reconciled Service delete successfully")
+
+	return ctrl.Result{}, nil
 }

--- a/tests/functional/openstackdataplane_controller_test.go
+++ b/tests/functional/openstackdataplane_controller_test.go
@@ -60,5 +60,12 @@ var _ = Describe("Dataplane Test", func() {
 			Expect(dataplaneRoleInstance.Spec.DeployStrategy.Deploy).Should(BeFalse())
 			Expect(dataplaneRoleInstance.Spec.NodeTemplate.AnsibleSSHPrivateKeySecret).Should(Equal("dataplane-ansible-ssh-private-key-secret"))
 		})
+		It("dataplane should have a finalizer", func() {
+			// the reconciler loop adds the finalizer so we have to wait for
+			// it to run
+			Eventually(func() []string {
+				return GetDataplane(dataplaneName).Finalizers
+			}, timeout, interval).Should(ContainElement("OpenStackDataPlane"))
+		})
 	})
 })

--- a/tests/functional/openstackdataplanerole_controller_test.go
+++ b/tests/functional/openstackdataplanerole_controller_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 package functional
 
 import (
-	"fmt"
 	"os"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -47,7 +46,6 @@ var _ = Describe("Dataplane Role Test", func() {
 
 		It("should have the Status fields initialized", func() {
 			dataplaneRoleInstance := GetDataplaneRole(dataplaneRoleName)
-			fmt.Printf("DataPlaneRoleInstance: %+v", dataplaneRoleInstance)
 			Expect(dataplaneRoleInstance.Status.Deployed).Should(BeFalse())
 		})
 	})


### PR DESCRIPTION
None of the controllers currently use finalizers. This changes adds the finalizers and handling required for them within the deletion process.