### PR TITLE
Linking playbooks in ovn, nova and libvirt services

### DIFF
--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_libvirt.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_libvirt.yaml
@@ -4,13 +4,4 @@ metadata:
   name: libvirt
 spec:
   label: dataplane-deployment-libvirt
-  role:
-    name: "Deploy EDPM libvirt"
-    hosts: "all"
-    strategy: "linear"
-    tasks:
-      - name: "libvirt"
-        import_role:
-          name: "osp.edpm.edpm_libvirt"
-        tags:
-          - "edpm_libvirt"
+  playbook: osp.edpm.libvirt

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_nova.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_nova.yaml
@@ -6,13 +6,4 @@ spec:
   label: dataplane-deployment-nova
   secrets:
     - nova-cell1-compute-config
-  role:
-    name: "Deploy EDPM Nova"
-    hosts: "all"
-    strategy: "linear"
-    tasks:
-      - name: "nova"
-        import_role:
-          name: "osp.edpm.edpm_nova"
-        tags:
-          - "edpm_nova"
+  playbook: osp.edpm.nova

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_ovn.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_ovn.yaml
@@ -4,14 +4,4 @@ metadata:
   name: ovn
 spec:
   label: dataplane-deployment-ovn
-  role:
-    name: "Deploy EDPM OVN"
-    hosts: "all"
-    strategy: "linear"
-    become: true
-    tasks:
-      - name: "ovn"
-        import_role:
-          name: "osp.edpm.edpm_ovn"
-        tags:
-          - "edpm_ovn"
+  playbook: osp.edpm.ovn

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/01-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/01-assert.yaml
@@ -624,19 +624,7 @@ spec:
   image: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
   name: openstackansibleee
   restartPolicy: Never
-  roles:
-    any_errors_fatal: true
-    become: true
-    gather_facts: false
-    hosts: all
-    name: Deploy EDPM OVN
-    strategy: linear
-    tasks:
-    - import_role:
-        name: osp.edpm.edpm_ovn
-      name: ovn
-      tags:
-      - edpm_ovn
+  playbook: osp.edpm.ovn
   uid: 1001
 status:
   JobStatus: Succeeded
@@ -695,19 +683,7 @@ spec:
   name: openstackansibleee
   preserveJobs: true
   restartPolicy: Never
-  roles:
-    any_errors_fatal: true
-    become: false
-    gather_facts: false
-    hosts: all
-    name: Deploy EDPM libvirt
-    strategy: linear
-    tasks:
-    - import_role:
-        name: osp.edpm.edpm_libvirt
-      name: libvirt
-      tags:
-      - edpm_libvirt
+  playbook: osp.edpm.libvirt
   uid: 1001
 status:
   JobStatus: Succeeded
@@ -771,19 +747,7 @@ spec:
   name: openstackansibleee
   preserveJobs: true
   restartPolicy: Never
-  roles:
-    any_errors_fatal: true
-    become: false
-    gather_facts: false
-    hosts: all
-    name: Deploy EDPM Nova
-    strategy: linear
-    tasks:
-    - import_role:
-        name: osp.edpm.edpm_nova
-      name: nova
-      tags:
-      - edpm_nova
+  playbook: osp.edpm.nova
   uid: 1001
 status:
   JobStatus: Succeeded


### PR DESCRIPTION
Following services will now use playbooks from edpm-ansible collection, rather than the previous structured 'role' field:

- ovn
- nova
- libvirt

Depends-On: https://github.com/openstack-k8s-operators/edpm-ansible/pull/280