### PR TITLE
Run download-cache after configure-network

### DIFF
--- a/api/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
@@ -1861,9 +1861,9 @@ spec:
                 type: boolean
               services:
                 default:
-                - download-cache
                 - configure-network
                 - validate-network
+                - download-cache
                 - install-os
                 - configure-os
                 - run-os

--- a/api/v1beta1/openstackdataplanenodeset_types.go
+++ b/api/v1beta1/openstackdataplanenodeset_types.go
@@ -56,7 +56,7 @@ type OpenStackDataPlaneNodeSetSpec struct {
 	NetworkAttachments []string `json:"networkAttachments,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={download-cache,configure-network,validate-network,install-os,configure-os,run-os,ovn,libvirt,nova}
+	// +kubebuilder:default={configure-network,validate-network,download-cache,install-os,configure-os,run-os,ovn,libvirt,nova}
 	// Services list
 	Services []string `json:"services"`
 }

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
@@ -1861,9 +1861,9 @@ spec:
                 type: boolean
               services:
                 default:
-                - download-cache
                 - configure-network
                 - validate-network
+                - download-cache
                 - install-os
                 - configure-os
                 - run-os

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset.yaml
@@ -9,9 +9,9 @@ spec:
     - name: ANSIBLE_ENABLE_TASK_DEBUGGER
       value: "True"
   services:
-    - download-cache
     - configure-network
     - validate-network
+    - download-cache
     - install-os
     - configure-os
     - run-os

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal.yaml
@@ -10,9 +10,9 @@ spec:
     - name: ANSIBLE_ENABLE_TASK_DEBUGGER
       value: "True"
   services:
-    - download-cache
     - configure-network
     - validate-network
+    - download-cache
     - install-os
     - configure-os
     - run-os

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal_with_ipam.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal_with_ipam.yaml
@@ -9,9 +9,9 @@ spec:
     - name: ANSIBLE_ENABLE_TASK_DEBUGGER
       value: "True"
   services:
-    - download-cache
     - configure-network
     - validate-network
+    - download-cache
     - install-os
     - configure-os
     - run-os

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_customnetworks.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_customnetworks.yaml
@@ -14,9 +14,9 @@ spec:
     - name: ANSIBLE_HOST_KEY_CHECKING
       value: false
   services:
-    - download-cache
     - configure-network
     - validate-network
+    - download-cache
     - install-os
     - configure-os
     - run-os

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_with_ipam.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_with_ipam.yaml
@@ -14,6 +14,7 @@ spec:
   services:
     - configure-network
     - validate-network
+    - download-cache
     - install-os
     - configure-os
     - run-os

--- a/docs/composable_services.md
+++ b/docs/composable_services.md
@@ -29,9 +29,9 @@ The default list of services as they will appear on the `services` field on an
 `OpenStackDataPlaneNodeSet` spec is:
 
     services:
-      - download-cache
       - configure-network
       - validate-network
+      - download-cache
       - install-os
       - configure-os
       - run-os
@@ -264,9 +264,9 @@ service to execute for the `edpm-compute` `NodeSet`.
     spec:
       services:
         - hello-world
-        - download-cache
         - configure-network
         - validate-network
+        - download-cache
         - install-os
         - configure-os
         - run-os

--- a/tests/functional/openstackdataplanenodeset_controller_test.go
+++ b/tests/functional/openstackdataplanenodeset_controller_test.go
@@ -110,9 +110,9 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 				NetworkAttachments: nil,
 				Nodes:              map[string]dataplanev1.NodeSection{},
 				Services: []string{
-					"download-cache",
 					"configure-network",
 					"validate-network",
+					"download-cache",
 					"install-os",
 					"configure-os",
 					"run-os",

--- a/tests/kuttl/tests/dataplane-create-test/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-create-test/00-assert.yaml
@@ -93,9 +93,9 @@ spec:
     managementNetwork: ctlplane
   preProvisioned: true
   services:
-  - download-cache
   - configure-network
   - validate-network
+  - download-cache
   - install-os
   - configure-os
   - run-os

--- a/tests/kuttl/tests/dataplane-create-test/00-dataplane-create.yaml
+++ b/tests/kuttl/tests/dataplane-create-test/00-dataplane-create.yaml
@@ -9,9 +9,9 @@ spec:
     - name: ANSIBLE_ENABLE_TASK_DEBUGGER
       value: "True"
   services:
-    - download-cache
     - configure-network
     - validate-network
+    - download-cache
     - install-os
     - configure-os
     - run-os

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/00-assert.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   preProvisioned: true
   services:
-  - download-cache
   - configure-network
   - validate-network
+  - download-cache
   - install-os
   - configure-os
   - run-os

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/00-dataplane-create.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/00-dataplane-create.yaml
@@ -33,9 +33,9 @@ metadata:
 spec:
   preProvisioned: true
   services:
-  - download-cache
   - configure-network
   - validate-network
+  - download-cache
   - install-os
   - configure-os
   - run-os

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/01-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/01-assert.yaml
@@ -5,9 +5,9 @@ metadata:
   namespace: openstack
 spec:
   services:
-  - download-cache
   - configure-network
   - validate-network
+  - download-cache
   - install-os
   - configure-os
   - run-os


### PR DESCRIPTION
We do gowvol in the configure-network service and we should do image downloads after that. This currently breaks the baremetal job as there is not enough space to create dirs as required.

Error: writing blob: adding layer with blob
"sha256:f39cd2eaaf10d896f872d413579dd8415bff1e3db4b0ed9476fb92cc5cf3ebb0": processing tar file(mkdir /etc/unbound: no space left on device): exit status 1