### PR TITLE
Use IPAM consistently

### DIFF
--- a/config/samples/dataplane_v1beta1_openstackdataplane_baremetal_with_ipam.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplane_baremetal_with_ipam.yaml
@@ -33,8 +33,6 @@ spec:
         bmhLabelSelector:
           app: openstack
         ctlplaneInterface: enp1s0
-        dnsSearchDomains:
-          - osptest.openstack.org
       nodeTemplate:
         nova: {}
         networks:

--- a/config/samples/dataplane_v1beta1_openstackdataplane_with_ipam.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplane_with_ipam.yaml
@@ -11,8 +11,18 @@ spec:
       hostName: edpm-compute-0
       ansibleHost: 192.168.122.100
       node:
-        ansibleVars:
-          ctlplane_ip: 192.168.122.100
+        ansibleVars: {}
+        networks:
+        - name: CtlPlane
+          subnetName: subnet1
+          defaultRoute: true
+          fixedIP: 192.168.122.100
+        - name: InternalApi
+          subnetName: subnet1
+        - name: Storage
+          subnetName: subnet1
+        - name: Tenant
+          subnetName: subnet1
       deployStrategy:
         deploy: false
     edpm-compute-1:
@@ -20,8 +30,18 @@ spec:
       hostName: edpm-compute-1
       ansibleHost: 192.168.122.101
       node:
-        ansibleVars:
-          ctlplane_ip: 192.168.122.101
+       ansibleVars: {}
+       networks:
+       - name: CtlPlane
+         subnetName: subnet1
+         defaultRoute: true
+         fixedIP: 192.168.122.101
+       - name: InternalApi
+         subnetName: subnet1
+       - name: Storage
+         subnetName: subnet1
+       - name: Tenant
+         subnetName: subnet1
       deployStrategy:
         deploy: false
   roles:
@@ -44,16 +64,6 @@ spec:
         # Defining the novaTemplate here means the nodes in this role are
         # computes
         nova: {}
-        networks:
-        - name: CtlPlane
-          subnetName: subnet1
-          defaultRoute: true
-        - name: InternalApi
-          subnetName: subnet1
-        - name: Storage
-          subnetName: subnet1
-        - name: Tenant
-          subnetName: subnet1
         managementNetwork: ctlplane
         ansibleUser: root
         ansiblePort: 22
@@ -92,11 +102,6 @@ spec:
           edpm_chrony_ntp_servers:
           - clock.redhat.com
           - clock2.redhat.com
-
-          ctlplane_dns_nameservers:
-          - 192.168.122.1
-          dns_search_domains: []
-
           registry_url: quay.io/podified-antelope-centos9
           image_tag: current-podified
           edpm_ovn_controller_agent_image: "{{ registry_url }}/openstack-ovn-controller:{{ image_tag }}"

--- a/pkg/deployment/inventory.go
+++ b/pkg/deployment/inventory.go
@@ -60,15 +60,17 @@ func GenerateRoleInventory(ctx context.Context, helper *helper.Helper,
 		} else {
 			host.Vars["ansible_host"] = node.Spec.HostName
 		}
-		ipSet, ok := allIPSets[node.Name]
-		if ok {
-			populateInventoryFromIPAM(&ipSet, host, dnsAddresses)
-		}
 
 		err = resolveAnsibleVars(&node.Spec.Node, &host, &ansible.Group{})
 		if err != nil {
 			return "", err
 		}
+
+		ipSet, ok := allIPSets[node.Name]
+		if ok {
+			populateInventoryFromIPAM(&ipSet, host, dnsAddresses)
+		}
+
 	}
 
 	if instance.Spec.NodeTemplate.Nova != nil {


### PR DESCRIPTION
If we use both IPs in ansibleVars and IPAM there can be issues with IPAM reserved IPs different from what's used in ansibleVars with duplicates. We've IPAM so that we can avoid duplicates.

There should be single interface to change those. For pre-provisoned nodes we shoud use fixedIP to ensure that we reserve the ctlplane IP we use for the node.

When using IPAM, IPs in ansibleVars would be ignored.