### PR TITLE
Remove --leader-elect for controller manager

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -36,4 +36,3 @@ spec:
         args:
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=127.0.0.1:8080"
-        - "--leader-elect"

--- a/config/manager/controller_manager_config.yaml
+++ b/config/manager/controller_manager_config.yaml
@@ -7,7 +7,7 @@ metrics:
 webhook:
   port: 9443
 leaderElection:
-  leaderElect: true
+  leaderElect: false
   resourceName: e12e763d.openstack.org
 # leaderElectionReleaseOnCancel defines if the leader should step down volume
 # when the Manager ends. This requires the binary to immediately end when the

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -38,8 +38,6 @@ spec:
       containers:
       - command:
         - /manager
-        args:
-        - --leader-elect
         image: controller:latest
         name: manager
         securityContext:


### PR DESCRIPTION
We use a single replica for the controller-manager and there is probably no need to use multiple of them for high availability of the operator pods. This patch removes the leader election with single replica. When we move to use multiple replicas we can use ENV var to patch both.