### PR TITLE
Use new content provider and standalone crc based edpm job

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -1,13 +1,7 @@
 ---
 - job:
-    name: dataplane-operator-content-provider
-    parent: content-provider-base
-    vars:
-      cifmw_operator_build_org: openstack-k8s-operators
-      cifmw_operator_build_operators:
-        - name: "openstack-operator"
-          src: "~/src/github.com/{{ cifmw_operator_build_org }}/openstack-operator"
-          image_base: dataplane
+    name: dataplane-operator-crc-podified-edpm-baremetal
+    parent: cifmw-crc-podified-edpm-baremetal
     irrelevant-files: &openstack_if
       - tests/kuttl
       - docs
@@ -24,18 +18,6 @@
       - .*/*.md
       - kuttl-test.yaml
       - renovate.json
-
-- job:
-    name: dataplane-operator-crc-podified-edpm-deployment
-    parent: cifmw-crc-podified-edpm-deployment
-    vars:
-      bmo_setup: true
-    irrelevant-files: *openstack_if
-
-- job:
-    name: dataplane-operator-crc-podified-edpm-baremetal
-    parent: cifmw-crc-podified-edpm-baremetal
-    irrelevant-files: *openstack_if
 
 - job:
     name: dataplane-operator-docs-preview

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -4,8 +4,8 @@
     github-check:
       jobs:
         - dataplane-operator-docs-preview
-        - dataplane-operator-content-provider
-        - dataplane-operator-crc-podified-edpm-baremetal: &content_provider
+        - openstack-k8s-operators-content-provider
+        - podified-multinode-edpm-deployment-crc: &content_provider
             dependencies:
-              - dataplane-operator-content-provider
-        - dataplane-operator-crc-podified-edpm-deployment: *content_provider
+              - openstack-k8s-operators-content-provider
+        - dataplane-operator-crc-podified-edpm-baremetal: *content_provider


### PR DESCRIPTION
This pr removes the old content provider and edpm job and uses the new content provider and standalone crc based edpm job.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/379