### PR TITLE
Replacing edpm_chrony_ntp_servers with timesync_ntp_servers

### DIFF
--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset.yaml
@@ -45,8 +45,8 @@ spec:
          service_net_map:
            nova_api_network: internal_api
            nova_libvirt_network: internal_api
-         edpm_chrony_ntp_servers:
-           - pool.ntp.org
+         timesync_ntp_servers:
+           - hostname: pool.ntp.org
          # edpm_network_config
          # Default nic config template for a EDPM compute node
          # These vars are edpm_network_config role vars

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal.yaml
@@ -65,8 +65,8 @@ spec:
         service_net_map:
           nova_api_network: internal_api
           nova_libvirt_network: internal_api
-        edpm_chrony_ntp_servers:
-          - pool.ntp.org
+        timesync_ntp_servers:
+          - hostname: pool.ntp.org
         # edpm_network_config
         # Default nic config template for a EDPM compute node
         # These vars are edpm_network_config role vars

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal_with_ipam.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal_with_ipam.yaml
@@ -51,8 +51,8 @@ spec:
          service_net_map:
            nova_api_network: internal_api
            nova_libvirt_network: internal_api
-         edpm_chrony_ntp_servers:
-           - pool.ntp.org
+         timesync_ntp_servers:
+           - hostname: pool.ntp.org
          # edpm_network_config
          # Default nic config template for a EDPM compute node
          # These vars are edpm_network_config role vars

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_bgp.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_bgp.yaml
@@ -47,8 +47,8 @@ spec:
          service_net_map:
            nova_api_network: internal_api
            nova_libvirt_network: internal_api
-         edpm_chrony_ntp_servers:
-           - pool.ntp.org
+         timesync_ntp_servers:
+           - hostname: pool.ntp.org
          # edpm_network_config
          # Default nic config template for a EDPM compute node
          # These vars are edpm_network_config role vars

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ceph.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ceph.yaml
@@ -27,8 +27,8 @@ spec:
         ctlplane_mtu: 1500
         ctlplane_subnet_cidr: 24
         dns_search_domains: []
-        edpm_chrony_ntp_servers:
-        - pool.ntp.org
+        timesync_ntp_servers:
+        - hostname: pool.ntp.org
         edpm_iscsid_image: '{{ registry_url }}/{{ image_prefix }}-iscsid:{{ image_tag }}'
         edpm_logrotate_crond_image: '{{ registry_url }}/{{ image_prefix }}-cron:{{ image_tag
           }}'

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ceph_hci.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ceph_hci.yaml
@@ -27,8 +27,8 @@ spec:
         ctlplane_mtu: 1500
         ctlplane_subnet_cidr: 24
         dns_search_domains: []
-        edpm_chrony_ntp_servers:
-        - pool.ntp.org
+        timesync_ntp_servers:
+        - hostname: pool.ntp.org
         edpm_iscsid_image: '{{ registry_url }}/{{ image_prefix }}-iscsid:{{ image_tag }}'
         edpm_logrotate_crond_image: '{{ registry_url }}/{{ image_prefix }}-cron:{{ image_tag
           }}'

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_networker.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_networker.yaml
@@ -42,8 +42,8 @@ spec:
          service_net_map:
            nova_api_network: internal_api
            nova_libvirt_network: internal_api
-         edpm_chrony_ntp_servers:
-           - pool.ntp.org
+         timesync_ntp_servers:
+           - hostname: pool.ntp.org
          # edpm_network_config
          # Default nic config template for a EDPM compute node
          # These vars are edpm_network_config role vars

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_nmstate.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_nmstate.yaml
@@ -46,8 +46,8 @@ spec:
         service_net_map:
           nova_api_network: internal_api
           nova_libvirt_network: internal_api
-        edpm_chrony_ntp_servers:
-        - pool.ntp.org
+        timesync_ntp_servers:
+          - hostname: pool.ntp.org
         # edpm_network_config
         # Default nic config template for a EDPM compute node
         # These vars are edpm_network_config role vars

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_sriov.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_sriov.yaml
@@ -43,8 +43,8 @@ spec:
          service_net_map:
            nova_api_network: internal_api
            nova_libvirt_network: internal_api
-         edpm_chrony_ntp_servers:
-           - pool.ntp.org
+         timesync_ntp_servers:
+           - hostname: pool.ntp.org
          # edpm_network_config
          # Default nic config template for a EDPM compute node
          # These vars are edpm_network_config role vars

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_with_ipam.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_with_ipam.yaml
@@ -64,8 +64,8 @@ spec:
          service_net_map:
            nova_api_network: internal_api
            nova_libvirt_network: internal_api
-         edpm_chrony_ntp_servers:
-           - pool.ntp.org
+         timesync_ntp_servers:
+           - hostname: pool.ntp.org
          # edpm_network_config
          # Default nic config template for a EDPM compute node
          # These vars are edpm_network_config role vars

--- a/docs/inheritance.md
+++ b/docs/inheritance.md
@@ -86,9 +86,9 @@ spec:
   nodeTemplate:
     ansibleVars:
       neutron_public_interface_name: eth0
-      edpm_chrony_ntp_servers:
-        - clock.redhat.com
-        - clock2.redhat.com
+      timesync_ntp_servers:
+        - hostname: clock.redhat.com
+        - hostname: clock2.redhat.com
   ...
 ```
 
@@ -110,13 +110,13 @@ vars:
 ```yaml
       neutron_public_interface_name: eth0
       tenant_ip: 192.168.24.100
-      edpm_chrony_ntp_servers:
-        - clock.redhat.com
-        - clock2.redhat.com
+      timesync_ntp_servers:
+        - hostname: clock.redhat.com
+        - hostname: clock2.redhat.com
 ```
 
 Only top level keys are compared for merging. E.g. if `edpm-compute-0`
-had a `edpm_chrony_ntp_servers` list with `clock3.redhat.com`, then
+had a `timesync_ntp_servers` list with `hostname: clock3.redhat.com`, then
 the resultant inventory for the node would not have three NTP servers;
 it would only have `clock3.redhat.com`. I.e. there is no "deep
 merging".

--- a/tests/kuttl/tests/dataplane-create-test/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-create-test/00-assert.yaml
@@ -34,8 +34,8 @@ spec:
         ctlplane_mtu: 1500
         ctlplane_subnet_cidr: 24
         dns_search_domains: []
-        edpm_chrony_ntp_servers:
-        - clock.redhat.com
+        timesync_ntp_servers:
+        - hostname: clock.redhat.com
         edpm_iscsid_image: '{{ registry_url }}/openstack-iscsid:{{ image_tag }}'
         edpm_logrotate_crond_image: '{{ registry_url }}/openstack-cron:{{ image_tag }}'
         edpm_network_config_hide_sensitive_logs: false

--- a/tests/kuttl/tests/dataplane-create-test/00-dataplane-create.yaml
+++ b/tests/kuttl/tests/dataplane-create-test/00-dataplane-create.yaml
@@ -43,8 +43,8 @@ spec:
          service_net_map:
            nova_api_network: internal_api
            nova_libvirt_network: internal_api
-         edpm_chrony_ntp_servers:
-           - clock.redhat.com
+         timesync_ntp_servers:
+           - hostname: clock.redhat.com
          # edpm_network_config
          # Default nic config template for a EDPM compute node
          # These vars are edpm_network_config role vars


### PR DESCRIPTION
The edpm_chrony role is getting removed, this variable has to be renamed in order to reflect the new reality.

Depends-On: https://github.com/openstack-k8s-operators/install_yamls/pull/575