### PR TITLE
Constraining doc build requirements

### DIFF
--- a/docs/doc_requirements.txt
+++ b/docs/doc_requirements.txt
@@ -1,5 +1,5 @@
-mkdocs
-mike
-mkdocs-git-revision-date-plugin
-mkdocs-material
-mkdocs-build-plantuml-plugin
+mkdocs>=1.5.2,<1.6.0
+mike>=1.1.2,<1.2.0
+mkdocs-git-revision-date-plugin>=0.3.2,<1.0.0
+mkdocs-material>=9.2.8,<9.3.0
+mkdocs-build-plantuml-plugin>=1.7.4,<1.8.0


### PR DESCRIPTION
Issues with unexpected changes in python requirements have plagued us before. It's better to be proactive about this and constrain versions to a sensible range, so we don't get surprise build failures at some point.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/513