### PR TITLE
Fix ExtraMounts

### DIFF
--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -87,7 +87,7 @@ func Deploy(
 
 		// Reset ExtraMounts to its original value, and then add in service
 		// specific mounts.
-		aeeSpec.ExtraMounts = []storage.VolMounts{}
+		aeeSpec.ExtraMounts = make([]storage.VolMounts, len(aeeSpecMounts))
 		copy(aeeSpec.ExtraMounts, aeeSpecMounts)
 		aeeSpec, err = addServiceExtraMounts(ctx, helper, aeeSpec, foundService)
 

--- a/tests/kuttl/tests/dataplane-extramounts/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-extramounts/00-assert.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneNodeSet
+metadata:
+  name: edpm-extramounts
+spec:
+  preProvisioned: true
+  deployStrategy:
+    deploy: true
+  services:
+    - test-service
+  nodeTemplate:
+    nodes: {}
+    extraMounts:
+    - extraVolType: edpm-ansible
+      mounts:
+      - mountPath: /usr/share/ansible/collections/ansible_collections/osp/edpm
+        name: edpm-ansible
+      volumes:
+      - name: edpm-ansible
+        persistentVolumeClaim:
+          claimName: edpm-ansible
+          readOnly: true
+---
+apiVersion: ansibleee.openstack.org/v1alpha1
+kind: OpenStackAnsibleEE
+metadata:
+  name: test-service-edpm-extramounts
+  namespace: openstack
+  ownerReferences:
+  - apiVersion: dataplane.openstack.org/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: OpenStackDataPlaneNodeSet
+    name: edpm-extramounts
+spec:
+  extraMounts:
+  - extraVolType: edpm-ansible
+    mounts:
+    - mountPath: /usr/share/ansible/collections/ansible_collections/osp/edpm
+      name: edpm-ansible
+    volumes:
+    - name: edpm-ansible
+      persistentVolumeClaim:
+        claimName: edpm-ansible
+        readOnly: true
+  - mounts:
+    - mountPath: /runner/env/ssh_key
+      name: ssh-key
+      subPath: ssh_key
+    - mountPath: /runner/inventory/hosts
+      name: inventory
+      subPath: inventory
+    - mountPath: /runner/network/nic-config-template
+      name: inventory
+      subPath: network
+    volumes:
+    - name: ssh-key
+      secret:
+        items:
+        - key: ssh-privatekey
+          path: ssh_key
+        secretName: dataplane-ansible-ssh-private-key-secret
+    - name: inventory
+      secret:
+        items:
+        - key: inventory
+          path: inventory
+        - key: network
+          path: network
+        secretName: dataplanenodeset-edpm-extramounts

--- a/tests/kuttl/tests/dataplane-extramounts/00-dataplane-create.yaml
+++ b/tests/kuttl/tests/dataplane-extramounts/00-dataplane-create.yaml
@@ -1,0 +1,31 @@
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneService
+metadata:
+  name: test-service
+spec:
+  label: test-service
+  playbook: test.yml
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneNodeSet
+metadata:
+  name: edpm-extramounts
+spec:
+  preProvisioned: true
+  deployStrategy:
+      deploy: true
+  services:
+    - test-service
+  nodeTemplate:
+    ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
+    nodes: {}
+    extraMounts:
+      - extraVolType: edpm-ansible
+        mounts:
+        - mountPath: /usr/share/ansible/collections/ansible_collections/osp/edpm
+          name: edpm-ansible
+        volumes:
+        - name: edpm-ansible
+          persistentVolumeClaim:
+            claimName: edpm-ansible
+            readOnly: true


### PR DESCRIPTION
ExtraMounts were being dropped and not added to the created
OpenStackAnsibleEE resources. The reason was because as each composable
service is deployed, aeeSpec.ExtraMounts is reset back to the original
value so that there is no cross over between mounts from individual
composable services. The reset was not working because the initialied
value of aeeSpec.ExtraMounts did not have a lenght set, causing the
copy() function to not actually copy any data.

The commit switches to using make(...) with a length parameter to ensure
the copy() works as intended.

Adds a new kuttl test, dataplane-extramounts, to test this specific
functionality.

Signed-off-by: James Slagle <jslagle@redhat.com>
