### PR TITLE
Merge frr and ovn-bg-agent services into one

### DIFF
--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_bgp.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_bgp.yaml
@@ -12,17 +12,13 @@ spec:
     - download-cache
     - configure-network
     - validate-network
-    - install-frr
-    - configure-frr
-    - run-frr
+    - frr
     - install-os
     - configure-os
     - run-os
     - ovn
     - neutron-metadata
-    - install-ovn-bgp-agent
-    - configure-ovn-bgp-agent
-    - run-ovn-bgp-agent
+    - ovn-bgp-agent
     - libvirt
     - nova
     - telemetry

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_configure_frr.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_configure_frr.yaml
@@ -1,7 +1,0 @@
-apiVersion: dataplane.openstack.org/v1beta1
-kind: OpenStackDataPlaneService
-metadata:
-  name: configure-frr
-spec:
-  label: dataplane-deployment-configure-frr
-  playbook: osp.edpm.configure_frr

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_configure_ovn_bgp_agent.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_configure_ovn_bgp_agent.yaml
@@ -1,7 +1,0 @@
-apiVersion: dataplane.openstack.org/v1beta1
-kind: OpenStackDataPlaneService
-metadata:
-  name: configure-ovn-bgp-agent
-spec:
-  label: dataplane-deployment-configure-ovn-bgp-agent
-  playbook: osp.edpm.configure_ovn_bgp_agent

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_frr.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_frr.yaml
@@ -1,7 +1,7 @@
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneService
 metadata:
-  name: run-frr
+  name: frr
 spec:
-  label: dataplane-deployment-run-frr
-  playbook: osp.edpm.run_frr
+  label: dataplane-deployment-frr
+  playbook: osp.edpm.frr

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_install_frr.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_install_frr.yaml
@@ -1,7 +1,0 @@
-apiVersion: dataplane.openstack.org/v1beta1
-kind: OpenStackDataPlaneService
-metadata:
-  name: install-frr
-spec:
-  label: dataplane-deployment-install-frr
-  playbook: osp.edpm.install_frr

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_install_ovn_bgp_agent.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_install_ovn_bgp_agent.yaml
@@ -1,7 +1,0 @@
-apiVersion: dataplane.openstack.org/v1beta1
-kind: OpenStackDataPlaneService
-metadata:
-  name: install-ovn-bgp-agent
-spec:
-  label: dataplane-deployment-install-ovn-bgp-agent
-  playbook: osp.edpm.install_ovn_bgp_agent

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_ovn_bgp_agent.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_ovn_bgp_agent.yaml
@@ -1,0 +1,7 @@
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneService
+metadata:
+  name: ovn-bgp-agent
+spec:
+  label: dataplane-deployment-ovn-bgp-agent
+  playbook: osp.edpm.ovn_bgp_agent

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_run_ovn_bgp_agent.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_run_ovn_bgp_agent.yaml
@@ -1,7 +1,0 @@
-apiVersion: dataplane.openstack.org/v1beta1
-kind: OpenStackDataPlaneService
-metadata:
-  name: run-ovn-bgp-agent
-spec:
-  label: dataplane-deployment-run-ovn-bgp-agent
-  playbook: osp.edpm.run_ovn_bgp_agent


### PR DESCRIPTION
There is no need to split the services in install, configure and run.

This task is about unifying them so that we just have a frr service and an ovn-bgp-agent service.

Depends-on: https://github.com/openstack-k8s-operators/edpm-ansible/pull/441