### PR TITLE
Add test for Input and Setup ready

### DIFF
--- a/tests/functional/openstackdataplanedeployment_controller_test.go
+++ b/tests/functional/openstackdataplanedeployment_controller_test.go
@@ -41,6 +41,17 @@ var _ = Describe("Dataplane Deployment Test", func() {
 			CreateSSHSecret(dataplaneSSHSecretName)
 		})
 
+		It("Should have Spec fields initialized", func() {
+			dataplaneDeploymentInstance := GetDataplaneDeployment(dataplaneDeploymentName)
+			expectedSpec := dataplanev1.OpenStackDataPlaneDeploymentSpec{
+				NodeSets:        []string{"edpm-compute-nodeset"},
+				AnsibleTags:     "",
+				AnsibleLimit:    "",
+				AnsibleSkipTags: "",
+			}
+			Expect(dataplaneDeploymentInstance.Spec).Should(Equal(expectedSpec))
+		})
+
 		It("should have conditions set", func() {
 			th.ExpectCondition(
 				dataplaneDeploymentName,


### PR DESCRIPTION
When we create a Dataplane Deployment, the NodeSet should move to Input and Setup Ready conditions. This change adds a small test to validate that functionality.