### PR TITLE
Don't remove IPSet/DNS Ready condtions for pre-provisioned

### DIFF
--- a/api/v1beta1/openstackdataplanerole_types.go
+++ b/api/v1beta1/openstackdataplanerole_types.go
@@ -109,17 +109,9 @@ func (instance *OpenStackDataPlaneRole) InitConditions() {
 		condition.UnknownCondition(SetupReadyCondition, condition.InitReason, condition.InitReason),
 	)
 
-	// Only set Baremetal related conditions if we have baremetal hosts included in the
-	// baremetalSetTemplate.
+	// Only set Baremetal condition for baremetal provisioning
 	if len(instance.Spec.BaremetalSetTemplate.BaremetalHosts) > 0 {
-		bmConditionsList := []condition.Type{
-			RoleBareMetalProvisionReadyCondition,
-			RoleIPReservationReadyCondition,
-			RoleDNSDataReadyCondition,
-		}
-		for _, c := range bmConditionsList {
-			cl = append(cl, *condition.UnknownCondition(c, condition.InitReason, condition.InitReason))
-		}
+		cl = append(cl, *condition.UnknownCondition(RoleBareMetalProvisionReadyCondition, condition.InitReason, condition.InitReason))
 	}
 
 	if instance.Spec.Services != nil && instance.Spec.DeployStrategy.Deploy {

--- a/controllers/openstackdataplanerole_controller.go
+++ b/controllers/openstackdataplanerole_controller.go
@@ -266,11 +266,6 @@ func (r *OpenStackDataPlaneRoleReconciler) Reconcile(ctx context.Context, req ct
 		if err != nil || !isReady {
 			return ctrl.Result{}, err
 		}
-	} else {
-		// We don't require any baremetal nodes, so we will remove these conditions from the status
-		instance.Status.Conditions.Remove(dataplanev1.RoleBareMetalProvisionReadyCondition)
-		instance.Status.Conditions.Remove(dataplanev1.RoleDNSDataReadyCondition)
-		instance.Status.Conditions.Remove(dataplanev1.RoleIPReservationReadyCondition)
 	}
 
 	// Ensure all nodes are in SetupReady state


### PR DESCRIPTION
We provision IPs and create DNSData when netconfig/dnsmasq services exist, using the networks provided with the node/role spec. Let's not remove them for all pre-provisioned scenarios.