### PR TITLE
Fix: Correct the opm version in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -266,7 +266,7 @@ ifeq (,$(shell which opm 2>/dev/null))
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
 	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.31.0/$${OS}-$${ARCH}-opm ;\
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.29.0/$${OS}-$${ARCH}-opm ;\
 	chmod +x $(OPM) ;\
 	}
 else


### PR DESCRIPTION
The opm version got aligned with the version of the operator-sdk in 80758b7916c53230ac0f71cb4ca60bd53f8af5cb.

OPM is versioned separately. This bumps OPM to the latest tagged release.