### PR TITLE
Ensure that all nodes are in SetupReady state before starting deploy

### DIFF
--- a/api/v1beta1/openstackdataplanenode_types.go
+++ b/api/v1beta1/openstackdataplanenode_types.go
@@ -85,9 +85,14 @@ func init() {
 	SchemeBuilder.Register(&OpenStackDataPlaneNode{}, &OpenStackDataPlaneNodeList{})
 }
 
-// IsReady - returns true if the DataPlane is ready
+// IsReady - returns true if the DataPlaneNode is ready
 func (instance OpenStackDataPlaneNode) IsReady() bool {
 	return instance.Status.Conditions.IsTrue(condition.DeploymentReadyCondition)
+}
+
+// IsSetupReady - returns true if the DataPlaneNode is ready to be deployed
+func (instance OpenStackDataPlaneNode) IsSetupReady() bool {
+	return instance.Status.Conditions.IsTrue(SetupReadyCondition)
 }
 
 // InitConditions - Initializes Status Conditons

--- a/controllers/openstackdataplanerole_controller.go
+++ b/controllers/openstackdataplanerole_controller.go
@@ -266,6 +266,18 @@ func (r *OpenStackDataPlaneRoleReconciler) Reconcile(ctx context.Context, req ct
 		}
 	}
 
+	// Ensure all nodes are in SetupReady state
+	setupReadyNodes := 0
+	for _, node := range nodes.Items {
+		if node.IsSetupReady() {
+			setupReadyNodes++
+		}
+	}
+
+	if setupReadyNodes < len(nodes.Items) {
+		return ctrl.Result{}, err
+	}
+
 	// Generate Role Inventory
 	roleConfigMap, err := deployment.GenerateRoleInventory(ctx, helper, instance,
 		nodes.Items, allIPSets, dnsAddresses)


### PR DESCRIPTION
All nodes should be in SetupReady state before the generation of the `roleConfigMap`, otherwise the first osaee service job will start leaving few nodes out of its inventory.

Here's an example of an inventory extracted from a `setup-repo` (the first osaee service) pod during its execution on 20 nodes:

```
$ ansible -i /tmp/hosts --list-hosts all
[WARNING]: Invalid characters were found in group names but not replaced, use -vvvv to see details
  hosts (16):
    edpm-compute-0
    edpm-compute-1
    edpm-compute-2
    edpm-compute-3
    edpm-compute-4
    edpm-compute-5
    edpm-compute-6
    edpm-compute-7
    edpm-compute-10
    edpm-compute-11
    edpm-compute-12
    edpm-compute-13
    edpm-compute-14
    edpm-compute-15
    edpm-compute-16
    edpm-compute-18
```