### PR TITLE
Linking playbooks in dataplane frr services

### DIFF
--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_install_frr.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_install_frr.yaml
@@ -4,15 +4,4 @@ metadata:
   name: install-frr
 spec:
   label: dataplane-deployment-install-frr
-  role:
-    name: "Deploy EDPM FRR Install"
-    hosts: "all"
-    strategy: "linear"
-    become: true
-    tasks:
-      - name: "Install edpm_frr"
-        import_role:
-          name: "osp.edpm.edpm_frr"
-          tasks_from: "install.yml"
-        tags:
-          - "edpm_frr"
+  playbook: osp.edpm.install_frr

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_run_frr.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_run_frr.yaml
@@ -4,15 +4,4 @@ metadata:
   name: run-frr
 spec:
   label: dataplane-deployment-run-frr
-  role:
-    name: "Deploy EDPM FRR Run"
-    hosts: "all"
-    strategy: "linear"
-    become: true
-    tasks:
-      - name: "Run edpm_frr"
-        import_role:
-          name: "osp.edpm.edpm_frr"
-          tasks_from: "run.yml"
-        tags:
-          - "edpm_frr"
+  playbook: osp.edpm.run_frr


### PR DESCRIPTION
Following services will now use playbooks from edpm-ansible collection, rather than the previous structured 'role' field:

- run_frr
- install_frr