### PR TITLE
Introduce dataplane-deployment-ceph-hci-pre

### DIFF
--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_ceph_hci_pre.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_ceph_hci_pre.yaml
@@ -1,0 +1,17 @@
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneService
+metadata:
+  name: ceph-hci-pre
+spec:
+  label: dataplane-deployment-ceph-hci-pre
+  role:
+    name: "Prepare EDPM to Host Ceph"
+    hosts: "all"
+    strategy: "linear"
+    become: true
+    tasks:
+      - name: "Prepare EDPM to Host Ceph"
+        import_role:
+          name: "osp.edpm.edpm_ceph_hci_pre"
+        tags:
+          - "edpm_ceph_hci_pre"


### PR DESCRIPTION
The ceph-hci-pre service calls the edpm-ansible role edpm_ceph_hci_pre to configure an EDPM node to host Ceph for collocation with Nova (HCI).

The deployer can shorten the services list to:

  - configure-network
  - validate-network
  - ceph-hci-pre

and then deploy Ceph out of band. After Ceph is deployed the full services list may be restored.

Jira: [OSP-25827](https://issues.redhat.com//browse/OSP-25827)
Depends-On: https://github.com/openstack-k8s-operators/edpm-ansible/pull/273