### PR TITLE
Introduce HCI DataSet example and Update Ceph DataSet example

### DIFF
--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ceph_hci.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ceph_hci.yaml
@@ -1,7 +1,7 @@
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneNodeSet
 metadata:
-  name: openstack-edpm-ceph
+  name: openstack-edpm-hci
   namespace: openstack
 spec:
   env:
@@ -94,6 +94,7 @@ spec:
           External: external
           InternalApi: internal_api
           Storage: storage
+          StorageMgmt: storage_mgmt
           Tenant: tenant
         neutron_physical_bridge_name: br-ex
         neutron_public_interface_name: eth0
@@ -101,22 +102,26 @@ spec:
         role_networks:
         - InternalApi
         - Storage
+        - StorageMgmt
         - Tenant
         service_net_map:
           nova_api_network: internal_api
           nova_libvirt_network: internal_api
         storage_cidr: "24"
         storage_host_routes: []
-        storage_vlan_id: 21
+        storage_mgmt_cidr: "24"
+        storage_mgmt_host_routes: []
+        storage_mgmt_mtu: 9000
+        storage_mgmt_vlan_id: 23
         storage_mtu: 9000
+        storage_vlan_id: 21
         tenant_cidr: "24"
         tenant_host_routes: []
         tenant_mtu: 1500
         tenant_vlan_id: 22
     ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
-    # Create a secret called ceph-conf-files with the cephx key and
-    # ceph.conf file and mount it so the ceph-client service can copy
-    # those files to the EDPM nodes.
+    # Add an `extraVolType: Ceph` with to mount the ceph-conf-files
+    # secret, after Ceph is deployed.
     extraMounts:
     - extraVolType: Logs
       mounts:
@@ -126,17 +131,6 @@ spec:
       - name: ansible-logs
         persistentVolumeClaim:
           claimName: ansible-ee-logs
-    - extraVolType: Ceph
-      mounts:
-      - mountPath: /etc/ceph
-        name: ceph
-        readOnly: true
-      volumes:
-      - name: ceph
-        projected:
-          sources:
-          - secret:
-              name: ceph-conf-files
     managementNetwork: ctlplane
   nodes:
     edpm-compute-0:
@@ -151,6 +145,8 @@ spec:
       - name: InternalApi
         subnetName: subnet1
       - name: Storage
+        subnetName: subnet1
+      - name: StorageMgmt
         subnetName: subnet1
       - name: Tenant
         subnetName: subnet1
@@ -167,6 +163,8 @@ spec:
         subnetName: subnet1
       - name: Storage
         subnetName: subnet1
+      - name: StorageMgmt
+        subnetName: subnet1
       - name: Tenant
         subnetName: subnet1
     edpm-compute-2:
@@ -182,18 +180,22 @@ spec:
         subnetName: subnet1
       - name: Storage
         subnetName: subnet1
+      - name: StorageMgmt
+        subnetName: subnet1
       - name: Tenant
         subnetName: subnet1
   preProvisioned: true
-  # Create a nova-custom-ceph service which uses a ConfigMap
+  # Uncomment the services below after Ceph is deployed and
+  # create a nova-custom-ceph service which uses a ConfigMap
   # containing libvirt overrides for Ceph RBD.
   services:
     - configure-network
     - validate-network
     - install-os
+    - ceph-hci-pre
     - configure-os
     - run-os
-    - ceph-client
-    - ovn
-    - libvirt
-    - nova-custom-ceph
+    # - ceph-client
+    # - ovn
+    # - libvirt
+    # - nova-custom-ceph


### PR DESCRIPTION
Update the Ceph OpenStackDataPlaneNodeSet sample to fit current conventions. In particular do not hard code IPs as it's not necessary and that data can be provided by IPAM. Also, use MTU 9000 for the storage network.

Introduce HCI OpenStackDataPlaneNodeSet sample which is like the updated Ceph example, except it adds the Storage Management network and uses MTU 9000 and has a shortended service list since HCI requires the list to be modified after the first run on EDPM Ansible so that the EDPM deployment can be paused so that
Ceph can be installed and then the rest of the EDPM deployment may be resolved.

Jira: [OSP-28997](https://issues.redhat.com//browse/OSP-28997)