### PR TITLE
Simplifying the controller result conditional

### DIFF
--- a/controllers/openstackdataplane_controller.go
+++ b/controllers/openstackdataplane_controller.go
@@ -128,7 +128,8 @@ func (r *OpenStackDataPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 	ctrlResult, err := createOrPatchDataPlaneResources(ctx, instance, helper)
 	if err != nil {
 		return ctrl.Result{}, err
-	} else if (ctrlResult != ctrl.Result{}) {
+	} else if !ctrlResult.IsZero() {
+		// if result isn't empty, return it
 		return ctrlResult, nil
 	}
 


### PR DESCRIPTION
Rather than check against an empty object, we can ask the object itself if it's empty.