### PR TITLE
Ensure InputReady condition for role/node

### DIFF
--- a/api/v1beta1/conditions.go
+++ b/api/v1beta1/conditions.go
@@ -128,4 +128,7 @@ const (
 
 	// RoleDNSDataReadyErrorMessage error
 	RoleDNSDataReadyErrorMessage = "RoleDNSDataReady error occurred"
+
+	// InputReadyWaitingMessage not yet ready
+	InputReadyWaitingMessage = "Waiting for input %s, not yet ready"
 )

--- a/api/v1beta1/openstackdataplanenode_types.go
+++ b/api/v1beta1/openstackdataplanenode_types.go
@@ -96,6 +96,7 @@ func (instance *OpenStackDataPlaneNode) InitConditions(instanceRole *OpenStackDa
 
 	cl := condition.CreateList(
 		condition.UnknownCondition(condition.DeploymentReadyCondition, condition.InitReason, condition.InitReason),
+		condition.UnknownCondition(condition.InputReadyCondition, condition.InitReason, condition.InitReason),
 		condition.UnknownCondition(SetupReadyCondition, condition.InitReason, condition.InitReason),
 	)
 

--- a/api/v1beta1/openstackdataplanerole_types.go
+++ b/api/v1beta1/openstackdataplanerole_types.go
@@ -105,6 +105,7 @@ func (instance *OpenStackDataPlaneRole) InitConditions() {
 
 	cl := condition.CreateList(
 		condition.UnknownCondition(condition.DeploymentReadyCondition, condition.InitReason, condition.InitReason),
+		condition.UnknownCondition(condition.InputReadyCondition, condition.InitReason, condition.InitReason),
 		condition.UnknownCondition(SetupReadyCondition, condition.InitReason, condition.InitReason),
 		condition.UnknownCondition(RoleBareMetalProvisionReadyCondition, condition.InitReason, condition.InitReason),
 		condition.UnknownCondition(RoleIPReservationReadyCondition, condition.InitReason, condition.InitReason),

--- a/config/manifests/bases/dataplane-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/dataplane-operator.clusterserviceversion.yaml
@@ -28,7 +28,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:number
       - description: 'AnsibleSSHPrivateKeySecret Private SSH Key secret containing
           private SSH key for connecting to node. Must be of the form: Secret.data.ssh-privatekey:
-          <base64 encoded private key contents> https://kubernetes.io/docs/concepts/configuration/secret/#ssh-authentication-secrets'
+          <base64 encoded private key contents> <https://kubernetes.io/docs/concepts/configuration/secret/#ssh-authentication-secrets>'
         displayName: Ansible SSHPrivate Key Secret
         path: node.ansibleSSHPrivateKeySecret
         x-descriptors:
@@ -63,7 +63,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:number
       - description: 'AnsibleSSHPrivateKeySecret Private SSH Key secret containing
           private SSH key for connecting to node. Must be of the form: Secret.data.ssh-privatekey:
-          <base64 encoded private key contents> https://kubernetes.io/docs/concepts/configuration/secret/#ssh-authentication-secrets'
+          <base64 encoded private key contents> <https://kubernetes.io/docs/concepts/configuration/secret/#ssh-authentication-secrets>'
         displayName: Ansible SSHPrivate Key Secret
         path: nodeTemplate.ansibleSSHPrivateKeySecret
         x-descriptors:
@@ -108,7 +108,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:number
       - description: 'AnsibleSSHPrivateKeySecret Private SSH Key secret containing
           private SSH key for connecting to node. Must be of the form: Secret.data.ssh-privatekey:
-          <base64 encoded private key contents> https://kubernetes.io/docs/concepts/configuration/secret/#ssh-authentication-secrets'
+          <base64 encoded private key contents> <https://kubernetes.io/docs/concepts/configuration/secret/#ssh-authentication-secrets>'
         displayName: Ansible SSHPrivate Key Secret
         path: nodes.node.ansibleSSHPrivateKeySecret
         x-descriptors:
@@ -125,7 +125,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:number
       - description: 'AnsibleSSHPrivateKeySecret Private SSH Key secret containing
           private SSH key for connecting to node. Must be of the form: Secret.data.ssh-privatekey:
-          <base64 encoded private key contents> https://kubernetes.io/docs/concepts/configuration/secret/#ssh-authentication-secrets'
+          <base64 encoded private key contents> <https://kubernetes.io/docs/concepts/configuration/secret/#ssh-authentication-secrets>'
         displayName: Ansible SSHPrivate Key Secret
         path: roles.nodeTemplate.ansibleSSHPrivateKeySecret
         x-descriptors:

--- a/config/samples/dataplane_v1beta1_openstackdataplane.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplane.yaml
@@ -41,14 +41,6 @@ spec:
           value: "True"
         - name: ANSIBLE_ENABLE_TASK_DEBUGGER
           value: "True"
-      baremetalSetTemplate:
-        deploymentSSHSecret: dataplane-ansible-ssh-private-key-secret
-        ctlplaneInterface: enp1s0
-        provisionServerName: openstackprovisionserver
-        ctlplaneGateway: 172.22.0.3
-        ctlplaneNetmask: 255.255.255.0
-        bmhNamespace: openstack
-        domainName: osptest.openstack.org
       preProvisioned: true
       services:
         - configure-network

--- a/pkg/deployment/baremetal.go
+++ b/pkg/deployment/baremetal.go
@@ -68,7 +68,10 @@ func DeployBaremetalSet(
 				}
 			}
 			baremetalSet.Spec.BaremetalHosts[node.Spec.HostName] = instanceSpec
-
+			commonSecret := instance.Spec.NodeTemplate.AnsibleSSHPrivateKeySecret
+			if baremetalSet.Spec.DeploymentSSHSecret == "" {
+				baremetalSet.Spec.DeploymentSSHSecret = commonSecret
+			}
 		}
 		err := controllerutil.SetControllerReference(
 			helper.GetBeforeObject(), baremetalSet, helper.GetScheme())

--- a/tests/kuttl/tests/dataplane-create-test/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-create-test/00-assert.yaml
@@ -141,6 +141,10 @@ status:
     severity: Info
     status: "False"
     type: DeploymentReady
+  - message: Input data complete
+    reason: Ready
+    status: "True"
+    type: InputReady
   - message: Init
     reason: Init
     status: Unknown
@@ -217,6 +221,10 @@ status:
     severity: Info
     status: "False"
     type: DeploymentReady
+  - message: Input data complete
+    reason: Ready
+    status: "True"
+    type: InputReady
   - message: Setup complete
     reason: Ready
     status: "True"
@@ -281,6 +289,10 @@ status:
     severity: Info
     status: "False"
     type: DeploymentReady
+  - message: Input data complete
+    reason: Ready
+    status: "True"
+    type: InputReady
   - message: Setup complete
     reason: Ready
     status: "True"

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/00-assert.yaml
@@ -65,6 +65,10 @@ status:
     severity: Info
     status: "False"
     type: DeploymentReady
+  - message: Input data complete
+    reason: Ready
+    status: "True"
+    type: InputReady
   - message: Init
     reason: Init
     status: Unknown

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/01-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/01-assert.yaml
@@ -50,6 +50,10 @@ status:
     reason: Ready
     status: "True"
     type: DeploymentReady
+  - message: Input data complete
+    reason: Ready
+    status: "True"
+    type: InputReady
   - message: NovaComputeReady ready
     reason: Ready
     status: "True"

--- a/tests/kuttl/tests/dataplane-service-custom-image/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-service-custom-image/00-assert.yaml
@@ -64,6 +64,10 @@ status:
     severity: Info
     status: "False"
     type: DeploymentReady
+  - message: Input data complete
+    reason: Ready
+    status: "True"
+    type: InputReady
   - message: Init
     reason: Init
     status: Unknown


### PR DESCRIPTION
We don't have a condition to ensure that inputs are ready for the role/node. This adds it and ensures that we check all required keys in the secret.