### PR TITLE
Avoid bumping our own api package version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,12 @@
   "constraints": {
     "go": "1.19"
   },
+  "packageRules": [
+     {
+       "matchPackageNames": ["github.com/openstack-k8s-operators/dataplane-operator/api"],
+       "enabled": false
+     }
+   ],
   "postUpgradeTasks": {
     "commands": ["make gowork", "make tidy", "make manifests generate"],
     "fileFilters": ["**/go.mod", "**/go.sum", "**/*.go", "**/*.yaml"],


### PR DESCRIPTION
This change excludes dataplane-operator/api from auto updates with renovate bot. This will avoid auto PR's moving us to v0.1.0.