### PR TITLE
Replace EDPM job redefinition with a proper template

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -1,25 +1,5 @@
 ---
 - job:
-    name: dataplane-operator-crc-podified-edpm-baremetal
-    parent: cifmw-crc-podified-edpm-baremetal
-    irrelevant-files: &openstack_if
-      - ^tests/.*$
-      - docs
-      - containers/ci
-      - .github/workflows
-      - .ci-operator.yaml
-      - .dockerignore
-      - .gitignore
-      - .golangci.yaml
-      - .pre-commit-config.yaml
-      - LICENSE
-      - OWNERS*
-      - PROJECT
-      - .*/*.md
-      - kuttl-test.yaml
-      - renovate.json
-
-- job:
     name: dataplane-operator-docs-preview
     parent: cifmw-doc
     vars:

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -4,8 +4,5 @@
     github-check:
       jobs:
         - dataplane-operator-docs-preview
-        - openstack-k8s-operators-content-provider
-        - podified-multinode-edpm-deployment-crc: &content_provider
-            dependencies:
-              - openstack-k8s-operators-content-provider
-        - dataplane-operator-crc-podified-edpm-baremetal: *content_provider
+    templates:
+      - podified-multinode-edpm-baremetal-pipeline


### PR DESCRIPTION
To avoid redefining jobs that are exact copies of the ci-framework ones we are introducing zuul templates that already define those jobs. This will allow easier maintainability as a change that needs to be applied in the base job and in every child one (ex. var removal, type change, etc.) won't require a change in every repo, just one change in the base one in ci-framework.