### PR TITLE
Don't drop ctlplane network for pre-provisioned

### DIFF
--- a/pkg/deployment/ipam.go
+++ b/pkg/deployment/ipam.go
@@ -193,14 +193,6 @@ func reserveIPs(ctx context.Context, helper *helper.Helper,
 		if len(nets) == 0 {
 			nets = instance.Spec.NodeTemplate.Networks
 		}
-		if instance.Spec.PreProvisioned {
-			// Drop CtlPlaneNetwork
-			for i, v := range nets {
-				if v.Name == CtlPlaneNetwork {
-					nets = append(nets[:i], nets[i+1:]...)
-				}
-			}
-		}
 		if len(nets) > 0 {
 			util.LogForObject(helper, "Reconciling IPSet", instance)
 			ipSet := &infranetworkv1.IPSet{


### PR DESCRIPTION
This was earlier added to make the CI jobs pass, now that you can specify the ctlplane network with fixedIP, this can be dropped.