### PR TITLE
Make with_ipam samples consistent with each other

### DIFF
--- a/config/samples/dataplane_v1beta1_openstackdataplane_baremetal_with_ipam.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplane_baremetal_with_ipam.yaml
@@ -26,6 +26,16 @@ spec:
           value: "True"
         - name: ANSIBLE_VERBOSITY
           value: "2"
+      services:
+        - repo-setup
+        - configure-network
+        - validate-network
+        - install-os
+        - configure-os
+        - run-os
+        - ovn
+        - libvirt
+        - nova
       networkAttachments:
         - ctlplane
       baremetalSetTemplate:
@@ -51,14 +61,13 @@ spec:
           service_net_map:
             nova_api_network: internal_api
             nova_libvirt_network: internal_api
-          edpm_chrony_ntp_servers:
-            - 0.pool.ntp.org
-            - 1.pool.ntp.org
+
           # edpm_network_config
           # Default nic config template for a EDPM compute node
           # These vars are edpm_network_config role vars
           edpm_network_config_template: templates/single_nic_vlans/single_nic_vlans.j2
           edpm_network_config_hide_sensitive_logs: false
+          #
           # These vars are for the network config templates themselves and are
           # considered EDPM network defaults.
           neutron_physical_bridge_name: br-ex
@@ -77,8 +86,11 @@ spec:
           edpm_nodes_validation_validate_controllers_icmp: false
           edpm_nodes_validation_validate_gateway_icmp: false
 
-          edpm_ovn_metadata_agent_metadata_agent_default_metadata_proxy_shared_secret: 12345678
-          edpm_ovn_metadata_agent_default_bind_host: 127.0.0.1
+          edpm_ovn_metadata_agent_metadata_agent_DEFAULT_metadata_proxy_shared_secret: 12345678
+          edpm_ovn_metadata_agent_DEFAULT_bind_host: 127.0.0.1
+          edpm_chrony_ntp_servers:
+          - clock.redhat.com
+          - clock2.redhat.com
           dns_search_domains: []
 
           registry_url: quay.io/podified-antelope-centos9
@@ -89,7 +101,6 @@ spec:
           edpm_nova_compute_container_image: "{{ registry_url }}/openstack-nova-compute:{{ image_tag }}"
           edpm_nova_libvirt_container_image: "{{ registry_url }}/openstack-nova-libvirt:{{ image_tag }}"
           edpm_ovn_metadata_agent_image: "{{ registry_url }}/openstack-neutron-metadata-agent-ovn:{{ image_tag }}"
-
           gather_facts: false
           enable_debug: false
           # edpm firewall, change the allowed CIDR if needed

--- a/config/samples/dataplane_v1beta1_openstackdataplane_with_ipam.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplane_with_ipam.yaml
@@ -51,8 +51,11 @@ spec:
           value: "True"
         - name: ANSIBLE_ENABLE_TASK_DEBUGGER
           value: "True"
+        - name: ANSIBLE_VERBOSITY
+          value: "2"
       preProvisioned: true
       services:
+        - repo-setup
         - configure-network
         - validate-network
         - install-os

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -221,8 +221,8 @@ With the nodes and the controlplane specific variables added, the full
               # Variables set with values from the controlplane
               edpm_ovn_metadata_agent_default_transport_url: rabbit://default_user@rabbitmq.openstack.svc:5672
               edpm_ovn_metadata_agent_metadata_agent_ovn_ovn_sb_connection: tcp:10.217.5.121:6642
-              edpm_ovn_metadata_agent_metadata_agent_default_nova_metadata_host: 127.0.0.1
-              edpm_ovn_metadata_agent_metadata_agent_default_metadata_proxy_shared_secret: 12345678
+              edpm_ovn_metadata_agent_metadata_agent_DEFAULT_nova_metadata_host: 127.0.0.1
+              edpm_ovn_metadata_agent_metadata_agent_DEFAULT_metadata_proxy_shared_secret: 12345678
               edpm_ovn_metadata_agent_default_bind_host: 127.0.0.1
               edpm_ovn_dbs:
               - 192.168.24.1


### PR DESCRIPTION
dataplane_v1beta1_openstackdataplane_baremetal_with_ipam.yaml is used by two different make targets in install_yamls, and
config/samples/dataplane_v1beta1_openstackdataplane_with_ipam.yaml by one.

This change aligns these samples for consistency, and to support work in install_yamls to make the baremetal workflow more practical and documented for developers.

The one functional change in this commit is the addition of the
`repo-setup` service to
dataplane_v1beta1_openstackdataplane_with_ipam.yaml. This service is
already patched in[1], and it is really time for
install_yamls/devsetup/scripts/edpm-compute-repos.sh to be retired.

[1] https://github.com/openstack-k8s-operators/install_yamls/blob/main/scripts/gen-edpm-kustomize.sh#L94-L96