### PR TITLE
Update HCI NodeSet with a pre/post Ceph Deployment example

### DIFF
--- a/config/samples/dataplane_v1beta1_openstackdataplanedeployment_post_ceph_hci.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanedeployment_post_ceph_hci.yaml
@@ -1,0 +1,16 @@
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneDeployment
+metadata:
+  name: deployment-post-ceph
+spec:
+  nodeSets:
+    - openstack-edpm-hci
+  # Create this deployment after Ceph is deployed
+  # on EDPM nodes in an HCI scenario. Create a
+  # nova-custom-ceph service which uses a ConfigMap
+  # containing libvirt overrides for Ceph RBD.
+  servicesOverride:
+    - ceph-client
+    - ovn
+    - libvirt
+    - nova-custom-ceph

--- a/config/samples/dataplane_v1beta1_openstackdataplanedeployment_pre_ceph_hci.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanedeployment_pre_ceph_hci.yaml
@@ -1,0 +1,16 @@
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneDeployment
+metadata:
+  name: deployment-pre-ceph
+spec:
+  nodeSets:
+    - openstack-edpm-hci
+  # Create this deployment before Ceph is deployed
+  # on EDPM nodes in an HCI scenario.
+  servicesOverride:
+    - configure-network
+    - validate-network
+    - install-os
+    - ceph-hci-pre
+    - configure-os
+    - run-os

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ceph_hci.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ceph_hci.yaml
@@ -185,17 +185,7 @@ spec:
       - name: Tenant
         subnetName: subnet1
   preProvisioned: true
-  # Uncomment the services below after Ceph is deployed and
-  # create a nova-custom-ceph service which uses a ConfigMap
-  # containing libvirt overrides for Ceph RBD.
-  services:
-    - configure-network
-    - validate-network
-    - install-os
-    - ceph-hci-pre
-    - configure-os
-    - run-os
-    # - ceph-client
-    # - ovn
-    # - libvirt
-    # - nova-custom-ceph
+  # Each OpenStackDataPlaneDeployment deployment-pre-ceph and
+  # deployment-post-ceph will override the services list so
+  # it is empty in this example.
+  services: []


### PR DESCRIPTION
Use servicesOverride feature of OpenStackDataPlaneDeployment to make HCI deployment examples more clear. Instead of having the human operator edit the services list before creating a second deployment, provide two deployment examples which each have the correct services list for before and after Ceph has been installed.

Jira: [OSP-29040](https://issues.redhat.com//browse/OSP-29040)