### PR TITLE
Add ability to override OpenStackDataPlane spec

### DIFF
--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -10,40 +10,6 @@ import (
 	dataplanev1 "github.com/openstack-k8s-operators/dataplane-operator/api/v1beta1"
 )
 
-func DefaultDataplaneNoNodesTemplate(name types.NamespacedName) *dataplanev1.OpenStackDataPlane {
-	return &dataplanev1.OpenStackDataPlane{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "dataplane.openstack.org/v1beta1",
-			Kind:       "OpenStackDataPlane",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name.Name,
-			Namespace: name.Namespace,
-		},
-		Spec: dataplanev1.OpenStackDataPlaneSpec{
-			DeployStrategy: dataplanev1.DeployStrategySection{
-				Deploy: false,
-			},
-			Roles: map[string]dataplanev1.OpenStackDataPlaneRoleSpec{
-				"edpm-compute-no-nodes": {
-					Services: []string{"configure-network", "validate-network", "install-os", "configure-os", "run-os"},
-					NodeTemplate: dataplanev1.NodeSection{
-						AnsibleSSHPrivateKeySecret: "dataplane-ansible-ssh-private-key-secret",
-					},
-				},
-			},
-		},
-	}
-}
-
-func CreateDataplaneNoNodes(name types.NamespacedName) *dataplanev1.OpenStackDataPlane {
-	instance := DefaultDataplaneNoNodesTemplate(name)
-	err := k8sClient.Create(ctx, instance)
-	Expect(err).NotTo(HaveOccurred())
-
-	return instance
-}
-
 func DefaultDataplaneRoleNoNodesTemplate(name types.NamespacedName) *dataplanev1.OpenStackDataPlaneRole {
 	return &dataplanev1.OpenStackDataPlaneRole{
 		TypeMeta: metav1.TypeMeta{
@@ -70,7 +36,7 @@ func CreateDataplaneRoleNoNodes(name types.NamespacedName) *dataplanev1.OpenStac
 	return instance
 }
 
-func GetDefaultDataplaneSpec() dataplanev1.OpenStackDataPlaneSpec {
+func DefaultDataPlaneSpec() dataplanev1.OpenStackDataPlaneSpec {
 	return dataplanev1.OpenStackDataPlaneSpec{
 		DeployStrategy: dataplanev1.DeployStrategySection{
 			Deploy: false,
@@ -100,10 +66,12 @@ func DefaultDataPlane(name types.NamespacedName, spec dataplanev1.OpenStackDataP
 	}
 }
 
-func CreateDataPlane(name types.NamespacedName, spec *dataplanev1.OpenStackDataPlaneSpec) {
-	instance := DefaultDataPlane(name, GetDefaultDataplaneSpec())
+func CreateDataPlane(name types.NamespacedName, spec dataplanev1.OpenStackDataPlaneSpec) *dataplanev1.OpenStackDataPlane {
+	instance := DefaultDataPlane(name, spec)
 	err := k8sClient.Create(ctx, instance)
 	Expect(err).NotTo(HaveOccurred())
+
+	return instance
 }
 
 func GetDataplane(name types.NamespacedName) *dataplanev1.OpenStackDataPlane {

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -70,6 +70,42 @@ func CreateDataplaneRoleNoNodes(name types.NamespacedName) *dataplanev1.OpenStac
 	return instance
 }
 
+func GetDefaultDataplaneSpec() dataplanev1.OpenStackDataPlaneSpec {
+	return dataplanev1.OpenStackDataPlaneSpec{
+		DeployStrategy: dataplanev1.DeployStrategySection{
+			Deploy: false,
+		},
+		Roles: map[string]dataplanev1.OpenStackDataPlaneRoleSpec{
+			"edpm-compute-no-nodes": {
+				Services: []string{"configure-network", "validate-network", "install-os", "configure-os", "run-os"},
+				NodeTemplate: dataplanev1.NodeSection{
+					AnsibleSSHPrivateKeySecret: "dataplane-ansible-ssh-private-key-secret",
+				},
+			},
+		},
+	}
+}
+
+func DefaultDataPlane(name types.NamespacedName, spec dataplanev1.OpenStackDataPlaneSpec) *dataplanev1.OpenStackDataPlane {
+	return &dataplanev1.OpenStackDataPlane{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "dataplane.openstack.org/v1beta1",
+			Kind:       "OpenStackDataPlane",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name.Name,
+			Namespace: name.Namespace,
+		},
+		Spec: spec,
+	}
+}
+
+func CreateDataPlane(name types.NamespacedName, spec *dataplanev1.OpenStackDataPlaneSpec) {
+	instance := DefaultDataPlane(name, GetDefaultDataplaneSpec())
+	err := k8sClient.Create(ctx, instance)
+	Expect(err).NotTo(HaveOccurred())
+}
+
 func GetDataplane(name types.NamespacedName) *dataplanev1.OpenStackDataPlane {
 	instance := &dataplanev1.OpenStackDataPlane{}
 	gomega.Eventually(func(g gomega.Gomega) error {

--- a/tests/functional/openstackdataplane_controller_test.go
+++ b/tests/functional/openstackdataplane_controller_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Dataplane Test", func() {
 
 	When("A Dataplane resorce is created", func() {
 		BeforeEach(func() {
-			DeferCleanup(th.DeleteInstance, CreateDataplaneNoNodes(dataplaneName))
+			DeferCleanup(th.DeleteInstance, CreateDataPlane(dataplaneName, DefaultDataPlaneSpec()))
 		})
 		It("should have the Spec fields initialized", func() {
 			dataplaneInstance := GetDataplane(dataplaneName)


### PR DESCRIPTION
This change adds a new method for overriding `OpenStackDataPlaneSpec` and removed duplicated logic to simplify the envtest implementation. This will increase the flexibility of these methods and allow for a greater range of scenarios to be tested without the need to introduce duplicated blocks of code.