### PR TITLE
Add Playbook field to OpenStackDataPlaneServiceSpec

### DIFF
--- a/api/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
@@ -36,6 +36,8 @@ spec:
                 type: string
               play:
                 type: string
+              playbook:
+                type: string
               role:
                 properties:
                   any_errors_fatal:

--- a/api/v1beta1/openstackdataplaneservice_types.go
+++ b/api/v1beta1/openstackdataplaneservice_types.go
@@ -49,9 +49,12 @@ type OpenStackDataPlaneServiceSpec struct {
 	// +kubebuilder:validation:Optional
 	Services []KubeService `json:"services,omitempty"`
 
-	// Play is the playbook contents that ansible will run on execution.
-	// If both Play and Role are specified, Play takes precedence
+	// Play is an inline playbook contents that ansible will run on execution.
+	// If both Play and Roles are specified, Play takes precedence
 	Play string `json:"play,omitempty"`
+
+	// Playbook is a path to the playbook that ansible will run on this execution
+	Playbook string `json:"playbook,omitempty"`
 
 	// Role is the description of an Ansible Role
 	// +kubebuilder:validation:Optional

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
@@ -36,6 +36,8 @@ spec:
                 type: string
               play:
                 type: string
+              playbook:
+                type: string
               role:
                 properties:
                   any_errors_fatal:

--- a/docs/openstack_dataplaneservice.md
+++ b/docs/openstack_dataplaneservice.md
@@ -131,7 +131,8 @@ OpenStackDataPlaneServiceSpec defines the desired state of OpenStackDataPlaneSer
 | ----- | ----------- | ------ | -------- |
 | label | Label to use for service | string | false |
 | services | Services to create to expose possible external services in computes | [][KubeService](#kubeservice) | false |
-| play | Play is the playbook contents that ansible will run on execution. If both Play and Role are specified, Play takes precedence | string | false |
+| play | Play is an inline playbook contents that ansible will run on execution. If both Play and Roles are specified, Play takes precedence | string | false |
+| playbook | Playbook is a path to the playbook that ansible will run on this execution | string | false |
 | role | Role is the description of an Ansible Role | *ansibleeev1.Role | false |
 | openStackAnsibleEERunnerImage | OpenStackAnsibleEERunnerImage image to use as the ansibleEE runner image | string | false |
 

--- a/pkg/deployment/ceph_client.go
+++ b/pkg/deployment/ceph_client.go
@@ -46,7 +46,7 @@ func ConfigureCephClient(ctx context.Context, helper *helper.Helper, obj client.
 		Tasks:    dataplaneutil.PopulateTasks(tasks),
 	}
 
-	err := dataplaneutil.AnsibleExecution(ctx, helper, obj, ConfigureCephClientLabel, sshKeySecret, inventoryConfigMap, "", role, aeeSpec)
+	err := dataplaneutil.AnsibleExecution(ctx, helper, obj, ConfigureCephClientLabel, sshKeySecret, inventoryConfigMap, "", "", role, aeeSpec)
 	if err != nil {
 		helper.GetLogger().Error(err, "Unable to execute Ansible for ConfigureCephClient")
 		return err

--- a/pkg/deployment/service.go
+++ b/pkg/deployment/service.go
@@ -49,7 +49,7 @@ func DeployService(ctx context.Context, helper *helper.Helper, obj client.Object
 	if foundService.Spec.Role != nil {
 		role = *foundService.Spec.Role
 	}
-	err := dataplaneutil.AnsibleExecution(ctx, helper, obj, foundService.Spec.Label, sshKeySecret, inventoryConfigMap, foundService.Spec.Play, role, aeeSpec)
+	err := dataplaneutil.AnsibleExecution(ctx, helper, obj, foundService.Spec.Label, sshKeySecret, inventoryConfigMap, foundService.Spec.Play, foundService.Spec.Playbook, role, aeeSpec)
 	if err != nil {
 		helper.GetLogger().Error(err, fmt.Sprintf("Unable to execute Ansible for %s", foundService.Name))
 		return err

--- a/pkg/util/ansible_execution.go
+++ b/pkg/util/ansible_execution.go
@@ -44,6 +44,7 @@ func AnsibleExecution(
 	sshKeySecret string,
 	inventoryConfigMap string,
 	play string,
+	playbook string,
 	role ansibleeev1.Role,
 	aeeSpec dataplanev1.AnsibleEESpec,
 ) error {
@@ -91,6 +92,9 @@ func AnsibleExecution(
 
 		if len(play) > 0 {
 			ansibleEE.Spec.Play = play
+		}
+		if len(playbook) > 0 {
+			ansibleEE.Spec.Playbook = playbook
 		}
 		ansibleEE.Spec.Role = &role
 


### PR DESCRIPTION
The services under config/services will be migrated to use playbooks
from edpm-ansible. This commit adds the Playbook field to the service
CRD so the services can be switched over to use playbooks. Once all
services are migrated, the Role field will be removed in a future
commit.

Signed-off-by: James Slagle <jslagle@redhat.com>
