### PR TITLE
Remove DeleteNamespaces function

### DIFF
--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -3,7 +3,6 @@ package functional
 import (
 	"github.com/onsi/gomega"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -90,13 +89,4 @@ func GetDataplaneRole(name types.NamespacedName) *dataplanev1.OpenStackDataPlane
 		return nil
 	}, timeout, interval).Should(Succeed())
 	return instance
-}
-
-func DeleteNamespace(name string) {
-	ns := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-		},
-	}
-	gomega.Expect(k8sClient.Delete(ctx, ns)).Should(gomega.Succeed())
 }


### PR DESCRIPTION
We are using the test-helpers DeleteNamespace function: https://github.com/openstack-k8s-operators/lib-common/blob/db7193b646f229eed2a06d46a1f6326734a4281c/modules/common/test/helpers/namespace.go#L52-L59

We don't need to duplicate this function in our base_test. This change removes our implementation.