### PR TITLE
Add support for ovn-controller and neutron-metadata-agent split

### DIFF
--- a/api/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
@@ -1868,6 +1868,7 @@ spec:
                 - configure-os
                 - run-os
                 - ovn
+                - neutron-metadata
                 - libvirt
                 - nova
                 - telemetry

--- a/api/v1beta1/openstackdataplanenodeset_types.go
+++ b/api/v1beta1/openstackdataplanenodeset_types.go
@@ -56,7 +56,7 @@ type OpenStackDataPlaneNodeSetSpec struct {
 	NetworkAttachments []string `json:"networkAttachments,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={download-cache,configure-network,validate-network,install-os,configure-os,run-os,ovn,libvirt,nova,telemetry}
+	// +kubebuilder:default={download-cache,configure-network,validate-network,install-os,configure-os,run-os,ovn,neutron-metadata,libvirt,nova,telemetry}
 	// Services list
 	Services []string `json:"services"`
 }
@@ -145,12 +145,12 @@ func (instance OpenStackDataPlaneNodeSet) GetAnsibleEESpec() AnsibleEESpec {
 
 // DataplaneAnsibleImageDefaults default images for dataplane services
 type DataplaneAnsibleImageDefaults struct {
-	Frr                string
-	IscsiD             string
-	Logrotate          string
-	NovaCompute        string
-	NovaLibvirt        string
-	OvnControllerAgent string
-	OvnMetadataAgent   string
-	OvnBgpAgent        string
+	Frr                  string
+	IscsiD               string
+	Logrotate            string
+	NeutronMetadataAgent string
+	NovaCompute          string
+	NovaLibvirt          string
+	OvnControllerAgent   string
+	OvnBgpAgent          string
 }

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
@@ -1868,6 +1868,7 @@ spec:
                 - configure-os
                 - run-os
                 - ovn
+                - neutron-metadata
                 - libvirt
                 - nova
                 - telemetry

--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -23,7 +23,7 @@ spec:
           value: quay.io/podified-antelope-centos9/openstack-nova-libvirt:current-podified
         - name: RELATED_IMAGE_OPENSTACK_EDPM_OVN_CONTROLLER_AGENT_DEFAULT_IMG
           value: quay.io/podified-antelope-centos9/openstack-ovn-controller:current-podified
-        - name: RELATED_IMAGE_OPENSTACK_EDPM_OVN_METADATA_AGENT_DEFAULT_IMG
+        - name: RELATED_IMAGE_OPENSTACK_EDPM_NEUTRON_METADATA_AGENT_DEFAULT_IMG
           value: quay.io/podified-antelope-centos9/openstack-neutron-metadata-agent-ovn:current-podified
         - name: RELATED_IMAGE_OPENSTACK_EDPM_OVN_BGP_AGENT_IMAGE
           value: quay.io/podified-antelope-centos9/openstack-ovn-bgp-agent:current-podified

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset.yaml
@@ -16,6 +16,7 @@ spec:
     - configure-os
     - run-os
     - ovn
+    - neutron-metadata
     - libvirt
     - nova
     - telemetry
@@ -130,7 +131,7 @@ spec:
          edpm_logrotate_crond_image: "{{ registry_url }}/openstack-cron:{{ image_tag }}"
          edpm_nova_compute_container_image: "{{ registry_url }}/openstack-nova-compute:{{ image_tag }}"
          edpm_nova_libvirt_container_image: "{{ registry_url }}/openstack-nova-libvirt:{{ image_tag }}"
-         edpm_ovn_metadata_agent_image: "{{ registry_url }}/openstack-neutron-metadata-agent-ovn:{{ image_tag }}"
+         edpm_neutron_metadata_agent_image: "{{ registry_url }}/openstack-neutron-metadata-agent-ovn:{{ image_tag }}"
          gather_facts: false
          enable_debug: false
          # edpm firewall, change the allowed CIDR if needed

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal.yaml
@@ -17,6 +17,7 @@ spec:
     - configure-os
     - run-os
     - ovn
+    - neutron-metadata
     - libvirt
     - nova
     - telemetry
@@ -152,7 +153,7 @@ spec:
         edpm_logrotate_crond_image: "{{ registry_url }}/openstack-cron:{{ image_tag }}"
         edpm_nova_compute_container_image: "{{ registry_url }}/openstack-nova-compute:{{ image_tag }}"
         edpm_nova_libvirt_container_image: "{{ registry_url }}/openstack-nova-libvirt:{{ image_tag }}"
-        edpm_ovn_metadata_agent_image: "{{ registry_url }}/openstack-neutron-metadata-agent-ovn:{{ image_tag }}"
+        edpm_neutron_metadata_agent_image: "{{ registry_url }}/openstack-neutron-metadata-agent-ovn:{{ image_tag }}"
 
         gather_facts: false
         enable_debug: false

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ceph.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ceph.yaml
@@ -195,5 +195,6 @@ spec:
     - run-os
     - ceph-client
     - ovn
+    - neutron-metadata
     - libvirt
     - nova-custom-ceph

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_customnetworks.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_customnetworks.yaml
@@ -21,6 +21,7 @@ spec:
     - configure-os
     - run-os
     - ovn
+    - neutron-metadata
     - libvirt
     - nova
     - telemetry

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_networker.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_networker.yaml
@@ -1,7 +1,7 @@
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneNodeSet
 metadata:
-  name: openstack-edpm-ipam
+  name: openstack-edpm
 spec:
   env:
     - name: ANSIBLE_FORCE_COLOR
@@ -16,32 +16,23 @@ spec:
     - configure-os
     - run-os
     - ovn
-    - neutron-metadata
-    - libvirt
-    - nova
     - telemetry
-  baremetalSetTemplate:
-    bmhLabelSelector:
-      app: openstack
-    ctlplaneInterface: enp1s0
-    cloudUserName: cloud-admin
+  preProvisioned: true
   nodes:
-    edpm-compute-0:
-      hostName: edpm-compute-0
+      edpm-compute-0:
+        hostName: edpm-compute-0
+        ansible:
+          ansibleHost: 192.168.122.100
+          ansibleVars:
+            ctlplane_ip: 192.168.122.100
+            internal_api_ip: 172.17.0.100
+            storage_ip: 172.18.0.100
+            tenant_ip: 172.19.0.100
+            fqdn_internal_api: edpm-compute-0.example.com
   networkAttachments:
     - ctlplane
   nodeTemplate:
     ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
-    networks:
-      - name: CtlPlane
-        subnetName: subnet1
-        defaultRoute: true
-      - name: InternalApi
-        subnetName: subnet1
-      - name: Storage
-        subnetName: subnet1
-      - name: Tenant
-        subnetName: subnet1
     managementNetwork: ctlplane
     ansible:
       ansibleUser: cloud-admin
@@ -88,10 +79,33 @@ spec:
                       {{ lookup('vars', networks_lower[network] ~ '_ip') }}/{{ lookup('vars', networks_lower[network] ~ '_cidr') }}
                   routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
               {% endfor %}
+
          # These vars are for the network config templates themselves and are
          # considered EDPM network defaults.
          neutron_physical_bridge_name: br-ex
          neutron_public_interface_name: eth0
+         ctlplane_mtu: 1500
+         ctlplane_subnet_cidr: 24
+         ctlplane_gateway_ip: 192.168.122.1
+         ctlplane_host_routes:
+         - ip_netmask: 0.0.0.0/0
+           next_hop: 192.168.122.1
+         external_mtu: 1500
+         external_vlan_id: 44
+         external_cidr: '24'
+         external_host_routes: []
+         internal_api_mtu: 1500
+         internal_api_vlan_id: 20
+         internal_api_cidr: '24'
+         internal_api_host_routes: []
+         storage_mtu: 1500
+         storage_vlan_id: 21
+         storage_cidr: '24'
+         storage_host_routes: []
+         tenant_mtu: 1500
+         tenant_vlan_id: 22
+         tenant_cidr: '24'
+         tenant_host_routes: []
          role_networks:
          - InternalApi
          - Storage
@@ -104,18 +118,19 @@ spec:
          # edpm_nodes_validation
          edpm_nodes_validation_validate_controllers_icmp: false
          edpm_nodes_validation_validate_gateway_icmp: false
+         ctlplane_dns_nameservers:
+         - 192.168.122.1
+         dns_search_domains: []
          registry_url: quay.io/podified-antelope-centos9
          image_tag: current-podified
          edpm_ovn_controller_agent_image: "{{ registry_url }}/openstack-ovn-controller:{{ image_tag }}"
          edpm_iscsid_image: "{{ registry_url }}/openstack-iscsid:{{ image_tag }}"
          edpm_logrotate_crond_image: "{{ registry_url }}/openstack-cron:{{ image_tag }}"
-         edpm_nova_compute_container_image: "{{ registry_url }}/openstack-nova-compute:{{ image_tag }}"
-         edpm_nova_libvirt_container_image: "{{ registry_url }}/openstack-nova-libvirt:{{ image_tag }}"
-         edpm_neutron_metadata_agent_image: "{{ registry_url }}/openstack-neutron-metadata-agent-ovn:{{ image_tag }}"
+         edpm_enable_chassis_gw: true
          gather_facts: false
          enable_debug: false
          # edpm firewall, change the allowed CIDR if needed
          edpm_sshd_configure_firewall: true
-         edpm_sshd_allowed_ranges: ['192.168.111.0/24']
+         edpm_sshd_allowed_ranges: ['192.168.122.0/24']
          # SELinux module
          edpm_selinux_mode: enforcing

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_with_ipam.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_with_ipam.yaml
@@ -16,6 +16,7 @@ spec:
     - configure-os
     - run-os
     - ovn
+    - neutron-metadata
     - libvirt
     - nova
     - telemetry
@@ -123,7 +124,7 @@ spec:
          edpm_logrotate_crond_image: "{{ registry_url }}/openstack-cron:{{ image_tag }}"
          edpm_nova_compute_container_image: "{{ registry_url }}/openstack-nova-compute:{{ image_tag }}"
          edpm_nova_libvirt_container_image: "{{ registry_url }}/openstack-nova-libvirt:{{ image_tag }}"
-         edpm_ovn_metadata_agent_image: "{{ registry_url }}/openstack-neutron-metadata-agent-ovn:{{ image_tag }}"
+         edpm_neutron_metadata_agent_image: "{{ registry_url }}/openstack-neutron-metadata-agent-ovn:{{ image_tag }}"
          gather_facts: false
          enable_debug: false
          # edpm firewall, change the allowed CIDR if needed

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_neutron_metadata.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_neutron_metadata.yaml
@@ -1,0 +1,10 @@
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneService
+metadata:
+  name: neutron-metadata
+spec:
+  label: dataplane-deployment-neutron-metadata
+  playbook: osp.edpm.neutron_metadata
+  secrets:
+  - neutron-ovn-metadata-agent-neutron-config
+  - nova-metadata-neutron-config

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_ovn.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_ovn.yaml
@@ -7,6 +7,3 @@ spec:
   playbook: osp.edpm.ovn
   configMaps:
   - ovncontroller-config
-  secrets:
-  - neutron-ovn-metadata-agent-neutron-config
-  - nova-metadata-neutron-config

--- a/controllers/openstackdataplanenodeset_controller.go
+++ b/controllers/openstackdataplanenodeset_controller.go
@@ -55,14 +55,14 @@ const (
 	IscsiDDefaultImage = "quay.io/podified-antelope-centos9/openstack-iscsid:current-podified"
 	// LogrotateDefaultImage -
 	LogrotateDefaultImage = "quay.io/podified-antelope-centos9/openstack-cron:current-podified"
+	// NeutronMetadataAgentDefaultImage -
+	NeutronMetadataAgentDefaultImage = "quay.io/podified-antelope-centos9/openstack-neutron-metadata-agent-ovn:current-podified"
 	// NovaComputeDefaultImage -
 	NovaComputeDefaultImage = "quay.io/podified-antelope-centos9/openstack-nova-compute:current-podified"
 	// NovaLibvirtDefaultImage -
 	NovaLibvirtDefaultImage = "quay.io/podified-antelope-centos9/openstack-nova-libvirt:current-podified"
 	// OvnControllerAgentDefaultImage -
 	OvnControllerAgentDefaultImage = "quay.io/podified-antelope-centos9/openstack-ovn-controller:current-podified"
-	// OvnMetadataAgentDefaultImage -
-	OvnMetadataAgentDefaultImage = "quay.io/podified-antelope-centos9/openstack-neutron-metadata-agent-ovn:current-podified"
 	// OvnBgpAgentDefaultImage -
 	OvnBgpAgentDefaultImage = "quay.io/podified-antelope-centos9/openstack-ovn-bgp-agent:current-podified"
 )
@@ -70,14 +70,14 @@ const (
 // SetupAnsibleImageDefaults -
 func SetupAnsibleImageDefaults() {
 	dataplaneAnsibleImageDefaults = dataplanev1.DataplaneAnsibleImageDefaults{
-		Frr:                util.GetEnvVar("RELATED_IMAGE_OPENSTACK_EDPM_FRR_DEFAULT_IMG", FrrDefaultImage),
-		IscsiD:             util.GetEnvVar("RELATED_IMAGE_OPENSTACK_EDPM_ISCSID_DEFAULT_IMG", IscsiDDefaultImage),
-		Logrotate:          util.GetEnvVar("RELATED_IMAGE_OPENSTACK_EDPM_LOGROTATE_CROND_DEFAULT_IMG", LogrotateDefaultImage),
-		NovaCompute:        util.GetEnvVar("RELATED_IMAGE_OPENSTACK_EDPM_NOVA_COMPUTE_DEFAULT_IMG", NovaComputeDefaultImage),
-		NovaLibvirt:        util.GetEnvVar("RELATED_IMAGE_OPENSTACK_EDPM_NOVA_LIBVIRT_DEFAULT_IMG", NovaLibvirtDefaultImage),
-		OvnControllerAgent: util.GetEnvVar("RELATED_IMAGE_OPENSTACK_EDPM_OVN_CONTROLLER_AGENT_DEFAULT_IMG", OvnControllerAgentDefaultImage),
-		OvnMetadataAgent:   util.GetEnvVar("RELATED_IMAGE_OPENSTACK_EDPM_OVN_METADATA_AGENT_DEFAULT_IMG", OvnMetadataAgentDefaultImage),
-		OvnBgpAgent:        util.GetEnvVar("RELATED_IMAGE_OPENSTACK_EDPM_OVN_BGP_AGENT_IMAGE", OvnBgpAgentDefaultImage),
+		Frr:                  util.GetEnvVar("RELATED_IMAGE_OPENSTACK_EDPM_FRR_DEFAULT_IMG", FrrDefaultImage),
+		IscsiD:               util.GetEnvVar("RELATED_IMAGE_OPENSTACK_EDPM_ISCSID_DEFAULT_IMG", IscsiDDefaultImage),
+		Logrotate:            util.GetEnvVar("RELATED_IMAGE_OPENSTACK_EDPM_LOGROTATE_CROND_DEFAULT_IMG", LogrotateDefaultImage),
+		NeutronMetadataAgent: util.GetEnvVar("RELATED_IMAGE_OPENSTACK_EDPM_NEUTRON_METADATA_AGENT_DEFAULT_IMG", NeutronMetadataAgentDefaultImage),
+		NovaCompute:          util.GetEnvVar("RELATED_IMAGE_OPENSTACK_EDPM_NOVA_COMPUTE_DEFAULT_IMG", NovaComputeDefaultImage),
+		NovaLibvirt:          util.GetEnvVar("RELATED_IMAGE_OPENSTACK_EDPM_NOVA_LIBVIRT_DEFAULT_IMG", NovaLibvirtDefaultImage),
+		OvnControllerAgent:   util.GetEnvVar("RELATED_IMAGE_OPENSTACK_EDPM_OVN_CONTROLLER_AGENT_DEFAULT_IMG", OvnControllerAgentDefaultImage),
+		OvnBgpAgent:          util.GetEnvVar("RELATED_IMAGE_OPENSTACK_EDPM_OVN_BGP_AGENT_IMAGE", OvnBgpAgentDefaultImage),
 	}
 }
 

--- a/docs/composable_services.md
+++ b/docs/composable_services.md
@@ -38,6 +38,7 @@ The default list of services as they will appear on the `services` field on an
       - libvirt
       - nova
       - ovn
+      - neutron-metadata
 
 If the `services` field is omitted from the `OpenStackDataPlaneNodeSet` spec,
 then the above list will be used.
@@ -71,6 +72,13 @@ configuration. For more information see the
 
     services:
       - ceph-hci-pre
+
+### neutron-metadata
+
+Include this service to run Neutron OVN Metadata agent on the EDPM nodes. This agent is needed to provide metadata services to the compute nodes.
+
+    services:
+      - neutron-metadata
 
 ### neutron-dhcp
 
@@ -118,6 +126,7 @@ returned.
     libvirt             8d
     nova                8d
     ovn                 8d
+    neutron-metadata    8d
 
 A service can be examined in more detail by looking at the YAML representation
 of the resource.
@@ -287,6 +296,7 @@ service to execute for the `edpm-compute` `NodeSet`.
         - configure-os
         - run-os
         - ovn
+        - neutron-metadata
         - libvirt
         - nova
       nodes:

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -271,6 +271,7 @@ The output should be similar to:
     run-os              6d6h
     validate-network    6d6h
     ovn                 6d6h
+    neutron-metadata    6d6h
     libvirt             6d6h
     nova                6d6h
     telemetry           6d6h

--- a/docs/openstack_dataplanenodeset.md
+++ b/docs/openstack_dataplanenodeset.md
@@ -85,10 +85,10 @@ DataplaneAnsibleImageDefaults default images for dataplane services
 | Frr |  | string | false |
 | IscsiD |  | string | false |
 | Logrotate |  | string | false |
+| NeutronMetadataAgent |  | string | false |
 | NovaCompute |  | string | false |
 | NovaLibvirt |  | string | false |
 | OvnControllerAgent |  | string | false |
-| OvnMetadataAgent |  | string | false |
 | OvnBgpAgent |  | string | false |
 
 [Back to Custom Resources](#custom-resources)

--- a/pkg/deployment/inventory.go
+++ b/pkg/deployment/inventory.go
@@ -155,6 +155,9 @@ func resolveGroupAnsibleVars(template *dataplanev1.NodeTemplate, group *ansible.
 	if template.Ansible.AnsibleVars["edpm_logrotate_crond_image"] == nil {
 		group.Vars["edpm_logrotate_crond_image"] = defaultImages.Logrotate
 	}
+	if template.Ansible.AnsibleVars["edpm_neutron_metadata_agent_image"] == nil {
+		group.Vars["edpm_neutron_metadata_agent_image"] = defaultImages.NeutronMetadataAgent
+	}
 	if template.Ansible.AnsibleVars["edpm_nova_compute_image"] == nil {
 		group.Vars["edpm_nova_compute_image"] = defaultImages.NovaCompute
 	}
@@ -163,9 +166,6 @@ func resolveGroupAnsibleVars(template *dataplanev1.NodeTemplate, group *ansible.
 	}
 	if template.Ansible.AnsibleVars["edpm_ovn_controller_agent_image"] == nil {
 		group.Vars["edpm_ovn_controller_agent_image"] = defaultImages.OvnControllerAgent
-	}
-	if template.Ansible.AnsibleVars["edpm_ovn_metadata_agent_image"] == nil {
-		group.Vars["edpm_ovn_metadata_agent_image"] = defaultImages.OvnMetadataAgent
 	}
 	if template.Ansible.AnsibleVars["edpm_ovn_bgp_agent_image"] == nil {
 		group.Vars["edpm_ovn_bgp_agent_image"] = defaultImages.OvnBgpAgent

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -19,10 +19,10 @@ var DefaultEdpmServiceAnsibleVarList = []string{
 	"edpm_frr_image",
 	"edpm_iscsid_image",
 	"edpm_logrotate_crond_image",
+	"edpm_neutron_metadata_agent_image",
 	"edpm_nova_compute_image",
 	"edpm_nova_libvirt_image",
 	"edpm_ovn_controller_agent_image",
-	"edpm_ovn_metadata_agent_image",
 	"edpm_ovn_bgp_agent_image",
 }
 

--- a/tests/functional/openstackdataplanenodeset_controller_test.go
+++ b/tests/functional/openstackdataplanenodeset_controller_test.go
@@ -62,10 +62,10 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 		"edpm_frr_image",
 		"edpm_iscsid_image",
 		"edpm_logrotate_crond_image",
+		"edpm_neutron_metadata_agent_image",
 		"edpm_nova_compute_image",
 		"edpm_nova_libvirt_image",
 		"edpm_ovn_controller_agent_image",
-		"edpm_ovn_metadata_agent_image",
 		"edpm_ovn_bgp_agent_image",
 	}
 
@@ -165,6 +165,7 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 					"configure-os",
 					"run-os",
 					"ovn",
+					"neutron-metadata",
 					"libvirt",
 					"nova",
 					"telemetry"},

--- a/tests/kuttl/tests/dataplane-create-test/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-create-test/00-assert.yaml
@@ -49,7 +49,7 @@ spec:
           image_tag }}'
         edpm_ovn_controller_agent_image: '{{ registry_url }}/openstack-ovn-controller:{{
           image_tag }}'
-        edpm_ovn_metadata_agent_image: '{{ registry_url }}/openstack-neutron-metadata-agent-ovn:{{
+        edpm_neutron_metadata_agent_image: '{{ registry_url }}/openstack-neutron-metadata-agent-ovn:{{
           image_tag }}'
         edpm_selinux_mode: enforcing
         edpm_sshd_allowed_ranges:
@@ -100,6 +100,7 @@ spec:
   - configure-os
   - run-os
   - ovn
+  - neutron-metadata
   - libvirt
   - nova
 status:

--- a/tests/kuttl/tests/dataplane-create-test/00-dataplane-create.yaml
+++ b/tests/kuttl/tests/dataplane-create-test/00-dataplane-create.yaml
@@ -16,6 +16,7 @@ spec:
     - configure-os
     - run-os
     - ovn
+    - neutron-metadata
     - libvirt
     - nova
   preProvisioned: true
@@ -96,7 +97,7 @@ spec:
          edpm_logrotate_crond_image: "{{ registry_url }}/openstack-cron:{{ image_tag }}"
          edpm_nova_compute_container_image: "{{ registry_url }}/openstack-nova-compute:{{ image_tag }}"
          edpm_nova_libvirt_container_image: "{{ registry_url }}/openstack-nova-libvirt:{{ image_tag }}"
-         edpm_ovn_metadata_agent_image: "{{ registry_url }}/openstack-neutron-metadata-agent-ovn:{{ image_tag }}"
+         edpm_neutron_metadata_agent_image: "{{ registry_url }}/openstack-neutron-metadata-agent-ovn:{{ image_tag }}"
          gather_facts: false
          enable_debug: false
          # edpm firewall, change the allowed CIDR if needed

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/00-assert.yaml
@@ -13,6 +13,7 @@ spec:
   - configure-os
   - run-os
   - ovn
+  - neutron-metadata
   - neutron-sriov
   - neutron-dhcp
   - libvirt

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/00-dataplane-create.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/00-dataplane-create.yaml
@@ -54,6 +54,7 @@ spec:
   - configure-os
   - run-os
   - ovn
+  - neutron-metadata
   - neutron-sriov
   - neutron-dhcp
   - libvirt

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/01-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/01-assert.yaml
@@ -12,6 +12,7 @@ spec:
   - configure-os
   - run-os
   - ovn
+  - neutron-metadata
   - neutron-sriov
   - neutron-dhcp
   - libvirt
@@ -371,7 +372,58 @@ spec:
         name: ovncontroller-config
       name: ovncontroller-config-0
   - mounts:
-    - mountPath: /var/lib/openstack/configs/ovn/10-neutron-metadata.conf
+    - mountPath: /runner/env/ssh_key
+      name: ssh-key
+      subPath: ssh_key
+    - mountPath: /runner/inventory/hosts
+      name: inventory
+      subPath: inventory
+    volumes:
+    - name: ssh-key
+      secret:
+        items:
+        - key: ssh-privatekey
+          path: ssh_key
+        secretName: dataplane-ansible-ssh-private-key-secret
+    - name: inventory
+      secret:
+        items:
+        - key: inventory
+          path: inventory
+        secretName: dataplanenodeset-edpm-compute-no-nodes
+  name: openstackansibleee
+  restartPolicy: Never
+  playbook: osp.edpm.ovn
+  uid: 1001
+status:
+  JobStatus: Succeeded
+  conditions:
+  - message: AnsibleExecutionJob complete
+    reason: Ready
+    status: "True"
+    type: Ready
+  - message: AnsibleExecutionJob complete
+    reason: Ready
+    status: "True"
+    type: AnsibleExecutionJobReady
+---
+apiVersion: ansibleee.openstack.org/v1alpha1
+kind: OpenStackAnsibleEE
+metadata:
+  generation: 1
+  name: dataplane-deployment-neutron-metadata-edpm-compute-no-nodes
+  namespace: openstack
+  ownerReferences:
+  - apiVersion: dataplane.openstack.org/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: OpenStackDataPlaneDeployment
+    name: edpm-compute-no-nodes
+spec:
+  backoffLimit: 6
+  extraMounts:
+  - mounts:
+    - mountPath: /var/lib/openstack/configs/neutron-metadata/10-neutron-metadata.conf
       name: neutron-ovn-metadata-agent-neutron-config-0
       subPath: 10-neutron-metadata.conf
     volumes:
@@ -382,7 +434,7 @@ spec:
         secretName: neutron-ovn-metadata-agent-neutron-config
       name: neutron-ovn-metadata-agent-neutron-config-0
   - mounts:
-    - mountPath: /var/lib/openstack/configs/ovn/05-nova-metadata.conf
+    - mountPath: /var/lib/openstack/configs/neutron-metadata/05-nova-metadata.conf
       name: nova-metadata-neutron-config-0
       subPath: 05-nova-metadata.conf
     volumes:
@@ -414,7 +466,7 @@ spec:
         secretName: dataplanenodeset-edpm-compute-no-nodes
   name: openstackansibleee
   restartPolicy: Never
-  playbook: osp.edpm.ovn
+  playbook: osp.edpm.neutron_metadata
   uid: 1001
 status:
   JobStatus: Succeeded

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/02-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/02-assert.yaml
@@ -40,7 +40,6 @@ spec:
         - key: inventory
           path: inventory
         secretName: dataplanenodeset-edpm-compute-no-nodes
-  image: quay.io/openstack-k8s-operators/openstack-ansibleee-runner@sha256:64eaa1d99e0103cb4536fa9f396d41c467168cab3fe3821f8135e9a9638d7295
   name: openstackansibleee
   play: |
     - hosts: localhost


### PR DESCRIPTION
This depends on the edpm-ansible PR:
Depends-On: https://github.com/openstack-k8s-operators/edpm-ansible/pull/382