### PR TITLE
Linking playbooks in dataplane ceph services

### DIFF
--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_ceph_client.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_ceph_client.yaml
@@ -4,14 +4,4 @@ metadata:
   name: ceph-client
 spec:
   label: dataplane-deployment-ceph-client
-  role:
-    name: "Configure EDPM as client of Ceph"
-    hosts: "all"
-    strategy: "linear"
-    become: true
-    tasks:
-      - name: "Configure EDPM as client of Ceph"
-        import_role:
-          name: "osp.edpm.edpm_ceph_client_files"
-        tags:
-          - "edpm_ceph_client"
+  playbook: osp.edpm.ceph_client

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_ceph_hci_pre.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_ceph_hci_pre.yaml
@@ -4,14 +4,4 @@ metadata:
   name: ceph-hci-pre
 spec:
   label: dataplane-deployment-ceph-hci-pre
-  role:
-    name: "Prepare EDPM to Host Ceph"
-    hosts: "all"
-    strategy: "linear"
-    become: true
-    tasks:
-      - name: "Prepare EDPM to Host Ceph"
-        import_role:
-          name: "osp.edpm.edpm_ceph_hci_pre"
-        tags:
-          - "edpm_ceph_hci_pre"
+  playbook: osp.edpm.ceph_hci_pre


### PR DESCRIPTION
Following services will now use playbooks from edpm-ansible collection, rather than the previous structured 'role' field:

- ceph-client
- ceph-hci-pre

Depends-On: https://github.com/openstack-k8s-operators/edpm-ansible/pull/279 