### PR TITLE
Use inventory as a secret instead of configmap

### DIFF
--- a/controllers/openstackdataplanenode_controller.go
+++ b/controllers/openstackdataplanenode_controller.go
@@ -206,7 +206,7 @@ func (r *OpenStackDataPlaneNodeReconciler) Reconcile(ctx context.Context, req ct
 	// all our input checks out so report InputReady
 	instance.Status.Conditions.MarkTrue(condition.InputReadyCondition, condition.InputReadyMessage)
 
-	nodeConfigMap, err := deployment.GenerateNodeInventory(ctx, helper, instance, instanceRole)
+	nodeSecret, err := deployment.GenerateNodeInventory(ctx, helper, instance, instanceRole)
 	if err != nil {
 		util.LogErrorForObject(helper, err, fmt.Sprintf("Unable to generate inventory for %s", instance.Name), instance)
 		return ctrl.Result{}, err
@@ -225,7 +225,7 @@ func (r *OpenStackDataPlaneNodeReconciler) Reconcile(ctx context.Context, req ct
 		}
 		deployResult, err := deployment.Deploy(
 			ctx, helper, instance, nodes,
-			ansibleSSHPrivateKeySecret, nodeConfigMap,
+			ansibleSSHPrivateKeySecret, nodeSecret,
 			&instance.Status, instance.GetAnsibleEESpec(*instanceRole),
 			deployment.GetServices(instance, instanceRole), instanceRole)
 		if err != nil {
@@ -308,7 +308,7 @@ func (r *OpenStackDataPlaneNodeReconciler) SetupWithManager(mgr ctrl.Manager) er
 		For(&dataplanev1.OpenStackDataPlaneNode{}).
 		Watches(&source.Kind{Type: &dataplanev1.OpenStackDataPlaneRole{}}, roleWatcher).
 		Owns(&v1alpha1.OpenStackAnsibleEE{}).
-		Owns(&corev1.ConfigMap{}).
+		Owns(&corev1.Secret{}).
 		Complete(r)
 }
 

--- a/controllers/openstackdataplanerole_controller.go
+++ b/controllers/openstackdataplanerole_controller.go
@@ -294,7 +294,7 @@ func (r *OpenStackDataPlaneRoleReconciler) Reconcile(ctx context.Context, req ct
 	}
 
 	// Generate Role Inventory
-	roleConfigMap, err := deployment.GenerateRoleInventory(ctx, helper, instance,
+	roleSecret, err := deployment.GenerateRoleInventory(ctx, helper, instance,
 		nodes.Items, allIPSets, dnsAddresses)
 	if err != nil {
 		util.LogErrorForObject(helper, err, fmt.Sprintf("Unable to generate inventory for %s", instance.Name), instance)
@@ -323,7 +323,7 @@ func (r *OpenStackDataPlaneRoleReconciler) Reconcile(ctx context.Context, req ct
 		}
 		deployResult, err := deployment.Deploy(
 			ctx, helper, instance, nodes, ansibleSSHPrivateKeySecret,
-			roleConfigMap, &instance.Status, ansibleEESpec,
+			roleSecret, &instance.Status, ansibleEESpec,
 			instance.Spec.Services, instance)
 		if err != nil {
 			util.LogErrorForObject(helper, err, fmt.Sprintf("Unable to deploy %s", instance.Name), instance)
@@ -396,7 +396,7 @@ func (r *OpenStackDataPlaneRoleReconciler) SetupWithManager(mgr ctrl.Manager) er
 		Owns(&baremetalv1.OpenStackBaremetalSet{}).
 		Owns(&infranetworkv1.IPSet{}).
 		Owns(&infranetworkv1.DNSData{}).
-		Owns(&corev1.ConfigMap{}).
+		Owns(&corev1.Secret{}).
 		Watches(&source.Kind{Type: &infranetworkv1.DNSMasq{}},
 			reconcileFunction).
 		Complete(r)

--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -48,7 +48,7 @@ func Deploy(
 	obj client.Object,
 	nodes *dataplanev1.OpenStackDataPlaneNodeList,
 	sshKeySecret string,
-	inventoryConfigMap string,
+	inventorySecret string,
 	status *dataplanev1.OpenStackDataPlaneStatus,
 	aeeSpec dataplanev1.AnsibleEESpec,
 	services []string,
@@ -100,7 +100,7 @@ func Deploy(
 			helper,
 			obj,
 			sshKeySecret,
-			inventoryConfigMap,
+			inventorySecret,
 			status,
 			readyCondition,
 			readyMessage,
@@ -137,7 +137,7 @@ func ConditionalDeploy(
 	helper *helper.Helper,
 	obj client.Object,
 	sshKeySecret string,
-	inventoryConfigMap string,
+	inventorySecret string,
 	status *dataplanev1.OpenStackDataPlaneStatus,
 	readyCondition condition.Type,
 	readyMessage string,
@@ -155,7 +155,7 @@ func ConditionalDeploy(
 
 	if status.Conditions.IsUnknown(readyCondition) {
 		log.Info(fmt.Sprintf("%s Unknown, starting %s", readyCondition, deployName))
-		err = deployFunc(ctx, helper, obj, sshKeySecret, inventoryConfigMap, aeeSpec, foundService)
+		err = deployFunc(ctx, helper, obj, sshKeySecret, inventorySecret, aeeSpec, foundService)
 		if err != nil {
 			util.LogErrorForObject(helper, err, fmt.Sprintf("Unable to %s for %s", deployName, obj.GetName()), obj)
 			return err

--- a/pkg/deployment/inventory.go
+++ b/pkg/deployment/inventory.go
@@ -31,8 +31,8 @@ import (
 	dataplanev1 "github.com/openstack-k8s-operators/dataplane-operator/api/v1beta1"
 	infranetworkv1 "github.com/openstack-k8s-operators/infra-operator/apis/network/v1beta1"
 	"github.com/openstack-k8s-operators/lib-common/modules/ansible"
-	"github.com/openstack-k8s-operators/lib-common/modules/common/configmap"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/secret"
 	utils "github.com/openstack-k8s-operators/lib-common/modules/common/util"
 )
 
@@ -76,24 +76,24 @@ func GenerateRoleInventory(ctx context.Context, helper *helper.Helper,
 		utils.LogErrorForObject(helper, err, "Could not parse Role inventory", instance)
 		return "", err
 	}
-	cmData := map[string]string{
+	secretData := map[string]string{
 		"inventory": string(invData),
 		"network":   string(instance.Spec.NodeTemplate.NetworkConfig.Template),
 	}
-	configMapName := fmt.Sprintf("dataplanerole-%s", instance.Name)
-	cms := []utils.Template{
-		// ConfigMap
+	secretName := fmt.Sprintf("dataplanerole-%s", instance.Name)
+	template := []utils.Template{
+		// Secret
 		{
-			Name:         configMapName,
+			Name:         secretName,
 			Namespace:    instance.Namespace,
 			Type:         utils.TemplateTypeNone,
 			InstanceType: instance.Kind,
-			CustomData:   cmData,
+			CustomData:   secretData,
 			Labels:       instance.ObjectMeta.Labels,
 		},
 	}
-	err = configmap.EnsureConfigMaps(ctx, helper, instance, cms, nil)
-	return configMapName, err
+	err = secret.EnsureSecrets(ctx, helper, instance, template, nil)
+	return secretName, err
 }
 
 // GenerateNodeInventory yields a parsed Inventory for node
@@ -156,24 +156,24 @@ func GenerateNodeInventory(ctx context.Context, helper *helper.Helper,
 		utils.LogErrorForObject(helper, err, "Could not Parse node inventory", instance)
 		return "", err
 	}
-	cmData := map[string]string{
+	secretData := map[string]string{
 		"inventory": string(invData),
 		"network":   string(networkConfig.Template),
 	}
-	configMapName := fmt.Sprintf("dataplanenode-%s", instance.Name)
-	cms := []utils.Template{
-		// ConfigMap
+	secretName := fmt.Sprintf("dataplanenode-%s", instance.Name)
+	template := []utils.Template{
+		// Secret
 		{
-			Name:         configMapName,
+			Name:         secretName,
 			Namespace:    instance.Namespace,
 			Type:         utils.TemplateTypeNone,
 			InstanceType: instance.Kind,
-			CustomData:   cmData,
+			CustomData:   secretData,
 			Labels:       instance.ObjectMeta.Labels,
 		},
 	}
-	err = configmap.EnsureConfigMaps(ctx, helper, instance, cms, nil)
-	return configMapName, err
+	err = secret.EnsureSecrets(ctx, helper, instance, template, nil)
+	return secretName, err
 }
 
 // populateInventoryFromIPAM populates inventory from IPAM

--- a/pkg/deployment/service.go
+++ b/pkg/deployment/service.go
@@ -43,9 +43,9 @@ type ServiceYAML struct {
 }
 
 // DeployService service deployment
-func DeployService(ctx context.Context, helper *helper.Helper, obj client.Object, sshKeySecret string, inventoryConfigMap string, aeeSpec dataplanev1.AnsibleEESpec, foundService dataplanev1.OpenStackDataPlaneService) error {
+func DeployService(ctx context.Context, helper *helper.Helper, obj client.Object, sshKeySecret string, inventorySecret string, aeeSpec dataplanev1.AnsibleEESpec, foundService dataplanev1.OpenStackDataPlaneService) error {
 
-	err := dataplaneutil.AnsibleExecution(ctx, helper, obj, foundService.Spec.Label, sshKeySecret, inventoryConfigMap, foundService.Spec.Play, foundService.Spec.Playbook, aeeSpec)
+	err := dataplaneutil.AnsibleExecution(ctx, helper, obj, foundService.Spec.Label, sshKeySecret, inventorySecret, foundService.Spec.Play, foundService.Spec.Playbook, aeeSpec)
 	if err != nil {
 		helper.GetLogger().Error(err, fmt.Sprintf("Unable to execute Ansible for %s", foundService.Name))
 		return err

--- a/pkg/util/ansible_execution.go
+++ b/pkg/util/ansible_execution.go
@@ -42,7 +42,7 @@ func AnsibleExecution(
 	obj client.Object,
 	label string,
 	sshKeySecret string,
-	inventoryConfigMap string,
+	inventorySecret string,
 	play string,
 	playbook string,
 	aeeSpec dataplanev1.AnsibleEESpec,
@@ -120,10 +120,8 @@ func AnsibleExecution(
 		inventoryVolume := corev1.Volume{
 			Name: "inventory",
 			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: inventoryConfigMap,
-					},
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: inventorySecret,
 					Items: []corev1.KeyToPath{
 						{
 							Key:  "inventory",

--- a/tests/kuttl/tests/dataplane-create-test/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-create-test/00-assert.yaml
@@ -258,278 +258,31 @@ status:
     type: SetupReady
 ---
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
   labels:
     openstackdataplane: openstack-edpm
   name: dataplanerole-edpm-compute
 data:
-  inventory: |
-    edpm-compute:
-        vars:
-            ansible_port: 22
-            ansible_user: root
-            ctlplane_dns_nameservers:
-                - 192.168.122.1
-            ctlplane_gateway_ip: 192.168.122.1
-            ctlplane_host_routes:
-                - ip_netmask: 0.0.0.0/0
-                  next_hop: 192.168.122.1
-            ctlplane_mtu: 1500
-            ctlplane_subnet_cidr: 24
-            dns_search_domains: []
-            edpm_chrony_ntp_servers:
-                - clock.redhat.com
-                - clock2.redhat.com
-            edpm_iscsid_image: '{{ registry_url }}/openstack-iscsid:{{ image_tag }}'
-            edpm_logrotate_crond_image: '{{ registry_url }}/openstack-cron:{{ image_tag }}'
-            edpm_network_config_hide_sensitive_logs: false
-            edpm_network_config_template: templates/single_nic_vlans/single_nic_vlans.j2
-            edpm_nodes_validation_validate_controllers_icmp: false
-            edpm_nodes_validation_validate_gateway_icmp: false
-            edpm_nova_compute_container_image: '{{ registry_url }}/openstack-nova-compute:{{ image_tag }}'
-            edpm_nova_libvirt_container_image: '{{ registry_url }}/openstack-nova-libvirt:{{ image_tag }}'
-            edpm_ovn_controller_agent_image: '{{ registry_url }}/openstack-ovn-controller:{{ image_tag }}'
-            edpm_ovn_dbs:
-                - 192.168.24.1
-            edpm_ovn_metadata_agent_DEFAULT_bind_host: 127.0.0.1
-            edpm_ovn_metadata_agent_DEFAULT_transport_url: rabbit://default_user@rabbitmq.openstack.svc:5672
-            edpm_ovn_metadata_agent_image: '{{ registry_url }}/openstack-neutron-metadata-agent-ovn:{{ image_tag }}'
-            edpm_ovn_metadata_agent_metadata_agent_DEFAULT_metadata_proxy_shared_secret: 12345678
-            edpm_ovn_metadata_agent_metadata_agent_DEFAULT_nova_metadata_host: 127.0.0.1
-            edpm_ovn_metadata_agent_metadata_agent_ovn_ovn_sb_connection: tcp:10.217.5.121:6642
-            edpm_selinux_mode: enforcing
-            edpm_sshd_allowed_ranges:
-                - 192.168.122.0/24
-            edpm_sshd_configure_firewall: true
-            enable_debug: false
-            external_cidr: "24"
-            external_host_routes: []
-            external_mtu: 1500
-            external_vlan_id: 44
-            gather_facts: false
-            image_tag: current-podified
-            internal_api_cidr: "24"
-            internal_api_host_routes: []
-            internal_api_mtu: 1500
-            internal_api_vlan_id: 20
-            management_network: ctlplane
-            networks_lower:
-                External: external
-                InternalApi: internal_api
-                Storage: storage
-                Tenant: tenant
-            neutron_physical_bridge_name: br-ex
-            neutron_public_interface_name: eth0
-            registry_url: quay.io/podified-antelope-centos9
-            role_networks:
-                - InternalApi
-                - Storage
-                - Tenant
-            service_net_map:
-                nova_api_network: internal_api
-                nova_libvirt_network: internal_api
-            storage_cidr: "24"
-            storage_host_routes: []
-            storage_mtu: 1500
-            storage_vlan_id: 21
-            tenant_cidr: "24"
-            tenant_host_routes: []
-            tenant_mtu: 1500
-            tenant_vlan_id: 22
-        hosts:
-            edpm-compute-0:
-                ansible_host: 192.168.122.100
-                ctlplane_ip: 192.168.122.100
-                fqdn_internal_api: edpm-compute-0.example.com
-                internal_api_ip: 172.17.0.100
-                storage_ip: 172.18.0.100
-                tenant_ip: 172.19.0.100
-            edpm-compute-1:
-                ansible_host: 192.168.122.101
-                ctlplane_ip: 192.168.122.101
-                fqdn_internal_api: edpm-compute-1.example.com
-                internal_api_ip: 172.17.0.101
-                storage_ip: 172.18.0.101
-                tenant_ip: 172.19.0.101
+  inventory: ZWRwbS1jb21wdXRlOgogICAgdmFyczoKICAgICAgICBhbnNpYmxlX3BvcnQ6IDIyCiAgICAgICAgYW5zaWJsZV91c2VyOiByb290CiAgICAgICAgY3RscGxhbmVfZG5zX25hbWVzZXJ2ZXJzOgogICAgICAgICAgICAtIDE5Mi4xNjguMTIyLjEKICAgICAgICBjdGxwbGFuZV9nYXRld2F5X2lwOiAxOTIuMTY4LjEyMi4xCiAgICAgICAgY3RscGxhbmVfaG9zdF9yb3V0ZXM6CiAgICAgICAgICAgIC0gaXBfbmV0bWFzazogMC4wLjAuMC8wCiAgICAgICAgICAgICAgbmV4dF9ob3A6IDE5Mi4xNjguMTIyLjEKICAgICAgICBjdGxwbGFuZV9tdHU6IDE1MDAKICAgICAgICBjdGxwbGFuZV9zdWJuZXRfY2lkcjogMjQKICAgICAgICBkbnNfc2VhcmNoX2RvbWFpbnM6IFtdCiAgICAgICAgZWRwbV9jaHJvbnlfbnRwX3NlcnZlcnM6CiAgICAgICAgICAgIC0gY2xvY2sucmVkaGF0LmNvbQogICAgICAgICAgICAtIGNsb2NrMi5yZWRoYXQuY29tCiAgICAgICAgZWRwbV9pc2NzaWRfaW1hZ2U6ICd7eyByZWdpc3RyeV91cmwgfX0vb3BlbnN0YWNrLWlzY3NpZDp7eyBpbWFnZV90YWcgfX0nCiAgICAgICAgZWRwbV9sb2dyb3RhdGVfY3JvbmRfaW1hZ2U6ICd7eyByZWdpc3RyeV91cmwgfX0vb3BlbnN0YWNrLWNyb246e3sgaW1hZ2VfdGFnIH19JwogICAgICAgIGVkcG1fbmV0d29ya19jb25maWdfaGlkZV9zZW5zaXRpdmVfbG9nczogZmFsc2UKICAgICAgICBlZHBtX25ldHdvcmtfY29uZmlnX3RlbXBsYXRlOiB0ZW1wbGF0ZXMvc2luZ2xlX25pY192bGFucy9zaW5nbGVfbmljX3ZsYW5zLmoyCiAgICAgICAgZWRwbV9ub2Rlc192YWxpZGF0aW9uX3ZhbGlkYXRlX2NvbnRyb2xsZXJzX2ljbXA6IGZhbHNlCiAgICAgICAgZWRwbV9ub2Rlc192YWxpZGF0aW9uX3ZhbGlkYXRlX2dhdGV3YXlfaWNtcDogZmFsc2UKICAgICAgICBlZHBtX25vdmFfY29tcHV0ZV9jb250YWluZXJfaW1hZ2U6ICd7eyByZWdpc3RyeV91cmwgfX0vb3BlbnN0YWNrLW5vdmEtY29tcHV0ZTp7eyBpbWFnZV90YWcgfX0nCiAgICAgICAgZWRwbV9ub3ZhX2xpYnZpcnRfY29udGFpbmVyX2ltYWdlOiAne3sgcmVnaXN0cnlfdXJsIH19L29wZW5zdGFjay1ub3ZhLWxpYnZpcnQ6e3sgaW1hZ2VfdGFnIH19JwogICAgICAgIGVkcG1fb3ZuX2NvbnRyb2xsZXJfYWdlbnRfaW1hZ2U6ICd7eyByZWdpc3RyeV91cmwgfX0vb3BlbnN0YWNrLW92bi1jb250cm9sbGVyOnt7IGltYWdlX3RhZyB9fScKICAgICAgICBlZHBtX292bl9kYnM6CiAgICAgICAgICAgIC0gMTkyLjE2OC4yNC4xCiAgICAgICAgZWRwbV9vdm5fbWV0YWRhdGFfYWdlbnRfREVGQVVMVF9iaW5kX2hvc3Q6IDEyNy4wLjAuMQogICAgICAgIGVkcG1fb3ZuX21ldGFkYXRhX2FnZW50X0RFRkFVTFRfdHJhbnNwb3J0X3VybDogcmFiYml0Oi8vZGVmYXVsdF91c2VyQHJhYmJpdG1xLm9wZW5zdGFjay5zdmM6NTY3MgogICAgICAgIGVkcG1fb3ZuX21ldGFkYXRhX2FnZW50X2ltYWdlOiAne3sgcmVnaXN0cnlfdXJsIH19L29wZW5zdGFjay1uZXV0cm9uLW1ldGFkYXRhLWFnZW50LW92bjp7eyBpbWFnZV90YWcgfX0nCiAgICAgICAgZWRwbV9vdm5fbWV0YWRhdGFfYWdlbnRfbWV0YWRhdGFfYWdlbnRfREVGQVVMVF9tZXRhZGF0YV9wcm94eV9zaGFyZWRfc2VjcmV0OiAxMjM0NTY3OAogICAgICAgIGVkcG1fb3ZuX21ldGFkYXRhX2FnZW50X21ldGFkYXRhX2FnZW50X0RFRkFVTFRfbm92YV9tZXRhZGF0YV9ob3N0OiAxMjcuMC4wLjEKICAgICAgICBlZHBtX292bl9tZXRhZGF0YV9hZ2VudF9tZXRhZGF0YV9hZ2VudF9vdm5fb3ZuX3NiX2Nvbm5lY3Rpb246IHRjcDoxMC4yMTcuNS4xMjE6NjY0MgogICAgICAgIGVkcG1fc2VsaW51eF9tb2RlOiBlbmZvcmNpbmcKICAgICAgICBlZHBtX3NzaGRfYWxsb3dlZF9yYW5nZXM6CiAgICAgICAgICAgIC0gMTkyLjE2OC4xMjIuMC8yNAogICAgICAgIGVkcG1fc3NoZF9jb25maWd1cmVfZmlyZXdhbGw6IHRydWUKICAgICAgICBlbmFibGVfZGVidWc6IGZhbHNlCiAgICAgICAgZXh0ZXJuYWxfY2lkcjogIjI0IgogICAgICAgIGV4dGVybmFsX2hvc3Rfcm91dGVzOiBbXQogICAgICAgIGV4dGVybmFsX210dTogMTUwMAogICAgICAgIGV4dGVybmFsX3ZsYW5faWQ6IDQ0CiAgICAgICAgZ2F0aGVyX2ZhY3RzOiBmYWxzZQogICAgICAgIGltYWdlX3RhZzogY3VycmVudC1wb2RpZmllZAogICAgICAgIGludGVybmFsX2FwaV9jaWRyOiAiMjQiCiAgICAgICAgaW50ZXJuYWxfYXBpX2hvc3Rfcm91dGVzOiBbXQogICAgICAgIGludGVybmFsX2FwaV9tdHU6IDE1MDAKICAgICAgICBpbnRlcm5hbF9hcGlfdmxhbl9pZDogMjAKICAgICAgICBtYW5hZ2VtZW50X25ldHdvcms6IGN0bHBsYW5lCiAgICAgICAgbmV0d29ya3NfbG93ZXI6CiAgICAgICAgICAgIEV4dGVybmFsOiBleHRlcm5hbAogICAgICAgICAgICBJbnRlcm5hbEFwaTogaW50ZXJuYWxfYXBpCiAgICAgICAgICAgIFN0b3JhZ2U6IHN0b3JhZ2UKICAgICAgICAgICAgVGVuYW50OiB0ZW5hbnQKICAgICAgICBuZXV0cm9uX3BoeXNpY2FsX2JyaWRnZV9uYW1lOiBici1leAogICAgICAgIG5ldXRyb25fcHVibGljX2ludGVyZmFjZV9uYW1lOiBldGgwCiAgICAgICAgcmVnaXN0cnlfdXJsOiBxdWF5LmlvL3BvZGlmaWVkLWFudGVsb3BlLWNlbnRvczkKICAgICAgICByb2xlX25ldHdvcmtzOgogICAgICAgICAgICAtIEludGVybmFsQXBpCiAgICAgICAgICAgIC0gU3RvcmFnZQogICAgICAgICAgICAtIFRlbmFudAogICAgICAgIHNlcnZpY2VfbmV0X21hcDoKICAgICAgICAgICAgbm92YV9hcGlfbmV0d29yazogaW50ZXJuYWxfYXBpCiAgICAgICAgICAgIG5vdmFfbGlidmlydF9uZXR3b3JrOiBpbnRlcm5hbF9hcGkKICAgICAgICBzdG9yYWdlX2NpZHI6ICIyNCIKICAgICAgICBzdG9yYWdlX2hvc3Rfcm91dGVzOiBbXQogICAgICAgIHN0b3JhZ2VfbXR1OiAxNTAwCiAgICAgICAgc3RvcmFnZV92bGFuX2lkOiAyMQogICAgICAgIHRlbmFudF9jaWRyOiAiMjQiCiAgICAgICAgdGVuYW50X2hvc3Rfcm91dGVzOiBbXQogICAgICAgIHRlbmFudF9tdHU6IDE1MDAKICAgICAgICB0ZW5hbnRfdmxhbl9pZDogMjIKICAgIGhvc3RzOgogICAgICAgIGVkcG0tY29tcHV0ZS0wOgogICAgICAgICAgICBhbnNpYmxlX2hvc3Q6IDE5Mi4xNjguMTIyLjEwMAogICAgICAgICAgICBjdGxwbGFuZV9pcDogMTkyLjE2OC4xMjIuMTAwCiAgICAgICAgICAgIGZxZG5faW50ZXJuYWxfYXBpOiBlZHBtLWNvbXB1dGUtMC5leGFtcGxlLmNvbQogICAgICAgICAgICBpbnRlcm5hbF9hcGlfaXA6IDE3Mi4xNy4wLjEwMAogICAgICAgICAgICBzdG9yYWdlX2lwOiAxNzIuMTguMC4xMDAKICAgICAgICAgICAgdGVuYW50X2lwOiAxNzIuMTkuMC4xMDAKICAgICAgICBlZHBtLWNvbXB1dGUtMToKICAgICAgICAgICAgYW5zaWJsZV9ob3N0OiAxOTIuMTY4LjEyMi4xMDEKICAgICAgICAgICAgY3RscGxhbmVfaXA6IDE5Mi4xNjguMTIyLjEwMQogICAgICAgICAgICBmcWRuX2ludGVybmFsX2FwaTogZWRwbS1jb21wdXRlLTEuZXhhbXBsZS5jb20KICAgICAgICAgICAgaW50ZXJuYWxfYXBpX2lwOiAxNzIuMTcuMC4xMDEKICAgICAgICAgICAgc3RvcmFnZV9pcDogMTcyLjE4LjAuMTAxCiAgICAgICAgICAgIHRlbmFudF9pcDogMTcyLjE5LjAuMTAxCg==
   network: ""
 ---
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
   labels:
     openstackdataplanerole: edpm-compute
   name: dataplanenode-edpm-compute-0
 data:
-  inventory: |
-    all:
-        hosts:
-            edpm-compute-0:
-                ansible_host: 192.168.122.100
-                ansible_port: "22"
-                ansible_user: root
-                ctlplane_dns_nameservers:
-                    - 192.168.122.1
-                ctlplane_gateway_ip: 192.168.122.1
-                ctlplane_host_routes:
-                    - ip_netmask: 0.0.0.0/0
-                      next_hop: 192.168.122.1
-                ctlplane_ip: 192.168.122.100
-                ctlplane_mtu: 1500
-                ctlplane_subnet_cidr: 24
-                dns_search_domains: []
-                edpm_chrony_ntp_servers:
-                    - clock.redhat.com
-                    - clock2.redhat.com
-                edpm_iscsid_image: '{{ registry_url }}/openstack-iscsid:{{ image_tag }}'
-                edpm_logrotate_crond_image: '{{ registry_url }}/openstack-cron:{{ image_tag }}'
-                edpm_network_config_hide_sensitive_logs: false
-                edpm_network_config_template: templates/single_nic_vlans/single_nic_vlans.j2
-                edpm_nodes_validation_validate_controllers_icmp: false
-                edpm_nodes_validation_validate_gateway_icmp: false
-                edpm_nova_compute_container_image: '{{ registry_url }}/openstack-nova-compute:{{ image_tag }}'
-                edpm_nova_libvirt_container_image: '{{ registry_url }}/openstack-nova-libvirt:{{ image_tag }}'
-                edpm_ovn_controller_agent_image: '{{ registry_url }}/openstack-ovn-controller:{{ image_tag }}'
-                edpm_ovn_dbs:
-                    - 192.168.24.1
-                edpm_ovn_metadata_agent_DEFAULT_bind_host: 127.0.0.1
-                edpm_ovn_metadata_agent_DEFAULT_transport_url: rabbit://default_user@rabbitmq.openstack.svc:5672
-                edpm_ovn_metadata_agent_image: '{{ registry_url }}/openstack-neutron-metadata-agent-ovn:{{ image_tag }}'
-                edpm_ovn_metadata_agent_metadata_agent_DEFAULT_metadata_proxy_shared_secret: 12345678
-                edpm_ovn_metadata_agent_metadata_agent_DEFAULT_nova_metadata_host: 127.0.0.1
-                edpm_ovn_metadata_agent_metadata_agent_ovn_ovn_sb_connection: tcp:10.217.5.121:6642
-                edpm_selinux_mode: enforcing
-                edpm_sshd_allowed_ranges:
-                    - 192.168.122.0/24
-                edpm_sshd_configure_firewall: true
-                enable_debug: false
-                external_cidr: "24"
-                external_host_routes: []
-                external_mtu: 1500
-                external_vlan_id: 44
-                fqdn_internal_api: edpm-compute-0.example.com
-                gather_facts: false
-                image_tag: current-podified
-                internal_api_cidr: "24"
-                internal_api_host_routes: []
-                internal_api_ip: 172.17.0.100
-                internal_api_mtu: 1500
-                internal_api_vlan_id: 20
-                management_network: ctlplane
-                networks: []
-                networks_lower:
-                    External: external
-                    InternalApi: internal_api
-                    Storage: storage
-                    Tenant: tenant
-                neutron_physical_bridge_name: br-ex
-                neutron_public_interface_name: eth0
-                registry_url: quay.io/podified-antelope-centos9
-                role_networks:
-                    - InternalApi
-                    - Storage
-                    - Tenant
-                service_net_map:
-                    nova_api_network: internal_api
-                    nova_libvirt_network: internal_api
-                storage_cidr: "24"
-                storage_host_routes: []
-                storage_ip: 172.18.0.100
-                storage_mtu: 1500
-                storage_vlan_id: 21
-                tenant_cidr: "24"
-                tenant_host_routes: []
-                tenant_ip: 172.19.0.100
-                tenant_mtu: 1500
-                tenant_vlan_id: 22
+  inventory: YWxsOgogICAgaG9zdHM6CiAgICAgICAgZWRwbS1jb21wdXRlLTA6CiAgICAgICAgICAgIGFuc2libGVfaG9zdDogMTkyLjE2OC4xMjIuMTAwCiAgICAgICAgICAgIGFuc2libGVfcG9ydDogIjIyIgogICAgICAgICAgICBhbnNpYmxlX3VzZXI6IHJvb3QKICAgICAgICAgICAgY3RscGxhbmVfZG5zX25hbWVzZXJ2ZXJzOgogICAgICAgICAgICAgICAgLSAxOTIuMTY4LjEyMi4xCiAgICAgICAgICAgIGN0bHBsYW5lX2dhdGV3YXlfaXA6IDE5Mi4xNjguMTIyLjEKICAgICAgICAgICAgY3RscGxhbmVfaG9zdF9yb3V0ZXM6CiAgICAgICAgICAgICAgICAtIGlwX25ldG1hc2s6IDAuMC4wLjAvMAogICAgICAgICAgICAgICAgICBuZXh0X2hvcDogMTkyLjE2OC4xMjIuMQogICAgICAgICAgICBjdGxwbGFuZV9pcDogMTkyLjE2OC4xMjIuMTAwCiAgICAgICAgICAgIGN0bHBsYW5lX210dTogMTUwMAogICAgICAgICAgICBjdGxwbGFuZV9zdWJuZXRfY2lkcjogMjQKICAgICAgICAgICAgZG5zX3NlYXJjaF9kb21haW5zOiBbXQogICAgICAgICAgICBlZHBtX2Nocm9ueV9udHBfc2VydmVyczoKICAgICAgICAgICAgICAgIC0gY2xvY2sucmVkaGF0LmNvbQogICAgICAgICAgICAgICAgLSBjbG9jazIucmVkaGF0LmNvbQogICAgICAgICAgICBlZHBtX2lzY3NpZF9pbWFnZTogJ3t7IHJlZ2lzdHJ5X3VybCB9fS9vcGVuc3RhY2staXNjc2lkOnt7IGltYWdlX3RhZyB9fScKICAgICAgICAgICAgZWRwbV9sb2dyb3RhdGVfY3JvbmRfaW1hZ2U6ICd7eyByZWdpc3RyeV91cmwgfX0vb3BlbnN0YWNrLWNyb246e3sgaW1hZ2VfdGFnIH19JwogICAgICAgICAgICBlZHBtX25ldHdvcmtfY29uZmlnX2hpZGVfc2Vuc2l0aXZlX2xvZ3M6IGZhbHNlCiAgICAgICAgICAgIGVkcG1fbmV0d29ya19jb25maWdfdGVtcGxhdGU6IHRlbXBsYXRlcy9zaW5nbGVfbmljX3ZsYW5zL3NpbmdsZV9uaWNfdmxhbnMuajIKICAgICAgICAgICAgZWRwbV9ub2Rlc192YWxpZGF0aW9uX3ZhbGlkYXRlX2NvbnRyb2xsZXJzX2ljbXA6IGZhbHNlCiAgICAgICAgICAgIGVkcG1fbm9kZXNfdmFsaWRhdGlvbl92YWxpZGF0ZV9nYXRld2F5X2ljbXA6IGZhbHNlCiAgICAgICAgICAgIGVkcG1fbm92YV9jb21wdXRlX2NvbnRhaW5lcl9pbWFnZTogJ3t7IHJlZ2lzdHJ5X3VybCB9fS9vcGVuc3RhY2stbm92YS1jb21wdXRlOnt7IGltYWdlX3RhZyB9fScKICAgICAgICAgICAgZWRwbV9ub3ZhX2xpYnZpcnRfY29udGFpbmVyX2ltYWdlOiAne3sgcmVnaXN0cnlfdXJsIH19L29wZW5zdGFjay1ub3ZhLWxpYnZpcnQ6e3sgaW1hZ2VfdGFnIH19JwogICAgICAgICAgICBlZHBtX292bl9jb250cm9sbGVyX2FnZW50X2ltYWdlOiAne3sgcmVnaXN0cnlfdXJsIH19L29wZW5zdGFjay1vdm4tY29udHJvbGxlcjp7eyBpbWFnZV90YWcgfX0nCiAgICAgICAgICAgIGVkcG1fb3ZuX2RiczoKICAgICAgICAgICAgICAgIC0gMTkyLjE2OC4yNC4xCiAgICAgICAgICAgIGVkcG1fb3ZuX21ldGFkYXRhX2FnZW50X0RFRkFVTFRfYmluZF9ob3N0OiAxMjcuMC4wLjEKICAgICAgICAgICAgZWRwbV9vdm5fbWV0YWRhdGFfYWdlbnRfREVGQVVMVF90cmFuc3BvcnRfdXJsOiByYWJiaXQ6Ly9kZWZhdWx0X3VzZXJAcmFiYml0bXEub3BlbnN0YWNrLnN2Yzo1NjcyCiAgICAgICAgICAgIGVkcG1fb3ZuX21ldGFkYXRhX2FnZW50X2ltYWdlOiAne3sgcmVnaXN0cnlfdXJsIH19L29wZW5zdGFjay1uZXV0cm9uLW1ldGFkYXRhLWFnZW50LW92bjp7eyBpbWFnZV90YWcgfX0nCiAgICAgICAgICAgIGVkcG1fb3ZuX21ldGFkYXRhX2FnZW50X21ldGFkYXRhX2FnZW50X0RFRkFVTFRfbWV0YWRhdGFfcHJveHlfc2hhcmVkX3NlY3JldDogMTIzNDU2NzgKICAgICAgICAgICAgZWRwbV9vdm5fbWV0YWRhdGFfYWdlbnRfbWV0YWRhdGFfYWdlbnRfREVGQVVMVF9ub3ZhX21ldGFkYXRhX2hvc3Q6IDEyNy4wLjAuMQogICAgICAgICAgICBlZHBtX292bl9tZXRhZGF0YV9hZ2VudF9tZXRhZGF0YV9hZ2VudF9vdm5fb3ZuX3NiX2Nvbm5lY3Rpb246IHRjcDoxMC4yMTcuNS4xMjE6NjY0MgogICAgICAgICAgICBlZHBtX3NlbGludXhfbW9kZTogZW5mb3JjaW5nCiAgICAgICAgICAgIGVkcG1fc3NoZF9hbGxvd2VkX3JhbmdlczoKICAgICAgICAgICAgICAgIC0gMTkyLjE2OC4xMjIuMC8yNAogICAgICAgICAgICBlZHBtX3NzaGRfY29uZmlndXJlX2ZpcmV3YWxsOiB0cnVlCiAgICAgICAgICAgIGVuYWJsZV9kZWJ1ZzogZmFsc2UKICAgICAgICAgICAgZXh0ZXJuYWxfY2lkcjogIjI0IgogICAgICAgICAgICBleHRlcm5hbF9ob3N0X3JvdXRlczogW10KICAgICAgICAgICAgZXh0ZXJuYWxfbXR1OiAxNTAwCiAgICAgICAgICAgIGV4dGVybmFsX3ZsYW5faWQ6IDQ0CiAgICAgICAgICAgIGZxZG5faW50ZXJuYWxfYXBpOiBlZHBtLWNvbXB1dGUtMC5leGFtcGxlLmNvbQogICAgICAgICAgICBnYXRoZXJfZmFjdHM6IGZhbHNlCiAgICAgICAgICAgIGltYWdlX3RhZzogY3VycmVudC1wb2RpZmllZAogICAgICAgICAgICBpbnRlcm5hbF9hcGlfY2lkcjogIjI0IgogICAgICAgICAgICBpbnRlcm5hbF9hcGlfaG9zdF9yb3V0ZXM6IFtdCiAgICAgICAgICAgIGludGVybmFsX2FwaV9pcDogMTcyLjE3LjAuMTAwCiAgICAgICAgICAgIGludGVybmFsX2FwaV9tdHU6IDE1MDAKICAgICAgICAgICAgaW50ZXJuYWxfYXBpX3ZsYW5faWQ6IDIwCiAgICAgICAgICAgIG1hbmFnZW1lbnRfbmV0d29yazogY3RscGxhbmUKICAgICAgICAgICAgbmV0d29ya3M6IFtdCiAgICAgICAgICAgIG5ldHdvcmtzX2xvd2VyOgogICAgICAgICAgICAgICAgRXh0ZXJuYWw6IGV4dGVybmFsCiAgICAgICAgICAgICAgICBJbnRlcm5hbEFwaTogaW50ZXJuYWxfYXBpCiAgICAgICAgICAgICAgICBTdG9yYWdlOiBzdG9yYWdlCiAgICAgICAgICAgICAgICBUZW5hbnQ6IHRlbmFudAogICAgICAgICAgICBuZXV0cm9uX3BoeXNpY2FsX2JyaWRnZV9uYW1lOiBici1leAogICAgICAgICAgICBuZXV0cm9uX3B1YmxpY19pbnRlcmZhY2VfbmFtZTogZXRoMAogICAgICAgICAgICByZWdpc3RyeV91cmw6IHF1YXkuaW8vcG9kaWZpZWQtYW50ZWxvcGUtY2VudG9zOQogICAgICAgICAgICByb2xlX25ldHdvcmtzOgogICAgICAgICAgICAgICAgLSBJbnRlcm5hbEFwaQogICAgICAgICAgICAgICAgLSBTdG9yYWdlCiAgICAgICAgICAgICAgICAtIFRlbmFudAogICAgICAgICAgICBzZXJ2aWNlX25ldF9tYXA6CiAgICAgICAgICAgICAgICBub3ZhX2FwaV9uZXR3b3JrOiBpbnRlcm5hbF9hcGkKICAgICAgICAgICAgICAgIG5vdmFfbGlidmlydF9uZXR3b3JrOiBpbnRlcm5hbF9hcGkKICAgICAgICAgICAgc3RvcmFnZV9jaWRyOiAiMjQiCiAgICAgICAgICAgIHN0b3JhZ2VfaG9zdF9yb3V0ZXM6IFtdCiAgICAgICAgICAgIHN0b3JhZ2VfaXA6IDE3Mi4xOC4wLjEwMAogICAgICAgICAgICBzdG9yYWdlX210dTogMTUwMAogICAgICAgICAgICBzdG9yYWdlX3ZsYW5faWQ6IDIxCiAgICAgICAgICAgIHRlbmFudF9jaWRyOiAiMjQiCiAgICAgICAgICAgIHRlbmFudF9ob3N0X3JvdXRlczogW10KICAgICAgICAgICAgdGVuYW50X2lwOiAxNzIuMTkuMC4xMDAKICAgICAgICAgICAgdGVuYW50X210dTogMTUwMAogICAgICAgICAgICB0ZW5hbnRfdmxhbl9pZDogMjIK
   network: ""
 ---
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
   labels:
     openstackdataplanerole: edpm-compute
   name: dataplanenode-edpm-compute-1
 data:
-  inventory: |
-    all:
-        hosts:
-            edpm-compute-1:
-                ansible_host: 192.168.122.101
-                ansible_port: "22"
-                ansible_user: root
-                ctlplane_dns_nameservers:
-                    - 192.168.122.1
-                ctlplane_gateway_ip: 192.168.122.1
-                ctlplane_host_routes:
-                    - ip_netmask: 0.0.0.0/0
-                      next_hop: 192.168.122.1
-                ctlplane_ip: 192.168.122.101
-                ctlplane_mtu: 1500
-                ctlplane_subnet_cidr: 24
-                dns_search_domains: []
-                edpm_chrony_ntp_servers:
-                    - clock.redhat.com
-                    - clock2.redhat.com
-                edpm_iscsid_image: '{{ registry_url }}/openstack-iscsid:{{ image_tag }}'
-                edpm_logrotate_crond_image: '{{ registry_url }}/openstack-cron:{{ image_tag }}'
-                edpm_network_config_hide_sensitive_logs: false
-                edpm_network_config_template: templates/single_nic_vlans/single_nic_vlans.j2
-                edpm_nodes_validation_validate_controllers_icmp: false
-                edpm_nodes_validation_validate_gateway_icmp: false
-                edpm_nova_compute_container_image: '{{ registry_url }}/openstack-nova-compute:{{ image_tag }}'
-                edpm_nova_libvirt_container_image: '{{ registry_url }}/openstack-nova-libvirt:{{ image_tag }}'
-                edpm_ovn_controller_agent_image: '{{ registry_url }}/openstack-ovn-controller:{{ image_tag }}'
-                edpm_ovn_dbs:
-                    - 192.168.24.1
-                edpm_ovn_metadata_agent_DEFAULT_bind_host: 127.0.0.1
-                edpm_ovn_metadata_agent_DEFAULT_transport_url: rabbit://default_user@rabbitmq.openstack.svc:5672
-                edpm_ovn_metadata_agent_image: '{{ registry_url }}/openstack-neutron-metadata-agent-ovn:{{ image_tag }}'
-                edpm_ovn_metadata_agent_metadata_agent_DEFAULT_metadata_proxy_shared_secret: 12345678
-                edpm_ovn_metadata_agent_metadata_agent_DEFAULT_nova_metadata_host: 127.0.0.1
-                edpm_ovn_metadata_agent_metadata_agent_ovn_ovn_sb_connection: tcp:10.217.5.121:6642
-                edpm_selinux_mode: enforcing
-                edpm_sshd_allowed_ranges:
-                    - 192.168.122.0/24
-                edpm_sshd_configure_firewall: true
-                enable_debug: false
-                external_cidr: "24"
-                external_host_routes: []
-                external_mtu: 1500
-                external_vlan_id: 44
-                fqdn_internal_api: edpm-compute-1.example.com
-                gather_facts: false
-                image_tag: current-podified
-                internal_api_cidr: "24"
-                internal_api_host_routes: []
-                internal_api_ip: 172.17.0.101
-                internal_api_mtu: 1500
-                internal_api_vlan_id: 20
-                management_network: ctlplane
-                networks: []
-                networks_lower:
-                    External: external
-                    InternalApi: internal_api
-                    Storage: storage
-                    Tenant: tenant
-                neutron_physical_bridge_name: br-ex
-                neutron_public_interface_name: eth0
-                registry_url: quay.io/podified-antelope-centos9
-                role_networks:
-                    - InternalApi
-                    - Storage
-                    - Tenant
-                service_net_map:
-                    nova_api_network: internal_api
-                    nova_libvirt_network: internal_api
-                storage_cidr: "24"
-                storage_host_routes: []
-                storage_ip: 172.18.0.101
-                storage_mtu: 1500
-                storage_vlan_id: 21
-                tenant_cidr: "24"
-                tenant_host_routes: []
-                tenant_ip: 172.19.0.101
-                tenant_mtu: 1500
-                tenant_vlan_id: 22
+  inventory: YWxsOgogICAgaG9zdHM6CiAgICAgICAgZWRwbS1jb21wdXRlLTE6CiAgICAgICAgICAgIGFuc2libGVfaG9zdDogMTkyLjE2OC4xMjIuMTAxCiAgICAgICAgICAgIGFuc2libGVfcG9ydDogIjIyIgogICAgICAgICAgICBhbnNpYmxlX3VzZXI6IHJvb3QKICAgICAgICAgICAgY3RscGxhbmVfZG5zX25hbWVzZXJ2ZXJzOgogICAgICAgICAgICAgICAgLSAxOTIuMTY4LjEyMi4xCiAgICAgICAgICAgIGN0bHBsYW5lX2dhdGV3YXlfaXA6IDE5Mi4xNjguMTIyLjEKICAgICAgICAgICAgY3RscGxhbmVfaG9zdF9yb3V0ZXM6CiAgICAgICAgICAgICAgICAtIGlwX25ldG1hc2s6IDAuMC4wLjAvMAogICAgICAgICAgICAgICAgICBuZXh0X2hvcDogMTkyLjE2OC4xMjIuMQogICAgICAgICAgICBjdGxwbGFuZV9pcDogMTkyLjE2OC4xMjIuMTAxCiAgICAgICAgICAgIGN0bHBsYW5lX210dTogMTUwMAogICAgICAgICAgICBjdGxwbGFuZV9zdWJuZXRfY2lkcjogMjQKICAgICAgICAgICAgZG5zX3NlYXJjaF9kb21haW5zOiBbXQogICAgICAgICAgICBlZHBtX2Nocm9ueV9udHBfc2VydmVyczoKICAgICAgICAgICAgICAgIC0gY2xvY2sucmVkaGF0LmNvbQogICAgICAgICAgICAgICAgLSBjbG9jazIucmVkaGF0LmNvbQogICAgICAgICAgICBlZHBtX2lzY3NpZF9pbWFnZTogJ3t7IHJlZ2lzdHJ5X3VybCB9fS9vcGVuc3RhY2staXNjc2lkOnt7IGltYWdlX3RhZyB9fScKICAgICAgICAgICAgZWRwbV9sb2dyb3RhdGVfY3JvbmRfaW1hZ2U6ICd7eyByZWdpc3RyeV91cmwgfX0vb3BlbnN0YWNrLWNyb246e3sgaW1hZ2VfdGFnIH19JwogICAgICAgICAgICBlZHBtX25ldHdvcmtfY29uZmlnX2hpZGVfc2Vuc2l0aXZlX2xvZ3M6IGZhbHNlCiAgICAgICAgICAgIGVkcG1fbmV0d29ya19jb25maWdfdGVtcGxhdGU6IHRlbXBsYXRlcy9zaW5nbGVfbmljX3ZsYW5zL3NpbmdsZV9uaWNfdmxhbnMuajIKICAgICAgICAgICAgZWRwbV9ub2Rlc192YWxpZGF0aW9uX3ZhbGlkYXRlX2NvbnRyb2xsZXJzX2ljbXA6IGZhbHNlCiAgICAgICAgICAgIGVkcG1fbm9kZXNfdmFsaWRhdGlvbl92YWxpZGF0ZV9nYXRld2F5X2ljbXA6IGZhbHNlCiAgICAgICAgICAgIGVkcG1fbm92YV9jb21wdXRlX2NvbnRhaW5lcl9pbWFnZTogJ3t7IHJlZ2lzdHJ5X3VybCB9fS9vcGVuc3RhY2stbm92YS1jb21wdXRlOnt7IGltYWdlX3RhZyB9fScKICAgICAgICAgICAgZWRwbV9ub3ZhX2xpYnZpcnRfY29udGFpbmVyX2ltYWdlOiAne3sgcmVnaXN0cnlfdXJsIH19L29wZW5zdGFjay1ub3ZhLWxpYnZpcnQ6e3sgaW1hZ2VfdGFnIH19JwogICAgICAgICAgICBlZHBtX292bl9jb250cm9sbGVyX2FnZW50X2ltYWdlOiAne3sgcmVnaXN0cnlfdXJsIH19L29wZW5zdGFjay1vdm4tY29udHJvbGxlcjp7eyBpbWFnZV90YWcgfX0nCiAgICAgICAgICAgIGVkcG1fb3ZuX2RiczoKICAgICAgICAgICAgICAgIC0gMTkyLjE2OC4yNC4xCiAgICAgICAgICAgIGVkcG1fb3ZuX21ldGFkYXRhX2FnZW50X0RFRkFVTFRfYmluZF9ob3N0OiAxMjcuMC4wLjEKICAgICAgICAgICAgZWRwbV9vdm5fbWV0YWRhdGFfYWdlbnRfREVGQVVMVF90cmFuc3BvcnRfdXJsOiByYWJiaXQ6Ly9kZWZhdWx0X3VzZXJAcmFiYml0bXEub3BlbnN0YWNrLnN2Yzo1NjcyCiAgICAgICAgICAgIGVkcG1fb3ZuX21ldGFkYXRhX2FnZW50X2ltYWdlOiAne3sgcmVnaXN0cnlfdXJsIH19L29wZW5zdGFjay1uZXV0cm9uLW1ldGFkYXRhLWFnZW50LW92bjp7eyBpbWFnZV90YWcgfX0nCiAgICAgICAgICAgIGVkcG1fb3ZuX21ldGFkYXRhX2FnZW50X21ldGFkYXRhX2FnZW50X0RFRkFVTFRfbWV0YWRhdGFfcHJveHlfc2hhcmVkX3NlY3JldDogMTIzNDU2NzgKICAgICAgICAgICAgZWRwbV9vdm5fbWV0YWRhdGFfYWdlbnRfbWV0YWRhdGFfYWdlbnRfREVGQVVMVF9ub3ZhX21ldGFkYXRhX2hvc3Q6IDEyNy4wLjAuMQogICAgICAgICAgICBlZHBtX292bl9tZXRhZGF0YV9hZ2VudF9tZXRhZGF0YV9hZ2VudF9vdm5fb3ZuX3NiX2Nvbm5lY3Rpb246IHRjcDoxMC4yMTcuNS4xMjE6NjY0MgogICAgICAgICAgICBlZHBtX3NlbGludXhfbW9kZTogZW5mb3JjaW5nCiAgICAgICAgICAgIGVkcG1fc3NoZF9hbGxvd2VkX3JhbmdlczoKICAgICAgICAgICAgICAgIC0gMTkyLjE2OC4xMjIuMC8yNAogICAgICAgICAgICBlZHBtX3NzaGRfY29uZmlndXJlX2ZpcmV3YWxsOiB0cnVlCiAgICAgICAgICAgIGVuYWJsZV9kZWJ1ZzogZmFsc2UKICAgICAgICAgICAgZXh0ZXJuYWxfY2lkcjogIjI0IgogICAgICAgICAgICBleHRlcm5hbF9ob3N0X3JvdXRlczogW10KICAgICAgICAgICAgZXh0ZXJuYWxfbXR1OiAxNTAwCiAgICAgICAgICAgIGV4dGVybmFsX3ZsYW5faWQ6IDQ0CiAgICAgICAgICAgIGZxZG5faW50ZXJuYWxfYXBpOiBlZHBtLWNvbXB1dGUtMS5leGFtcGxlLmNvbQogICAgICAgICAgICBnYXRoZXJfZmFjdHM6IGZhbHNlCiAgICAgICAgICAgIGltYWdlX3RhZzogY3VycmVudC1wb2RpZmllZAogICAgICAgICAgICBpbnRlcm5hbF9hcGlfY2lkcjogIjI0IgogICAgICAgICAgICBpbnRlcm5hbF9hcGlfaG9zdF9yb3V0ZXM6IFtdCiAgICAgICAgICAgIGludGVybmFsX2FwaV9pcDogMTcyLjE3LjAuMTAxCiAgICAgICAgICAgIGludGVybmFsX2FwaV9tdHU6IDE1MDAKICAgICAgICAgICAgaW50ZXJuYWxfYXBpX3ZsYW5faWQ6IDIwCiAgICAgICAgICAgIG1hbmFnZW1lbnRfbmV0d29yazogY3RscGxhbmUKICAgICAgICAgICAgbmV0d29ya3M6IFtdCiAgICAgICAgICAgIG5ldHdvcmtzX2xvd2VyOgogICAgICAgICAgICAgICAgRXh0ZXJuYWw6IGV4dGVybmFsCiAgICAgICAgICAgICAgICBJbnRlcm5hbEFwaTogaW50ZXJuYWxfYXBpCiAgICAgICAgICAgICAgICBTdG9yYWdlOiBzdG9yYWdlCiAgICAgICAgICAgICAgICBUZW5hbnQ6IHRlbmFudAogICAgICAgICAgICBuZXV0cm9uX3BoeXNpY2FsX2JyaWRnZV9uYW1lOiBici1leAogICAgICAgICAgICBuZXV0cm9uX3B1YmxpY19pbnRlcmZhY2VfbmFtZTogZXRoMAogICAgICAgICAgICByZWdpc3RyeV91cmw6IHF1YXkuaW8vcG9kaWZpZWQtYW50ZWxvcGUtY2VudG9zOQogICAgICAgICAgICByb2xlX25ldHdvcmtzOgogICAgICAgICAgICAgICAgLSBJbnRlcm5hbEFwaQogICAgICAgICAgICAgICAgLSBTdG9yYWdlCiAgICAgICAgICAgICAgICAtIFRlbmFudAogICAgICAgICAgICBzZXJ2aWNlX25ldF9tYXA6CiAgICAgICAgICAgICAgICBub3ZhX2FwaV9uZXR3b3JrOiBpbnRlcm5hbF9hcGkKICAgICAgICAgICAgICAgIG5vdmFfbGlidmlydF9uZXR3b3JrOiBpbnRlcm5hbF9hcGkKICAgICAgICAgICAgc3RvcmFnZV9jaWRyOiAiMjQiCiAgICAgICAgICAgIHN0b3JhZ2VfaG9zdF9yb3V0ZXM6IFtdCiAgICAgICAgICAgIHN0b3JhZ2VfaXA6IDE3Mi4xOC4wLjEwMQogICAgICAgICAgICBzdG9yYWdlX210dTogMTUwMAogICAgICAgICAgICBzdG9yYWdlX3ZsYW5faWQ6IDIxCiAgICAgICAgICAgIHRlbmFudF9jaWRyOiAiMjQiCiAgICAgICAgICAgIHRlbmFudF9ob3N0X3JvdXRlczogW10KICAgICAgICAgICAgdGVuYW50X2lwOiAxNzIuMTkuMC4xMDEKICAgICAgICAgICAgdGVuYW50X210dTogMTUwMAogICAgICAgICAgICB0ZW5hbnRfdmxhbl9pZDogMjIK
   network: ""

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/01-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/01-assert.yaml
@@ -123,14 +123,14 @@ spec:
         - key: ssh-privatekey
           path: ssh_key
         secretName: dataplane-ansible-ssh-private-key-secret
-    - configMap:
+    - name: inventory
+      secret:
         items:
         - key: inventory
           path: inventory
         - key: network
           path: network
-        name: dataplanerole-edpm-compute-no-nodes
-      name: inventory
+        secretName: dataplanerole-edpm-compute-no-nodes
   image: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
   name: openstackansibleee
   restartPolicy: Never
@@ -179,14 +179,14 @@ spec:
         - key: ssh-privatekey
           path: ssh_key
         secretName: dataplane-ansible-ssh-private-key-secret
-    - configMap:
+    - name: inventory
+      secret:
         items:
         - key: inventory
           path: inventory
         - key: network
           path: network
-        name: dataplanerole-edpm-compute-no-nodes
-      name: inventory
+        secretName: dataplanerole-edpm-compute-no-nodes
   image: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
   name: openstackansibleee
   restartPolicy: Never
@@ -235,14 +235,14 @@ spec:
         - key: ssh-privatekey
           path: ssh_key
         secretName: dataplane-ansible-ssh-private-key-secret
-    - configMap:
+    - name: inventory
+      secret:
         items:
         - key: inventory
           path: inventory
         - key: network
           path: network
-        name: dataplanerole-edpm-compute-no-nodes
-      name: inventory
+        secretName: dataplanerole-edpm-compute-no-nodes
   image: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
   name: openstackansibleee
   restartPolicy: Never
@@ -292,14 +292,14 @@ spec:
         - key: ssh-privatekey
           path: ssh_key
         secretName: dataplane-ansible-ssh-private-key-secret
-    - configMap:
+    - name: inventory
+      secret:
         items:
         - key: inventory
           path: inventory
         - key: network
           path: network
-        name: dataplanerole-edpm-compute-no-nodes
-      name: inventory
+        secretName: dataplanerole-edpm-compute-no-nodes
   image: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
   name: openstackansibleee
   restartPolicy: Never
@@ -348,14 +348,14 @@ spec:
         - key: ssh-privatekey
           path: ssh_key
         secretName: dataplane-ansible-ssh-private-key-secret
-    - configMap:
+    - name: inventory
+      secret:
         items:
         - key: inventory
           path: inventory
         - key: network
           path: network
-        name: dataplanerole-edpm-compute-no-nodes
-      name: inventory
+        secretName: dataplanerole-edpm-compute-no-nodes
   image: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
   name: openstackansibleee
   restartPolicy: Never
@@ -405,14 +405,14 @@ spec:
         - key: ssh-privatekey
           path: ssh_key
         secretName: dataplane-ansible-ssh-private-key-secret
-    - configMap:
+    - name: inventory
+      secret:
         items:
         - key: inventory
           path: inventory
         - key: network
           path: network
-        name: dataplanerole-edpm-compute-no-nodes
-      name: inventory
+        secretName: dataplanerole-edpm-compute-no-nodes
   image: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
   name: openstackansibleee
   restartPolicy: Never
@@ -463,14 +463,14 @@ spec:
         - key: ssh-privatekey
           path: ssh_key
         secretName: dataplane-ansible-ssh-private-key-secret
-    - configMap:
+    - name: inventory
+      secret:
         items:
         - key: inventory
           path: inventory
         - key: network
           path: network
-        name: dataplanerole-edpm-compute-no-nodes
-      name: inventory
+        secretName: dataplanerole-edpm-compute-no-nodes
   image: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
   name: openstackansibleee
   preserveJobs: true
@@ -536,14 +536,14 @@ spec:
         - key: ssh-privatekey
           path: ssh_key
         secretName: dataplane-ansible-ssh-private-key-secret
-    - configMap:
+    - name: inventory
+      secret:
         items:
         - key: inventory
           path: inventory
         - key: network
           path: network
-        name: dataplanerole-edpm-compute-no-nodes
-      name: inventory
+        secretName: dataplanerole-edpm-compute-no-nodes
   image: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
   name: openstackansibleee
   preserveJobs: true

--- a/tests/kuttl/tests/dataplane-service-config/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-service-config/00-assert.yaml
@@ -76,14 +76,14 @@ spec:
         - key: ssh-privatekey
           path: ssh_key
         secretName: dataplane-ansible-ssh-private-key-secret
-    - configMap:
+    - name: inventory
+      secret:
         items:
         - key: inventory
           path: inventory
         - key: network
           path: network
-        name: dataplanerole-edpm-compute-no-nodes
-      name: inventory
+        secretName: dataplanerole-edpm-compute-no-nodes
   image: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
   name: openstackansibleee
   play: |

--- a/tests/kuttl/tests/dataplane-service-custom-image/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-service-custom-image/00-assert.yaml
@@ -108,14 +108,14 @@ spec:
         - key: ssh-privatekey
           path: ssh_key
         secretName: dataplane-ansible-ssh-private-key-secret
-    - configMap:
+    - name: inventory
+      secret:
         items:
         - key: inventory
           path: inventory
         - key: network
           path: network
-        name: dataplanerole-edpm-compute-no-nodes
-      name: inventory
+        secretName: dataplanerole-edpm-compute-no-nodes
   image: example.com/repo/runner-image:latest
   name: openstackansibleee
   restartPolicy: Never


### PR DESCRIPTION
Changing it into secret, as the inventory may require secret values.
```
EDPM_OVN_METADATA_AGENT_TRANSPORT_URL=$(oc get secret rabbitmq-transport-url-neutron-neutron-transport -o json | jq -r .data.transport_url | base64 -d)
EDPM_OVN_METADATA_AGENT_PROXY_SHARED_SECRET=$(oc get secret osp-secret -o json | jq -r .data.MetadataSecret  | base64 -d)
```


