### PR TITLE
Remove the yaml mapping for OpenStackAnsibleEERunnerImage

### DIFF
--- a/api/v1beta1/openstackdataplaneservice_types.go
+++ b/api/v1beta1/openstackdataplaneservice_types.go
@@ -70,7 +70,7 @@ type OpenStackDataPlaneServiceSpec struct {
 
 	// OpenStackAnsibleEERunnerImage image to use as the ansibleEE runner image
 	// +kubebuilder:validation:Optional
-	OpenStackAnsibleEERunnerImage string `json:"openStackAnsibleEERunnerImage,omitempty" yaml:"openStackAnsibleEERunnerImage,omitempty"`
+	OpenStackAnsibleEERunnerImage string `json:"openStackAnsibleEERunnerImage,omitempty"`
 }
 
 // OpenStackDataPlaneServiceStatus defines the observed state of OpenStackDataPlaneService


### PR DESCRIPTION
Something is happening with the decode or clone of OpenStackDataPlaneServiceSpec which is resulting in OpenStackAnsibleEERunnerImage being stripped, meaning any custom runner image is not being applied for the actual run.

This is an attempt to fix that issue.