### PR TITLE
[docs] Fix EDPM_OVN_DBS for multi pods

### DIFF
--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -160,7 +160,7 @@ export EDPM_OVN_METADATA_AGENT_SB_CONNECTION=$(oc get ovndbcluster ovndbcluster-
 export EDPM_OVN_METADATA_AGENT_NOVA_METADATA_HOST=$(oc get svc nova-metadata-internal -o json |jq -r '.status.loadBalancer.ingress[0].ip')
 export EDPM_OVN_METADATA_AGENT_PROXY_SHARED_SECRET=$(oc get secret osp-secret -o json | jq -r .data.MetadataSecret  | base64 -d)
 export EDPM_OVN_METADATA_AGENT_BIND_HOST=127.0.0.1
-export EDPM_OVN_DBS=$(oc get ovndbcluster ovndbcluster-sb -o json | jq -r '.status.networkAttachments."openstack/internalapi"[0]')
+export EDPM_OVN_DBS=$(oc get ovndbcluster ovndbcluster-sb -o json | jq -r '.status.networkAttachments."openstack/internalapi"')
 
 echo "
 edpm_ovn_metadata_agent_DEFAULT_transport_url: ${EDPM_OVN_METADATA_AGENT_TRANSPORT_URL}
@@ -168,8 +168,7 @@ edpm_ovn_metadata_agent_metadata_agent_ovn_ovn_sb_connection: ${EDPM_OVN_METADAT
 edpm_ovn_metadata_agent_metadata_agent_DEFAULT_nova_metadata_host: ${EDPM_OVN_METADATA_AGENT_NOVA_METADATA_HOST}
 edpm_ovn_metadata_agent_metadata_agent_DEFAULT_metadata_proxy_shared_secret: ${EDPM_OVN_METADATA_AGENT_PROXY_SHARED_SECRET}
 edpm_ovn_metadata_agent_DEFAULT_bind_host: ${EDPM_OVN_METADATA_AGENT_BIND_HOST}
-edpm_ovn_dbs:
-- ${EDPM_OVN_DBS}
+edpm_ovn_dbs: ${EDPM_OVN_DBS}
 "
 ```
 


### PR DESCRIPTION
Currently internal ip of first pod was set,
fix it for replicas>1.

Related-Fix: https://github.com/openstack-k8s-operators/install_yamls/pull/459