### PR TITLE
Update network-config-template to new format

### DIFF
--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset.yaml
@@ -46,8 +46,8 @@ spec:
          # Default nic config template for a EDPM compute node
          # These vars are edpm_network_config role vars
          edpm_network_config_hide_sensitive_logs: false
-         edpm_network_config_template: templates/single_nic_vlans/single_nic_vlans.j2
-         edpm_network_config_override: |
+         edpm_network_config_override: ""
+         edpm_network_config_template: |
               ---
               {% set mtu_list = [ctlplane_mtu] %}
               {% for network in role_networks %}

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal.yaml
@@ -68,8 +68,8 @@ spec:
         # Default nic config template for a EDPM compute node
         # These vars are edpm_network_config role vars
         edpm_network_config_hide_sensitive_logs: false
-        edpm_network_config_template: templates/single_nic_vlans/single_nic_vlans.j2
-        edpm_network_config_override: |
+        edpm_network_config_override: ""
+        edpm_network_config_template: |
              ---
              {% set mtu_list = [ctlplane_mtu] %}
              {% for network in role_networks %}

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal_with_ipam.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal_with_ipam.yaml
@@ -54,8 +54,8 @@ spec:
          # Default nic config template for a EDPM compute node
          # These vars are edpm_network_config role vars
          edpm_network_config_hide_sensitive_logs: false
-         edpm_network_config_template: templates/single_nic_vlans/single_nic_vlans.j2
-         edpm_network_config_override: |
+         edpm_network_config_override: ""
+         edpm_network_config_template: |
               ---
               {% set mtu_list = [ctlplane_mtu] %}
               {% for network in role_networks %}

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ceph.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ceph.yaml
@@ -56,8 +56,8 @@ spec:
         # edpm_network_config
         # Default nic config template for a EDPM compute node
         # These vars are edpm_network_config role vars
-        edpm_network_config_template: templates/single_nic_vlans/single_nic_vlans.j2
-        edpm_network_config_override: |
+        edpm_network_config_override: ""
+        edpm_network_config_template: |
              ---
              {% set mtu_list = [ctlplane_mtu] %}
              {% for network in role_networks %}

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_customnetworks.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_customnetworks.yaml
@@ -48,8 +48,8 @@ spec:
         # edpm_network_config
         # Default nic config template for a EDPM compute node
         # These vars are edpm_network_config role vars
-        edpm_network_config_template: templates/single_nic_vlans/single_nic_vlans.j2
-        edpm_network_config_override: |
+        edpm_network_config_override: ""
+        edpm_network_config_template: |
              ---
              {% set mtu_list = [ctlplane_mtu] %}
              {% for network in role_networks %}

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_with_ipam.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_with_ipam.yaml
@@ -66,8 +66,8 @@ spec:
          # edpm_network_config
          # Default nic config template for a EDPM compute node
          # These vars are edpm_network_config role vars
-         edpm_network_config_template: templates/single_nic_vlans/single_nic_vlans.j2
-         edpm_network_config_override: |
+         edpm_network_config_override: ""
+         edpm_network_config_template: |
               ---
               {% set mtu_list = [ctlplane_mtu] %}
               {% for network in role_networks %}


### PR DESCRIPTION
This commit updates the sample files to use the new format that will accept Jinja2 files instead of a file path. We maintain the edpm_network_config_override variable for now to be backwards compatible with other projects that depend on it existing.

Depends-On: https://github.com/openstack-k8s-operators/edpm-ansible/pull/362
Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/581