### PR TITLE
Remove explicit EDPM deploy pod name variable.

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -30,14 +30,11 @@
     parent: cifmw-crc-podified-edpm-deployment
     vars:
       bmo_setup: true
-      cifmw_edpm_deploy_nova_pod_name: dataplane-deployment-nova-edpm-compute
     irrelevant-files: *openstack_if
 
 - job:
     name: dataplane-operator-crc-podified-edpm-baremetal
     parent: cifmw-crc-podified-edpm-baremetal
-    vars:
-      cifmw_edpm_deploy_nova_pod_name: dataplane-deployment-nova-edpm-compute
     irrelevant-files: *openstack_if
 
 - job:


### PR DESCRIPTION
With the introduction of the new wait condition for EDPM deployment there is now no need to check for the status of the deploy pod, so it's name is no more needed.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/442