### PR TITLE
Only mark SetupCondition after resources created

### DIFF
--- a/controllers/openstackdataplane_controller.go
+++ b/controllers/openstackdataplane_controller.go
@@ -125,15 +125,15 @@ func (r *OpenStackDataPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 		instance.Status.Conditions.MarkFalse(dataplanev1.SetupReadyCondition, condition.RequestedReason, condition.SeverityInfo, condition.ReadyInitMessage)
 	}
 
-	// all setup tasks complete, mark SetupReadyCondition True
-	instance.Status.Conditions.MarkTrue(dataplanev1.SetupReadyCondition, condition.ReadyMessage)
-
 	ctrlResult, err := createOrPatchDataPlaneResources(ctx, instance, helper)
 	if err != nil {
 		return ctrl.Result{}, err
 	} else if (ctrlResult != ctrl.Result{}) {
 		return ctrlResult, nil
 	}
+
+	// all setup tasks complete, mark SetupReadyCondition True
+	instance.Status.Conditions.MarkTrue(dataplanev1.SetupReadyCondition, condition.ReadyMessage)
 
 	var deployErrors []string
 	shouldRequeue := false


### PR DESCRIPTION
We currently always set the SetupCondition to True regardless of anything else. This change moves the declaration for Marktrue to be after the createOrPathDataPlaneResources() function. This way we only set SetupComplete if the dataplane resources were configured without error.