### PR TITLE
Add flag to create IPv6 DNS records which map to the IPv4 address

### DIFF
--- a/api/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
@@ -39,6 +39,8 @@ spec:
             type: object
           spec:
             properties:
+              addressIPv6MapIPv4:
+                type: boolean
               baremetalSetTemplate:
                 properties:
                   automatedCleaningMode:

--- a/api/bases/dataplane.openstack.org_openstackdataplanes.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplanes.yaml
@@ -962,6 +962,8 @@ spec:
               roles:
                 additionalProperties:
                   properties:
+                    addressIPv6MapIPv4:
+                      type: boolean
                     baremetalSetTemplate:
                       properties:
                         automatedCleaningMode:

--- a/api/v1beta1/openstackdataplanerole_types.go
+++ b/api/v1beta1/openstackdataplanerole_types.go
@@ -63,6 +63,12 @@ type OpenStackDataPlaneRoleSpec struct {
 	// +kubebuilder:default={configure-network,validate-network,install-os,configure-os,run-os}
 	// Services list
 	Services []string `json:"services"`
+
+	// +kubebuilder:validation:Optional
+	//
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	// AddressIPv6MapIPv4 - Whether to create IPv6 DNS records which map to the IPv4 address, for environments which are IPv4 only
+	AddressIPv6MapIPv4 bool `json:"addressIPv6MapIPv4,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplaneroles.yaml
@@ -39,6 +39,8 @@ spec:
             type: object
           spec:
             properties:
+              addressIPv6MapIPv4:
+                type: boolean
               baremetalSetTemplate:
                 properties:
                   automatedCleaningMode:

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanes.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanes.yaml
@@ -962,6 +962,8 @@ spec:
               roles:
                 additionalProperties:
                   properties:
+                    addressIPv6MapIPv4:
+                      type: boolean
                     baremetalSetTemplate:
                       properties:
                         automatedCleaningMode:

--- a/config/manifests/bases/dataplane-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/dataplane-operator.clusterserviceversion.yaml
@@ -52,6 +52,12 @@ spec:
       kind: OpenStackDataPlaneRole
       name: openstackdataplaneroles.dataplane.openstack.org
       specDescriptors:
+      - description: AddressIPv6MapIPv4 - Whether to create IPv6 DNS records which
+          map to the IPv4 address, for environments which are IPv4 only
+        displayName: Address IPv6 Map IPv4
+        path: addressIPv6MapIPv4
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Deploy boolean to trigger ansible execution
         displayName: Deploy
         path: deployStrategy.deploy
@@ -114,6 +120,12 @@ spec:
         path: nodes.node.ansibleSSHPrivateKeySecret
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes:Secret
+      - description: AddressIPv6MapIPv4 - Whether to create IPv6 DNS records which
+          map to the IPv4 address, for environments which are IPv4 only
+        displayName: Address IPv6 Map IPv4
+        path: roles.addressIPv6MapIPv4
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Deploy boolean to trigger ansible execution
         displayName: Deploy
         path: roles.deployStrategy.deploy

--- a/docs/openstack_dataplanerole.md
+++ b/docs/openstack_dataplanerole.md
@@ -123,5 +123,6 @@ OpenStackDataPlaneRoleSpec defines the desired state of OpenStackDataPlaneRole
 | deployStrategy | DeployStrategy section to control how the node is deployed | [DeployStrategySection](#deploystrategysection) | false |
 | networkAttachments | NetworkAttachments is a list of NetworkAttachment resource names to pass to the ansibleee resource which allows to connect the ansibleee runner to the given network | []string | false |
 | services | Services list | []string | true |
+| addressIPv6MapIPv4 | \n\nAddressIPv6MapIPv4 - Whether to create IPv6 DNS records which map to the IPv4 address, for environments which are IPv4 only | bool | false |
 
 [Back to Custom Resources](#custom-resources)

--- a/pkg/deployment/ipam.go
+++ b/pkg/deployment/ipam.go
@@ -18,6 +18,7 @@ package deployment
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -91,6 +92,12 @@ func createOrPatchDNSData(ctx context.Context, helper *helper.Helper,
 					fqdnNames = append(fqdnNames, fqdnName)
 					dnsRecord.Hostnames = fqdnNames
 					allDNSRecords = append(allDNSRecords, dnsRecord)
+					if instance.Spec.AddressIPv6MapIPv4 {
+						dnsRecord = infranetworkv1.DNSHost{}
+						dnsRecord.IP = fmt.Sprintf("::ffff:%s", res.Address)
+						dnsRecord.Hostnames = fqdnNames
+						allDNSRecords = append(allDNSRecords, dnsRecord)
+					}
 					// Adding only ctlplane domain for ansibleee.
 					// TODO (rabi) This is not very efficient.
 					if res.Network == CtlPlaneNetwork && ctlplaneSearchDomain == "" {


### PR DESCRIPTION
install-yamls-crc-podified-edpm-baremetal is currently broken with ansible halting on a name resolution failure[1].

The dnsmasq log[1] shows the v4 A record resolves, but the v6 AAAA lookup is delegated to 192.168.122.1 which returns NODATA-IPv6, which is what halts ansible execution.

We would need to document this flag to be set in IPv4 only environments.

Other options worth considering for this issue:
- Modify the dnsmasq controller to allow setting the --filter-AAAA flag[3] in IPv4 only environments
- Modify the ansibleee image to configure ssh with the "-4" flag to avoid attempting IPv6 (I attempted doing this by setting dataplane env ANSIBLE_SSH_COMMON_ARGS or ansibleVars ansible_ssh_common_args but it didn't change the behaviour.

[1] https://logserver.rdoproject.org/60/460/210937ab2df5f884dfdff504d78ceb631f77c66b/github-check/install-yamls-crc-podified-edpm-baremetal/65fec9e/ci-framework-data/logs/crc/pods/openstack_dataplane-deployment-configure-network-edpm-compute-kfms9_4895d0cb-ba5c-4c82-a6e5-3ffbe307ecd3/openstackansibleee/0.log
[2] https://logserver.rdoproject.org/60/460/210937ab2df5f884dfdff504d78ceb631f77c66b/github-check/install-yamls-crc-podified-edpm-baremetal/65fec9e/ci-framework-data/logs/crc/pods/openstack_dnsmasq-dns-695d5c4585-zf9q7_cf80e892-2259-448f-8b08-9938ba532ffa/dnsmasq-dns/0.log
[3] https://thekelleys.org.uk/dnsmasq/docs/dnsmasq-man.html