### PR TITLE
Reset aeeSpec.ExtraMounts after each service deploy

### DIFF
--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/00-dataplane-create.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/00-dataplane-create.yaml
@@ -4,7 +4,8 @@ kind: Secret
 metadata:
   name: nova-cell1-compute-config
 data:
-  00-ansibleVars: Zm9vCg==
+  01-nova.conf: Zm9vCg==
+  nova-blank.conf: Zm9vCg==
 ---
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlane

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/01-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/01-assert.yaml
@@ -500,15 +500,24 @@ spec:
   envConfigMapName: openstack-aee-default-env
   extraMounts:
   - mounts:
-    - mountPath: /var/lib/openstack/configs/nova/00-ansibleVars
+    - mountPath: /var/lib/openstack/configs/nova/01-nova.conf
       name: nova-cell1-compute-config-0
-      subPath: 00-ansibleVars
+      subPath: 01-nova.conf
+    - mountPath: /var/lib/openstack/configs/nova/nova-blank.conf
+      name: nova-cell1-compute-config-1
+      subPath: nova-blank.conf
     volumes:
     - name: nova-cell1-compute-config-0
       secret:
         items:
-        - key: 00-ansibleVars
-          path: 00-ansibleVars
+        - key: 01-nova.conf
+          path: 01-nova.conf
+        secretName: nova-cell1-compute-config
+    - name: nova-cell1-compute-config-1
+      secret:
+        items:
+        - key: nova-blank.conf
+          path: nova-blank.conf
         secretName: nova-cell1-compute-config
   - mounts:
     - mountPath: /runner/env/ssh_key


### PR DESCRIPTION
The ExtraMounts field for the aeeSpec needs to be reset back to its
original value after each service deployment. Otherwise, every new
service's extra mounts are appended to the list.

Signed-off-by: James Slagle <jslagle@redhat.com>
