### PR TITLE
Add $SKIP_FIREWALL

### DIFF
--- a/hack/configure_local_webhook.sh
+++ b/hack/configure_local_webhook.sh
@@ -5,10 +5,13 @@ TMPDIR=${TMPDIR:-"/tmp/k8s-webhook-server/serving-certs"}
 SKIP_CERT=${SKIP_CERT:-false}
 CRC_IP=${CRC_IP:-$(/sbin/ip -o -4 addr list crc | awk '{print $4}' | cut -d/ -f1)}
 FIREWALL_ZONE=${FIREWALL_ZONE:-"libvirt"}
+SKIP_FIREWALL=${SKIP_FIREWALL:-false}
 
-#Open 9443
-sudo firewall-cmd --zone=${FIREWALL_ZONE} --add-port=9443/tcp
-sudo firewall-cmd --runtime-to-permanent
+if [ "$SKIP_FIREWALL" = false ] ; then
+    #Open 9443
+    sudo firewall-cmd --zone=${FIREWALL_ZONE} --add-port=9443/tcp
+    sudo firewall-cmd --runtime-to-permanent
+fi
 
 # Generate the certs and the ca bundle
 if [ "$SKIP_CERT" = false ] ; then


### PR DESCRIPTION
firewall-cmd is distro dependent, so it can be skipped in some cases
with SKIP_FIREWALL=true.

SKIP_FIREWALL=true make run-with-webhooks

This matches functionality from other operators (nova-operator).

Signed-off-by: James Slagle <jslagle@redhat.com>
