### PR TITLE
Better distinguish between Ready conditions

### DIFF
--- a/api/v1beta1/conditions.go
+++ b/api/v1beta1/conditions.go
@@ -40,9 +40,8 @@ const (
 	// SetupReadyCondition - Overall setup condition
 	SetupReadyCondition condition.Type = "SetupReady"
 
-	// RoleBareMetalProvisionReadyCondition Status=True condition indicates
-	// all baremetal nodes provisioned for the Role.
-	RoleBareMetalProvisionReadyCondition condition.Type = "RoleBaremetalProvisionReady"
+	// NodeSetReadyMessage - NodeSet Ready
+	NodeSetReadyMessage = "NodeSet Ready"
 
 	// NodeSetBareMetalProvisionReadyCondition Status=True condition indicates
 	// all baremetal nodes provisioned for the NodeSet.

--- a/controllers/openstackdataplanenodeset_controller.go
+++ b/controllers/openstackdataplanenodeset_controller.go
@@ -162,7 +162,7 @@ func (r *OpenStackDataPlaneNodeSetReconciler) Reconcile(ctx context.Context, req
 	defer func() { // update the Ready condition based on the sub conditions
 		if instance.Status.Conditions.AllSubConditionIsTrue() {
 			instance.Status.Conditions.MarkTrue(
-				condition.ReadyCondition, condition.ReadyMessage)
+				condition.ReadyCondition, dataplanev1.NodeSetReadyMessage)
 		} else {
 			// something is not ready so reset the Ready condition
 			instance.Status.Conditions.MarkUnknown(

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/01-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/01-assert.yaml
@@ -25,7 +25,7 @@ spec:
     ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
 status:
   conditions:
-  - message: Setup complete
+  - message: NodeSet Ready
     reason: Ready
     status: "True"
     type: Ready


### PR DESCRIPTION
This change adds the NodeSetReadyMessage back to better distinguish between the Setup condition and the overall deployment being completed.