### PR TITLE
Linking playbooks in dataplane network services

### DIFF
--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_configure_network.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_configure_network.yaml
@@ -10,41 +10,4 @@ metadata:
   name: configure-network
 spec:
   label: dataplane-deployment-configure-network
-  role:
-
-    name: "Deploy EDPM Network"
-    hosts: "all"
-    strategy: "linear"
-    tasks:
-      - name: "Grow volumes"
-        import_role:
-          name: "osp.edpm.edpm_growvols"
-        tags:
-          - "edpm_growvols"
-      - name: "Install edpm_bootstrap"
-        import_role:
-          name: "osp.edpm.edpm_bootstrap"
-          tasks_from: "bootstrap.yml"
-        tags:
-          - "edpm_bootstrap"
-      - name: "Install edpm_kernel"
-        import_role:
-          name: "osp.edpm.edpm_kernel"
-        tags:
-          - "edpm_kernel"
-      - name: "Import edpm_tuned"
-        import_role:
-          name: "osp.edpm.edpm_tuned"
-        tags:
-          - "edpm_tuned"
-      - name: "Configure Kernel Args"
-        import_role:
-          name: "osp.edpm.edpm_kernel"
-          tasks_from: "kernelargs.yml"
-        tags:
-          - "edpm_kernel"
-      - name: "import edpm_network_config"
-        import_role:
-          name: "osp.edpm.edpm_network_config"
-        tags:
-          - "edpm_network_config"
+  playbook: osp.edpm.configure_network

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_validate_network.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_validate_network.yaml
@@ -10,13 +10,4 @@ metadata:
   name: validate-network
 spec:
   label: dataplane-deployment-validate-network
-  role:
-    name: "osp.edpm.edpm_nodes_validation"
-    hosts: "all"
-    strategy: "linear"
-    tasks:
-      - name: "import edpm_nodes_validation"
-        import_role:
-          name: "osp.edpm.edpm_nodes_validation"
-        tags:
-          - "edpm_nodes_validation"
+  playbook: osp.edpm.validate_network

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/01-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/01-assert.yaml
@@ -134,46 +134,7 @@ spec:
   image: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
   name: openstackansibleee
   restartPolicy: Never
-  roles:
-    any_errors_fatal: true
-    become: false
-    gather_facts: false
-    hosts: all
-    name: Deploy EDPM Network
-    strategy: linear
-    tasks:
-    - import_role:
-        name: osp.edpm.edpm_growvols
-      name: Grow volumes
-      tags:
-      - edpm_growvols
-    - import_role:
-        name: osp.edpm.edpm_bootstrap
-        tasks_from: bootstrap.yml
-      name: Install edpm_bootstrap
-      tags:
-      - edpm_bootstrap
-    - import_role:
-        name: osp.edpm.edpm_kernel
-      name: Install edpm_kernel
-      tags:
-      - edpm_kernel
-    - import_role:
-        name: osp.edpm.edpm_tuned
-      name: Import edpm_tuned
-      tags:
-      - edpm_tuned
-    - import_role:
-        name: osp.edpm.edpm_kernel
-        tasks_from: kernelargs.yml
-      name: Configure Kernel Args
-      tags:
-      - edpm_kernel
-    - import_role:
-        name: osp.edpm.edpm_network_config
-      name: import edpm_network_config
-      tags:
-      - edpm_network_config
+  playbook: osp.edpm.configure_network
   uid: 1001
 status:
   JobStatus: Succeeded
@@ -229,17 +190,7 @@ spec:
   image: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
   name: openstackansibleee
   restartPolicy: Never
-  roles:
-    any_errors_fatal: true
-    become: false
-    gather_facts: false
-    hosts: all
-    name: osp.edpm.edpm_nodes_validation
-    strategy: linear
-    tasks:
-    - import_role:
-        name: osp.edpm.edpm_nodes_validation
-      name: import edpm_nodes_validation
+  playbook: osp.edpm.validate_network
   uid: 1001
 status:
   JobStatus: Succeeded


### PR DESCRIPTION
Following services will now use playbooks from edpm-ansible collection, rather than the previous structured 'role' field:

- configure-network
- validate-network