### PR TITLE
Don't attach all networks to ansibleee pods

### DIFF
--- a/config/samples/dataplane_v1beta1_openstackdataplane.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplane.yaml
@@ -48,9 +48,6 @@ spec:
         - run-os
       networkAttachments:
         - ctlplane
-        - internalapi
-        - storage
-        - tenant
       nodeTemplate:
         # Defining the novaTemplate here means the nodes in this role are
         # computes

--- a/config/samples/dataplane_v1beta1_openstackdataplane_baremetal_with_ipam.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplane_baremetal_with_ipam.yaml
@@ -28,9 +28,6 @@ spec:
           value: "2"
       networkAttachments:
         - ctlplane
-        - internalapi
-        - storage
-        - tenant
       baremetalSetTemplate:
         deploymentSSHSecret: dataplane-ansible-ssh-private-key-secret
         bmhLabelSelector:

--- a/config/samples/dataplane_v1beta1_openstackdataplane_with_ipam.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplane_with_ipam.yaml
@@ -40,9 +40,6 @@ spec:
         - run-os
       networkAttachments:
         - ctlplane
-        - internalapi
-        - storage
-        - tenant
       nodeTemplate:
         # Defining the novaTemplate here means the nodes in this role are
         # computes


### PR DESCRIPTION
We use mcvlan with NADs, so you can't reach the metallb lb endpoints with these networks. API endpoints inside the cluster should be reached using cluster network.