### PR TITLE
Remove network_config_override

### DIFF
--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset.yaml
@@ -48,7 +48,6 @@ spec:
          # Default nic config template for a EDPM compute node
          # These vars are edpm_network_config role vars
          edpm_network_config_hide_sensitive_logs: false
-         edpm_network_config_override: ""
          edpm_network_config_template: |
               ---
               {% set mtu_list = [ctlplane_mtu] %}

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal.yaml
@@ -68,7 +68,6 @@ spec:
         # Default nic config template for a EDPM compute node
         # These vars are edpm_network_config role vars
         edpm_network_config_hide_sensitive_logs: false
-        edpm_network_config_override: ""
         edpm_network_config_template: |
              ---
              {% set mtu_list = [ctlplane_mtu] %}

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal_with_ipam.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal_with_ipam.yaml
@@ -54,7 +54,6 @@ spec:
          # Default nic config template for a EDPM compute node
          # These vars are edpm_network_config role vars
          edpm_network_config_hide_sensitive_logs: false
-         edpm_network_config_override: ""
          edpm_network_config_template: |
               ---
               {% set mtu_list = [ctlplane_mtu] %}

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ceph.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ceph.yaml
@@ -56,7 +56,6 @@ spec:
         # edpm_network_config
         # Default nic config template for a EDPM compute node
         # These vars are edpm_network_config role vars
-        edpm_network_config_override: ""
         edpm_network_config_template: |
              ---
              {% set mtu_list = [ctlplane_mtu] %}

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_customnetworks.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_customnetworks.yaml
@@ -48,7 +48,6 @@ spec:
         # edpm_network_config
         # Default nic config template for a EDPM compute node
         # These vars are edpm_network_config role vars
-        edpm_network_config_override: ""
         edpm_network_config_template: |
              ---
              {% set mtu_list = [ctlplane_mtu] %}

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_sriov.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_sriov.yaml
@@ -48,7 +48,6 @@ spec:
          # Default nic config template for a EDPM compute node
          # These vars are edpm_network_config role vars
          edpm_network_config_hide_sensitive_logs: false
-         edpm_network_config_override: ""
          edpm_network_config_template: |
               ---
               {% set mtu_list = [ctlplane_mtu] %}

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_with_ipam.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_with_ipam.yaml
@@ -67,7 +67,6 @@ spec:
          # edpm_network_config
          # Default nic config template for a EDPM compute node
          # These vars are edpm_network_config role vars
-         edpm_network_config_override: ""
          edpm_network_config_template: |
               ---
               {% set mtu_list = [ctlplane_mtu] %}


### PR DESCRIPTION
The edpm_network_config_override variable has been removed from the network_config role. This functionality is now provided exclusively by the edpm_network_config_template variable.