### PR TITLE
Use appropriate message for final Ready condition

### DIFF
--- a/api/v1beta1/conditions.go
+++ b/api/v1beta1/conditions.go
@@ -24,26 +24,17 @@ const (
 	// DataPlaneNodeReadyMessage ready
 	DataPlaneNodeReadyMessage = "DataPlaneNode ready"
 
-	// DataPlaneNodeReadyWaitingMessage ready
-	DataPlaneNodeReadyWaitingMessage = "DataPlaneNode not yet ready"
-
 	// DataPlaneNodeErrorMessage error
 	DataPlaneNodeErrorMessage = "DataPlaneNode error occurred %s"
 
 	// DataPlaneRoleReadyMessage ready
 	DataPlaneRoleReadyMessage = "DataPlaneRole ready"
 
-	// DataPlaneRoleReadyWaitingMessage ready
-	DataPlaneRoleReadyWaitingMessage = "DataPlaneRole not yet ready"
-
 	// DataPlaneRoleErrorMessage error
 	DataPlaneRoleErrorMessage = "DataPlaneRole error occurred %s"
 
 	// DataPlaneReadyMessage ready
 	DataPlaneReadyMessage = "DataPlane ready"
-
-	// DataPlaneReadyWaitingMessage ready
-	DataPlaneReadyWaitingMessage = "DataPlane not yet ready"
 
 	// DataPlaneErrorMessage error
 	DataPlaneErrorMessage = "DataPlane error occurred %s"

--- a/controllers/openstackdataplane_controller.go
+++ b/controllers/openstackdataplane_controller.go
@@ -99,7 +99,7 @@ func (r *OpenStackDataPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 		// update the Ready condition based on the sub conditions
 		if instance.Status.Conditions.AllSubConditionIsTrue() {
 			instance.Status.Conditions.MarkTrue(
-				condition.ReadyCondition, condition.ReadyMessage)
+				condition.ReadyCondition, dataplanev1.DataPlaneReadyMessage)
 		} else {
 			// something is not ready so reset the Ready condition
 			instance.Status.Conditions.MarkUnknown(

--- a/controllers/openstackdataplanenode_controller.go
+++ b/controllers/openstackdataplanenode_controller.go
@@ -124,7 +124,7 @@ func (r *OpenStackDataPlaneNodeReconciler) Reconcile(ctx context.Context, req ct
 		if instance.Status.Conditions.AllSubConditionIsTrue() {
 			instance.Status.Deployed = true
 			instance.Status.Conditions.MarkTrue(
-				condition.ReadyCondition, condition.ReadyMessage)
+				condition.ReadyCondition, dataplanev1.DataPlaneNodeReadyMessage)
 		} else {
 			// something is not ready so reset the Ready condition
 			instance.Status.Conditions.MarkUnknown(

--- a/controllers/openstackdataplanerole_controller.go
+++ b/controllers/openstackdataplanerole_controller.go
@@ -131,7 +131,7 @@ func (r *OpenStackDataPlaneRoleReconciler) Reconcile(ctx context.Context, req ct
 		// update the Ready condition based on the sub conditions
 		if instance.Status.Conditions.AllSubConditionIsTrue() {
 			instance.Status.Conditions.MarkTrue(
-				condition.ReadyCondition, condition.ReadyMessage)
+				condition.ReadyCondition, dataplanev1.DataPlaneRoleReadyMessage)
 		} else {
 			// something is not ready so reset the Ready condition
 			instance.Status.Conditions.MarkUnknown(

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/01-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/01-assert.yaml
@@ -9,7 +9,7 @@ spec:
     deploy: true
 status:
   conditions:
-  - message: Setup complete
+  - message: DataPlane ready
     reason: Ready
     status: "True"
     type: Ready
@@ -42,7 +42,7 @@ spec:
     deploy: true
 status:
   conditions:
-  - message: Setup complete
+  - message: DataPlaneRole ready
     reason: Ready
     status: "True"
     type: Ready


### PR DESCRIPTION
We use `SetupReadyCondition` that we set before deployment has been started and use the same message i.e "Setup Complete" for final `Ready` condition. This is confusing. Let's use the custom messages that we've for `Ready` condition.

Also cleans up some of the redundant condition messages.