### PR TITLE
Fix Regression with IPAM

### DIFF
--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal_with_ipam.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal_with_ipam.yaml
@@ -20,7 +20,6 @@ spec:
   deployStrategy:
       deploy: true
   baremetalSetTemplate:
-    bmhNamespace: openstack
     deploymentSSHSecret: dataplane-ansible-ssh-private-key-secret
     bmhLabelSelector:
       app: openstack
@@ -33,29 +32,19 @@ spec:
     nodes:
        edpm-compute-0:
          hostName: edpm-compute-0
-         ansible:
-           ansibleUser: root
-           ansibleHost: 192.168.122.100
-           ansibleVars:
-             ctlplane_ip: 192.168.122.100
-             internal_api_ip: 172.17.0.100
-             storage_ip: 172.18.0.100
-             tenant_ip: 172.19.0.100
-             fqdn_internal_api: edpm-compute-0.example.com
-         networks:
-         - name: CtlPlane
-           subnetName: subnet1
-           defaultRoute: true
-           fixedIP: 192.168.122.100
-         - name: InternalApi
-           subnetName: subnet1
-         - name: Storage
-           subnetName: subnet1
-         - name: Tenant
-           subnetName: subnet1
+    networks:
+      - name: CtlPlane
+        subnetName: subnet1
+        defaultRoute: true
+      - name: InternalApi
+        subnetName: subnet1
+      - name: Storage
+        subnetName: subnet1
+      - name: Tenant
+        subnetName: subnet1
     managementNetwork: ctlplane
     ansible:
-      ansibleUser: root
+      ansibleUser: cloud-admin
       ansiblePort: 22
       ansibleVars:
          service_net_map:
@@ -72,28 +61,6 @@ spec:
          # considered EDPM network defaults.
          neutron_physical_bridge_name: br-ex
          neutron_public_interface_name: eth0
-         ctlplane_mtu: 1500
-         ctlplane_subnet_cidr: 24
-         ctlplane_gateway_ip: 192.168.122.1
-         ctlplane_host_routes:
-         - ip_netmask: 0.0.0.0/0
-           next_hop: 192.168.122.1
-         external_mtu: 1500
-         external_vlan_id: 44
-         external_cidr: '24'
-         external_host_routes: []
-         internal_api_mtu: 1500
-         internal_api_vlan_id: 20
-         internal_api_cidr: '24'
-         internal_api_host_routes: []
-         storage_mtu: 1500
-         storage_vlan_id: 21
-         storage_cidr: '24'
-         storage_host_routes: []
-         tenant_mtu: 1500
-         tenant_vlan_id: 22
-         tenant_cidr: '24'
-         tenant_host_routes: []
          role_networks:
          - InternalApi
          - Storage
@@ -111,9 +78,6 @@ spec:
          edpm_ovn_metadata_agent_metadata_agent_DEFAULT_nova_metadata_host: 127.0.0.1
          edpm_ovn_metadata_agent_metadata_agent_DEFAULT_metadata_proxy_shared_secret: 12345678
          edpm_ovn_metadata_agent_DEFAULT_bind_host: 127.0.0.1
-         ctlplane_dns_nameservers:
-         - 192.168.122.1
-         dns_search_domains: []
          edpm_ovn_dbs:
          - 192.168.122.1
          registry_url: quay.io/podified-antelope-centos9

--- a/pkg/deployment/ipam.go
+++ b/pkg/deployment/ipam.go
@@ -73,7 +73,9 @@ func createOrPatchDNSData(ctx context.Context, helper *helper.Helper,
 	// Build DNSData CR
 	for nodeName, node := range instance.Spec.NodeTemplate.Nodes {
 		nets := node.Networks
-
+		if len(nets) == 0 {
+			nets = instance.Spec.NodeTemplate.Networks
+		}
 		if len(nets) > 0 {
 			// Get IPSet
 			ipSet, ok := allIPSets[nodeName]
@@ -211,14 +213,10 @@ func reserveIPs(ctx context.Context, helper *helper.Helper,
 	for nodeName, node := range instance.Spec.NodeTemplate.Nodes {
 		nets := node.Networks
 
-		if instance.Spec.PreProvisioned {
-			// Drop CtlPlaneNetwork
-			for i, v := range nets {
-				if v.Name == CtlPlaneNetwork {
-					nets = append(nets[:i], nets[i+1:]...)
-				}
-			}
+		if len(nets) == 0 {
+			nets = instance.Spec.NodeTemplate.Networks
 		}
+
 		if len(nets) > 0 {
 			util.LogForObject(helper, "Reconciling IPSet", instance)
 			ipSet := &infranetworkv1.IPSet{


### PR DESCRIPTION
We should use Spec.NodeTemplate.Networks if there are no node.Networks. Also, remove the block to remove ctlplane network. Fixes the sample used in CI.

- ansible_user: cloud-admin
- Remove all ansible vars for network ips
- Remove BMH namespace from the sample as it is also used with CBO. We patch it in install_yamls for CI.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/528