### PR TITLE
Ensure dnsmasq/dns and netconfig/netconfig don't exist during kuttl tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,6 +233,8 @@ $(GINKGO): $(LOCALBIN)
 
 .PHONY: kuttl-test
 kuttl-test: ## Run kuttl tests
+	if oc get dnsmasq dns; then echo "dnsmasq/dns CR can not exist during kuttl tests"; exit 1; fi
+	if oc get netconfig netconfig; then echo "netconfig/netconfig CR can not exist during kuttl tests"; exit 1; fi
 	$(LOCALBIN)/kubectl-kuttl test --config kuttl-test.yaml tests/kuttl/tests $(KUTTL_ARGS)
 
 .PHONY: kuttl


### PR DESCRIPTION
These resources are not expected to exist during kuttl test execution.
When they do, the baremetal conditions are added to the
OpenStackDataPlaneRole resources which causes the kuttl tests to fail
various assertions.

These resources are created when an OpenStackControlPlane is created
with install_yamls. Testing for them before executing kuttl tests from
dataplane-operator makes it clear that they should not exist.

Signed-off-by: James Slagle <jslagle@redhat.com>
