### PR TITLE
Fix dataplane status when roles aren't found

### DIFF
--- a/controllers/openstackdataplane_controller.go
+++ b/controllers/openstackdataplane_controller.go
@@ -157,6 +157,10 @@ func (r *OpenStackDataPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 		if err != nil {
 			return ctrl.Result{}, err
 		}
+		r.Log.Info("found roles", "total", len(roles.Items))
+		if len(instance.Spec.Roles) > len(roles.Items) {
+			shouldRequeue = true
+		}
 
 		for _, role := range roles.Items {
 			logger.Info("DataPlane deploy", "role.Name", role.Name)

--- a/controllers/openstackdataplanerole_controller.go
+++ b/controllers/openstackdataplanerole_controller.go
@@ -189,6 +189,7 @@ func (r *OpenStackDataPlaneRoleReconciler) Reconcile(ctx context.Context, req ct
 	if err != nil {
 		return ctrl.Result{}, err
 	}
+	r.Log.Info("found nodes", "total", len(nodes.Items))
 
 	// Order the nodes based on Name
 	sort.SliceStable(nodes.Items, func(i, j int) bool {

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/00-dataplane-create.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/00-dataplane-create.yaml
@@ -9,9 +9,9 @@ spec:
     edpm-compute-no-nodes:
       nodeTemplate:
         ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
-        services:
-          - configure-network
-          - validate-network
-          - install-os
-          - configure-os
-          - run-os
+      services:
+        - configure-network
+        - validate-network
+        - install-os
+        - configure-os
+        - run-os

--- a/tests/kuttl/tests/dataplane-service-custom-image/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-service-custom-image/00-assert.yaml
@@ -29,7 +29,6 @@ status:
     reason: Ready
     status: "True"
     type: SetupReady
-  deployed: true
 ---
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneRole


### PR DESCRIPTION
Currently, dataplane is set to ready when the roles aren't in place yet 

closes #250