### PR TITLE
[doc]Trigger nova discover hosts after EDPM deploy

### DIFF
--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -387,6 +387,13 @@ edpm-compute-0   True    DataPlaneNode Ready
 edpm-compute-1   True    DataPlaneNode Ready
 ```
 
+If the deployment involved adding new compute nodes then after the deployment
+is ready those compute nodes need to be mapped in nova. To do that run the
+following command:
+```console
+oc rsh nova-cell0-conductor-0 nova-manage cell_v2 discover_hosts --verbose
+```
+
 ### Understanding dataplane conditions
 
 Each dataplane resource has a series of conditions within their `status`


### PR DESCRIPTION
The periodic host discovery is now disabled in nova-scheduler as it is not scaling well. Instead after EDPM compute node deployment the nova-manage cell_v2 discover_hosts CLI needs to be run to trigger the discovery.

This PR documents the new necessary manual step.

Related-To: openstack-k8s-operators/nova-operator#519
Related: https://issues.redhat.com/browse/OSPRH-319