### PR TITLE
Remove config/manager/kustomization.yaml from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ testbin/*
 bundle/*
 bundle.Dockerfile
 custom-bundle.Dockerfile.pinned
-config/manager/kustomization.yaml
 
 # Test binary, build with `go test -c`
 *.test


### PR DESCRIPTION
This file is required to build a bundle image. The file is actually maintained in the repository.