### PR TITLE
Update nic-config samples and docs

### DIFF
--- a/config/samples/dataplane_v1beta1_openstackdataplane.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplane.yaml
@@ -54,6 +54,40 @@ spec:
         ansibleUser: root
         ansiblePort: 22
         ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
+        networkConfig:
+          template: |
+              ---
+              {% set control_virtual_ip = net_vip_map.ctlplane %}
+              {% set public_virtual_ip = vip_port_map.external.ip_address %}
+              {% if ':' in control_virtual_ip %}
+              {%   set control_virtual_cidr = 128 %}
+              {% else %}
+              {%   set control_virtual_cidr = 32 %}
+              {%   endif %}
+              {% if ':' in public_virtual_ip %}
+              {%   set public_virtual_cidr = 128 %}
+              {% else %}
+              {%   set public_virtual_cidr = 32 %}
+              {%   endif %}
+              network_config:
+              - type: ovs_bridge
+                name: br-ctlplane
+                use_dhcp: false
+                mtu: {{ ctlplane_mtu }}
+                ovs_extra:
+                - br-set-external-id br-ctlplane bridge-id br-ctlplane
+                addresses:
+                - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+                - ip_netmask: {{ control_virtual_ip}}/{{ control_virtual_cidr }}
+                - ip_netmask: {{ public_virtual_ip}}/{{ public_virtual_cidr }}
+                routes: {{ ctlplane_host_routes }}
+                dns_servers: {{ ctlplane_dns_nameservers }}
+                domain: {{ dns_search_domains }}
+                members:
+                  - type: interface
+                    name: {{ neutron_public_interface_name }}
+                    primary: true
+                    mtu: {{ ctlplane_mtu }}
         ansibleVars:
           service_net_map:
             nova_api_network: internal_api
@@ -62,7 +96,6 @@ spec:
           # edpm_network_config
           # Default nic config template for a EDPM compute node
           # These vars are edpm_network_config role vars
-          edpm_network_config_template: templates/single_nic_vlans/single_nic_vlans.j2
           edpm_network_config_hide_sensitive_logs: false
           #
           # These vars are for the network config templates themselves and are

--- a/config/samples/dataplane_v1beta1_openstackdataplane_baremetal.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplane_baremetal.yaml
@@ -54,6 +54,40 @@ spec:
         ansibleUser: cloud-admin
         ansiblePort: 22
         ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
+        networkConfig:
+          template: |
+              ---
+              {% set control_virtual_ip = net_vip_map.ctlplane %}
+              {% set public_virtual_ip = vip_port_map.external.ip_address %}
+              {% if ':' in control_virtual_ip %}
+              {%   set control_virtual_cidr = 128 %}
+              {% else %}
+              {%   set control_virtual_cidr = 32 %}
+              {%   endif %}
+              {% if ':' in public_virtual_ip %}
+              {%   set public_virtual_cidr = 128 %}
+              {% else %}
+              {%   set public_virtual_cidr = 32 %}
+              {%   endif %}
+              network_config:
+              - type: ovs_bridge
+                name: br-ctlplane
+                use_dhcp: false
+                mtu: {{ ctlplane_mtu }}
+                ovs_extra:
+                - br-set-external-id br-ctlplane bridge-id br-ctlplane
+                addresses:
+                - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+                - ip_netmask: {{ control_virtual_ip}}/{{ control_virtual_cidr }}
+                - ip_netmask: {{ public_virtual_ip}}/{{ public_virtual_cidr }}
+                routes: {{ ctlplane_host_routes }}
+                dns_servers: {{ ctlplane_dns_nameservers }}
+                domain: {{ dns_search_domains }}
+                members:
+                  - type: interface
+                    name: {{ neutron_public_interface_name }}
+                    primary: true
+                    mtu: {{ ctlplane_mtu }}
         ansibleVars:
           service_net_map:
             nova_api_network: internal_api
@@ -63,7 +97,6 @@ spec:
           # edpm_network_config
           # Default nic config template for a EDPM compute node
           # These vars are edpm_network_config role vars
-          edpm_network_config_template: templates/single_nic_vlans/single_nic_vlans.j2
           edpm_network_config_hide_sensitive_logs: false
 
           # These vars are for the network config templates themselves and are

--- a/config/samples/dataplane_v1beta1_openstackdataplane_baremetal_with_ipam.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplane_baremetal_with_ipam.yaml
@@ -48,6 +48,40 @@ spec:
         managementNetwork: CtlPlane
         ansibleUser: cloud-admin
         ansiblePort: 22
+        networkConfig:
+          template: |
+            ---
+            {% set control_virtual_ip = net_vip_map.ctlplane %}
+            {% set public_virtual_ip = vip_port_map.external.ip_address %}
+            {% if ':' in control_virtual_ip %}
+            {%   set control_virtual_cidr = 128 %}
+            {% else %}
+            {%   set control_virtual_cidr = 32 %}
+            {%   endif %}
+            {% if ':' in public_virtual_ip %}
+            {%   set public_virtual_cidr = 128 %}
+            {% else %}
+            {%   set public_virtual_cidr = 32 %}
+            {%   endif %}
+            network_config:
+            - type: ovs_bridge
+              name: br-ctlplane
+              use_dhcp: false
+              mtu: {{ ctlplane_mtu }}
+              ovs_extra:
+              - br-set-external-id br-ctlplane bridge-id br-ctlplane
+              addresses:
+              - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+              - ip_netmask: {{ control_virtual_ip}}/{{ control_virtual_cidr }}
+              - ip_netmask: {{ public_virtual_ip}}/{{ public_virtual_cidr }}
+              routes: {{ ctlplane_host_routes }}
+              dns_servers: {{ ctlplane_dns_nameservers }}
+              domain: {{ dns_search_domains }}
+              members:
+                - type: interface
+                  name: {{ neutron_public_interface_name }}
+                  primary: true
+                  mtu: {{ ctlplane_mtu }}
         ansibleVars:
           service_net_map:
             nova_api_network: internal_api
@@ -58,7 +92,6 @@ spec:
           # edpm_network_config
           # Default nic config template for a EDPM compute node
           # These vars are edpm_network_config role vars
-          edpm_network_config_template: templates/single_nic_vlans/single_nic_vlans.j2
           edpm_network_config_hide_sensitive_logs: false
           # These vars are for the network config templates themselves and are
           # considered EDPM network defaults.

--- a/config/samples/dataplane_v1beta1_openstackdataplane_ceph.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplane_ceph.yaml
@@ -89,6 +89,40 @@ spec:
         ansibleUser: root
         ansiblePort: 22
         ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
+        networkConfig:
+          template: |
+              ---
+              {% set control_virtual_ip = net_vip_map.ctlplane %}
+              {% set public_virtual_ip = vip_port_map.external.ip_address %}
+              {% if ':' in control_virtual_ip %}
+              {%   set control_virtual_cidr = 128 %}
+              {% else %}
+              {%   set control_virtual_cidr = 32 %}
+              {%   endif %}
+              {% if ':' in public_virtual_ip %}
+              {%   set public_virtual_cidr = 128 %}
+              {% else %}
+              {%   set public_virtual_cidr = 32 %}
+              {%   endif %}
+              network_config:
+              - type: ovs_bridge
+                name: br-ctlplane
+                use_dhcp: false
+                mtu: {{ ctlplane_mtu }}
+                ovs_extra:
+                - br-set-external-id br-ctlplane bridge-id br-ctlplane
+                addresses:
+                - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+                - ip_netmask: {{ control_virtual_ip}}/{{ control_virtual_cidr }}
+                - ip_netmask: {{ public_virtual_ip}}/{{ public_virtual_cidr }}
+                routes: {{ ctlplane_host_routes }}
+                dns_servers: {{ ctlplane_dns_nameservers }}
+                domain: {{ dns_search_domains }}
+                members:
+                  - type: interface
+                    name: {{ neutron_public_interface_name }}
+                    primary: true
+                    mtu: {{ ctlplane_mtu }}
         ansibleVars:
           service_net_map:
             nova_api_network: internal_api
@@ -97,7 +131,6 @@ spec:
           # edpm_network_config
           # Default nic config template for a EDPM compute node
           # These vars are edpm_network_config role vars
-          edpm_network_config_template: templates/single_nic_vlans/single_nic_vlans.j2
           edpm_network_config_hide_sensitive_logs: false
           #
           # These vars are for the network config templates themselves and are

--- a/config/samples/dataplane_v1beta1_openstackdataplane_customnetworks.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplane_customnetworks.yaml
@@ -43,32 +43,26 @@ spec:
         ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
         networkConfig:
           template: |
-            ---
-            network_config:
-            - type: interface
-              name: nic2
-              mtu: 1500
-              addresses:
-                - ip_netmask:
-                    {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
-            - type: ovs_bridge
-              name: {{ neutron_physical_bridge_name }}
-              mtu: 1500
-              use_dhcp: false
-              dns_servers: {{ ctlplane_dns_nameservers }}
-              domain: []
-              addresses:
-              - ip_netmask: {{ lookup('vars', networks_lower["External"] ~ '_ip') }}/{{ lookup('vars', networks_lower["External"] ~ '_cidr') }}
-              routes: [{'ip_netmask': '0.0.0.0/0', 'next_hop': '192.168.1.254'}]
-              members:
-              - type: interface
-                name: nic1
-                mtu: 1500
-                # force the MAC address of the bridge to this interface
-                primary: true
-              - type: vlan
-                mtu: 1500
-                vlan_id: 20
+              ---
+              {% set control_virtual_ip = net_vip_map.ctlplane %}
+              {% set public_virtual_ip = vip_port_map.external.ip_address %}
+              {% if ':' in control_virtual_ip %}
+              {%   set control_virtual_cidr = 128 %}
+              {% else %}
+              {%   set control_virtual_cidr = 32 %}
+              {%   endif %}
+              {% if ':' in public_virtual_ip %}
+              {%   set public_virtual_cidr = 128 %}
+              {% else %}
+              {%   set public_virtual_cidr = 32 %}
+              {%   endif %}
+              network_config:
+              - type: ovs_bridge
+                name: br-ctlplane
+                use_dhcp: false
+                mtu: {{ ctlplane_mtu }}
+                ovs_extra:
+                - br-set-external-id br-ctlplane bridge-id br-ctlplane
                 addresses:
                 - ip_netmask:
                     172.17.0.101/24
@@ -87,11 +81,21 @@ spec:
                 - ip_netmask:
                     172.19.0.101/24
                 routes: []
+                - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+                - ip_netmask: {{ control_virtual_ip}}/{{ control_virtual_cidr }}
+                - ip_netmask: {{ public_virtual_ip}}/{{ public_virtual_cidr }}
+                routes: {{ ctlplane_host_routes }}
+                dns_servers: {{ ctlplane_dns_nameservers }}
+                domain: {{ dns_search_domains }}
+                members:
+                  - type: interface
+                    name: {{ neutron_public_interface_name }}
+                    primary: true
+                    mtu: {{ ctlplane_mtu }}
         ansibleVars:
           # edpm_network_config
           # Default nic config template for a EDPM compute node
           # These vars are edpm_network_config role vars
-          edpm_network_config_template: /runner/network/nic-config-template
           edpm_network_config_hide_sensitive_logs: false
           edpm_network_config_update: false
           #

--- a/config/samples/dataplane_v1beta1_openstackdataplanenode.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenode.yaml
@@ -11,3 +11,37 @@ spec:
       - network: ctlplane
         fixedIP: 192.168.122.18
     ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
+    networkConfig:
+      template: |
+          ---
+          {% set control_virtual_ip = net_vip_map.ctlplane %}
+          {% set public_virtual_ip = vip_port_map.external.ip_address %}
+          {% if ':' in control_virtual_ip %}
+          {%   set control_virtual_cidr = 128 %}
+          {% else %}
+          {%   set control_virtual_cidr = 32 %}
+          {%   endif %}
+          {% if ':' in public_virtual_ip %}
+          {%   set public_virtual_cidr = 128 %}
+          {% else %}
+          {%   set public_virtual_cidr = 32 %}
+          {%   endif %}
+          network_config:
+          - type: ovs_bridge
+            name: br-ctlplane
+            use_dhcp: false
+            mtu: {{ ctlplane_mtu }}
+            ovs_extra:
+            - br-set-external-id br-ctlplane bridge-id br-ctlplane
+            addresses:
+            - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+            - ip_netmask: {{ control_virtual_ip}}/{{ control_virtual_cidr }}
+            - ip_netmask: {{ public_virtual_ip}}/{{ public_virtual_cidr }}
+            routes: {{ ctlplane_host_routes }}
+            dns_servers: {{ ctlplane_dns_nameservers }}
+            domain: {{ dns_search_domains }}
+            members:
+              - type: interface
+                name: {{ neutron_public_interface_name }}
+                primary: true
+                mtu: {{ ctlplane_mtu }}

--- a/config/samples/dataplane_v1beta1_openstackdataplanenode_edpm_compute_0.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenode_edpm_compute_0.yaml
@@ -11,5 +11,39 @@ spec:
     ansibleVars:
       tenant_ip: 192.168.24.100
     ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
+    networkConfig:
+      template: |
+          ---
+          {% set control_virtual_ip = net_vip_map.ctlplane %}
+          {% set public_virtual_ip = vip_port_map.external.ip_address %}
+          {% if ':' in control_virtual_ip %}
+          {%   set control_virtual_cidr = 128 %}
+          {% else %}
+          {%   set control_virtual_cidr = 32 %}
+          {%   endif %}
+          {% if ':' in public_virtual_ip %}
+          {%   set public_virtual_cidr = 128 %}
+          {% else %}
+          {%   set public_virtual_cidr = 32 %}
+          {%   endif %}
+          network_config:
+          - type: ovs_bridge
+            name: br-ctlplane
+            use_dhcp: false
+            mtu: {{ ctlplane_mtu }}
+            ovs_extra:
+            - br-set-external-id br-ctlplane bridge-id br-ctlplane
+            addresses:
+            - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+            - ip_netmask: {{ control_virtual_ip}}/{{ control_virtual_cidr }}
+            - ip_netmask: {{ public_virtual_ip}}/{{ public_virtual_cidr }}
+            routes: {{ ctlplane_host_routes }}
+            dns_servers: {{ ctlplane_dns_nameservers }}
+            domain: {{ dns_search_domains }}
+            members:
+              - type: interface
+                name: {{ neutron_public_interface_name }}
+                primary: true
+                mtu: {{ ctlplane_mtu }}
   deployStrategy:
     deploy: false

--- a/config/samples/dataplane_v1beta1_openstackdataplanenode_edpm_compute_0_full.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenode_edpm_compute_0_full.yaml
@@ -11,9 +11,42 @@ spec:
     ansibleUser: root
     ansiblePort: 22
     ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
+    networkConfig:
+      template: |
+          ---
+          {% set control_virtual_ip = net_vip_map.ctlplane %}
+          {% set public_virtual_ip = vip_port_map.external.ip_address %}
+          {% if ':' in control_virtual_ip %}
+          {%   set control_virtual_cidr = 128 %}
+          {% else %}
+          {%   set control_virtual_cidr = 32 %}
+          {%   endif %}
+          {% if ':' in public_virtual_ip %}
+          {%   set public_virtual_cidr = 128 %}
+          {% else %}
+          {%   set public_virtual_cidr = 32 %}
+          {%   endif %}
+          network_config:
+          - type: ovs_bridge
+            name: br-ctlplane
+            use_dhcp: false
+            mtu: {{ ctlplane_mtu }}
+            ovs_extra:
+            - br-set-external-id br-ctlplane bridge-id br-ctlplane
+            addresses:
+            - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+            - ip_netmask: {{ control_virtual_ip}}/{{ control_virtual_cidr }}
+            - ip_netmask: {{ public_virtual_ip}}/{{ public_virtual_cidr }}
+            routes: {{ ctlplane_host_routes }}
+            dns_servers: {{ ctlplane_dns_nameservers }}
+            domain: {{ dns_search_domains }}
+            members:
+              - type: interface
+                name: {{ neutron_public_interface_name }}
+                primary: true
+                mtu: {{ ctlplane_mtu }}
     ansibleVars:
       tenant_ip: 192.168.24.100
-      edpm_network_config_template: templates/net_config_bridge.j2
       edpm_network_config_hide_sensitive_logs: false
       neutron_physical_bridge_name: br-ex
       neutron_public_interface_name: eth0

--- a/config/samples/dataplane_v1beta1_openstackdataplanenode_edpm_compute_1.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenode_edpm_compute_1.yaml
@@ -11,5 +11,39 @@ spec:
     ansibleVars:
       tenant_ip: 192.168.24.101
     ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
+    networkConfig:
+      template: |
+          ---
+          {% set control_virtual_ip = net_vip_map.ctlplane %}
+          {% set public_virtual_ip = vip_port_map.external.ip_address %}
+          {% if ':' in control_virtual_ip %}
+          {%   set control_virtual_cidr = 128 %}
+          {% else %}
+          {%   set control_virtual_cidr = 32 %}
+          {%   endif %}
+          {% if ':' in public_virtual_ip %}
+          {%   set public_virtual_cidr = 128 %}
+          {% else %}
+          {%   set public_virtual_cidr = 32 %}
+          {%   endif %}
+          network_config:
+          - type: ovs_bridge
+            name: br-ctlplane
+            use_dhcp: false
+            mtu: {{ ctlplane_mtu }}
+            ovs_extra:
+            - br-set-external-id br-ctlplane bridge-id br-ctlplane
+            addresses:
+            - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+            - ip_netmask: {{ control_virtual_ip}}/{{ control_virtual_cidr }}
+            - ip_netmask: {{ public_virtual_ip}}/{{ public_virtual_cidr }}
+            routes: {{ ctlplane_host_routes }}
+            dns_servers: {{ ctlplane_dns_nameservers }}
+            domain: {{ dns_search_domains }}
+            members:
+              - type: interface
+                name: {{ neutron_public_interface_name }}
+                primary: true
+                mtu: {{ ctlplane_mtu }}
   deployStrategy:
     deploy: false

--- a/config/samples/dataplane_v1beta1_openstackdataplanenode_from.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenode_from.yaml
@@ -10,3 +10,37 @@ spec:
     networks:
       - network: ctlplane
         fixedIP: 192.168.122.18
+    networkConfig:
+      template: |
+          ---
+          {% set control_virtual_ip = net_vip_map.ctlplane %}
+          {% set public_virtual_ip = vip_port_map.external.ip_address %}
+          {% if ':' in control_virtual_ip %}
+          {%   set control_virtual_cidr = 128 %}
+          {% else %}
+          {%   set control_virtual_cidr = 32 %}
+          {%   endif %}
+          {% if ':' in public_virtual_ip %}
+          {%   set public_virtual_cidr = 128 %}
+          {% else %}
+          {%   set public_virtual_cidr = 32 %}
+          {%   endif %}
+          network_config:
+          - type: ovs_bridge
+            name: br-ctlplane
+            use_dhcp: false
+            mtu: {{ ctlplane_mtu }}
+            ovs_extra:
+            - br-set-external-id br-ctlplane bridge-id br-ctlplane
+            addresses:
+            - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+            - ip_netmask: {{ control_virtual_ip}}/{{ control_virtual_cidr }}
+            - ip_netmask: {{ public_virtual_ip}}/{{ public_virtual_cidr }}
+            routes: {{ ctlplane_host_routes }}
+            dns_servers: {{ ctlplane_dns_nameservers }}
+            domain: {{ dns_search_domains }}
+            members:
+              - type: interface
+                name: {{ neutron_public_interface_name }}
+                primary: true
+                mtu: {{ ctlplane_mtu }}

--- a/config/samples/dataplane_v1beta1_openstackdataplanerole.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanerole.yaml
@@ -12,50 +12,38 @@ spec:
   nodeTemplate:
     networkConfig:
       template: |
-        ---
-        network_config:
-        - type: interface
-          name: nic2
-          mtu: 1500
-          addresses:
-            - ip_netmask:
-                {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
-        - type: ovs_bridge
-          name: {{ neutron_physical_bridge_name }}
-          mtu: 1500
-          use_dhcp: false
-          dns_servers: {{ ctlplane_dns_nameservers }}
-          domain: []
-          addresses:
-          - ip_netmask: {{ lookup('vars', networks_lower["External"] ~ '_ip') }}/{{ lookup('vars', networks_lower["External"] ~ '_cidr') }}
-          routes: [{'ip_netmask': '0.0.0.0/0', 'next_hop': '192.168.1.254'}]
-          members:
-          - type: interface
-            name: nic1
-            mtu: 1500
-            # force the MAC address of the bridge to this interface
-            primary: true
-          - type: vlan
-            mtu: 1500
-            vlan_id: 20
-            addresses:
-            - ip_netmask:
-                172.17.0.101/24
-            routes: []
-          - type: vlan
-            mtu: 1500
-            vlan_id: 25
-            addresses:
-            - ip_netmask:
-                172.18.0.101/24
-            routes: []
-          - type: vlan
-            mtu: 1500
-            vlan_id: 22
-            addresses:
-            - ip_netmask:
-                172.19.0.101/24
-            routes: []
+            ---
+            {% set control_virtual_ip = net_vip_map.ctlplane %}
+            {% set public_virtual_ip = vip_port_map.external.ip_address %}
+            {% if ':' in control_virtual_ip %}
+            {%   set control_virtual_cidr = 128 %}
+            {% else %}
+            {%   set control_virtual_cidr = 32 %}
+            {%   endif %}
+            {% if ':' in public_virtual_ip %}
+            {%   set public_virtual_cidr = 128 %}
+            {% else %}
+            {%   set public_virtual_cidr = 32 %}
+            {%   endif %}
+            network_config:
+            - type: ovs_bridge
+              name: br-ctlplane
+              use_dhcp: false
+              mtu: {{ ctlplane_mtu }}
+              ovs_extra:
+              - br-set-external-id br-ctlplane bridge-id br-ctlplane
+              addresses:
+              - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+              - ip_netmask: {{ control_virtual_ip}}/{{ control_virtual_cidr }}
+              - ip_netmask: {{ public_virtual_ip}}/{{ public_virtual_cidr }}
+              routes: {{ ctlplane_host_routes }}
+              dns_servers: {{ ctlplane_dns_nameservers }}
+              domain: {{ dns_search_domains }}
+              members:
+                - type: interface
+                  name: {{ neutron_public_interface_name }}
+                  primary: true
+                  mtu: {{ ctlplane_mtu }}
     managed: false
     managementNetwork: ctlplane
     ansibleUser: root

--- a/config/samples/dataplane_v1beta1_openstackdataplanerole_edpm_compute.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanerole_edpm_compute.yaml
@@ -16,8 +16,41 @@ spec:
     ansibleUser: root
     ansiblePort: 22
     ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
+    networkConfig:
+      template: |
+          ---
+          {% set control_virtual_ip = net_vip_map.ctlplane %}
+          {% set public_virtual_ip = vip_port_map.external.ip_address %}
+          {% if ':' in control_virtual_ip %}
+          {%   set control_virtual_cidr = 128 %}
+          {% else %}
+          {%   set control_virtual_cidr = 32 %}
+          {%   endif %}
+          {% if ':' in public_virtual_ip %}
+          {%   set public_virtual_cidr = 128 %}
+          {% else %}
+          {%   set public_virtual_cidr = 32 %}
+          {%   endif %}
+          network_config:
+          - type: ovs_bridge
+            name: br-ctlplane
+            use_dhcp: false
+            mtu: {{ ctlplane_mtu }}
+            ovs_extra:
+            - br-set-external-id br-ctlplane bridge-id br-ctlplane
+            addresses:
+            - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+            - ip_netmask: {{ control_virtual_ip}}/{{ control_virtual_cidr }}
+            - ip_netmask: {{ public_virtual_ip}}/{{ public_virtual_cidr }}
+            routes: {{ ctlplane_host_routes }}
+            dns_servers: {{ ctlplane_dns_nameservers }}
+            domain: {{ dns_search_domains }}
+            members:
+              - type: interface
+                name: {{ neutron_public_interface_name }}
+                primary: true
+                mtu: {{ ctlplane_mtu }}
     ansibleVars:
-      edpm_network_config_template: templates/net_config_bridge.j2
       edpm_network_config_hide_sensitive_logs: false
       neutron_physical_bridge_name: br-ex
       neutron_public_interface_name: eth0

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -137,7 +137,6 @@ inline in the example.
               # edpm_network_config
               # Default nic config template for a EDPM compute node
               # These vars are edpm_network_config role vars
-              edpm_network_config_template: templates/single_nic_vlans/single_nic_vlans.j2
 
               # See config/samples/dataplane_v1beta1_openstackdataplane.yaml
               # for the other most common ansible varialbes that need to be set.


### PR DESCRIPTION
This change updates the nic-config samples and documentation to reflect the changes made in:
https://github.com/openstack-k8s-operators/edpm-ansible/pull/243
