### PR TITLE
Removed roles from `install-os` service since they already called in `configure-network` service

### DIFF
--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_install_os.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_install_os.yaml
@@ -10,17 +10,6 @@ spec:
     strategy: "linear"
     become: true
     tasks:
-      - name: "Install edpm_bootstrap"
-        import_role:
-          name: "osp.edpm.edpm_bootstrap"
-          tasks_from: "bootstrap.yml"
-        tags:
-          - "edpm_bootstrap"
-      - name: "Install edpm_kernel"
-        import_role:
-          name: "osp.edpm.edpm_kernel"
-        tags:
-          - "edpm_kernel"
       - name: "Install edpm_podman"
         import_role:
           name: "osp.edpm.edpm_podman"

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/01-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/01-assert.yaml
@@ -296,17 +296,6 @@ spec:
     strategy: linear
     tasks:
     - import_role:
-        name: osp.edpm.edpm_bootstrap
-        tasks_from: bootstrap.yml
-      name: Install edpm_bootstrap
-      tags:
-      - edpm_bootstrap
-    - import_role:
-        name: osp.edpm.edpm_kernel
-      name: Install edpm_kernel
-      tags:
-      - edpm_kernel
-    - import_role:
         name: osp.edpm.edpm_podman
         tasks_from: install.yml
       name: Install edpm_podman


### PR DESCRIPTION
The `edpm_bootstrap` and the `edpm_kernel` roles are already defined and called in the `configure-network` service [1], so their presence in `install-os` it's useless.

[1] https://github.com/openstack-k8s-operators/dataplane-operator/blob/130162a8b3727d9dbc7b34ea441c2ea7364db3e6/config/services/dataplane_v1beta1_openstackdataplaneservice_configure_network.yaml#L24-L34