### PR TITLE
Linking playbooks in dataplane ovn bgp agent services

### DIFF
--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_configure_ovn_bgp_agent.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_configure_ovn_bgp_agent.yaml
@@ -4,15 +4,4 @@ metadata:
   name: configure-ovn-bgp-agent
 spec:
   label: dataplane-deployment-configure-ovn-bgp-agent
-  role:
-    name: "Deploy EDPM OVN BGP Agent Configure"
-    hosts: "all"
-    strategy: "linear"
-    become: true
-    tasks:
-      - name: "Configure edpm_ovn_bgp_agent"
-        import_role:
-          name: "osp.edpm.edpm_ovn_bgp_agent"
-          tasks_from: "configure.yml"
-        tags:
-          - "edpm_ovn_bgp_agent"
+  playbook: osp.edpm.configure_ovn_bgp_agent

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_install_ovn_bgp_agent.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_install_ovn_bgp_agent.yaml
@@ -4,15 +4,4 @@ metadata:
   name: install-ovn-bgp-agent
 spec:
   label: dataplane-deployment-install-ovn-bgp-agent
-  role:
-    name: "Deploy EDPM OVN BGP Agent Install"
-    hosts: "all"
-    strategy: "linear"
-    become: true
-    tasks:
-      - name: "Install edpm_ovn_bgp_agent"
-        import_role:
-          name: "osp.edpm.edpm_ovn_bgp_agent"
-          tasks_from: "install.yml"
-        tags:
-          - "edpm_ovn_bgp_agent"
+  playbook: osp.edpm.install_ovn_bgp_agent

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_run_ovn_bgp_agent.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_run_ovn_bgp_agent.yaml
@@ -4,15 +4,4 @@ metadata:
   name: run-ovn-bgp-agent
 spec:
   label: dataplane-deployment-run-ovn-bgp-agent
-  role:
-    name: "Deploy EDPM OVN BGP Agent Run"
-    hosts: "all"
-    strategy: "linear"
-    become: true
-    tasks:
-      - name: "Run edpm_ovn_bgp_agent"
-        import_role:
-          name: "osp.edpm.edpm_ovn_bgp_agent"
-          tasks_from: "run.yml"
-        tags:
-          - "edpm_ovn_bgp_agent"
+  playbook: osp.edpm.run_ovn_bgp_agent


### PR DESCRIPTION
Following services will now use playbooks from edpm-ansible collection, rather than the previous structured 'role' field:

- install-ovn-bgp-agent
- configure-ovn-bgp-agent
- run-ovn-bgp-agent