### PR TITLE
Fix services list in HCI example

### DIFF
--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ceph_hci.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ceph_hci.yaml
@@ -186,6 +186,18 @@ spec:
         subnetName: subnet1
   preProvisioned: true
   # Each OpenStackDataPlaneDeployment deployment-pre-ceph and
-  # deployment-post-ceph will override the services list so
-  # it is empty in this example.
-  services: []
+  # deployment-post-ceph will override the services list. The
+  # full service list is defined here only so the non-custom
+  # services will be defined by the operator.
+  services:
+    - configure-network
+    - validate-network
+    - install-os
+    - ceph-hci-pre
+    - configure-os
+    - run-os
+    - ceph-client
+    - ovn
+    - neutron-metadata
+    - libvirt
+    - nova-custom-ceph


### PR DESCRIPTION
Any services include in the OpenStackDataPlaneNodeSet are automatically created by the data plane controller. Since we don't want to burden the user with manually creating these, restore the full list of services which are used. We still rely on the servicesOverride in each deployment however to identify which subset of services are deployed when.