### PR TITLE
Added `bootstrap` service

### DIFF
--- a/api/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
@@ -1862,6 +1862,7 @@ spec:
               services:
                 default:
                 - download-cache
+                - bootstrap
                 - configure-network
                 - validate-network
                 - install-os

--- a/api/v1beta1/openstackdataplanenodeset_types.go
+++ b/api/v1beta1/openstackdataplanenodeset_types.go
@@ -56,7 +56,7 @@ type OpenStackDataPlaneNodeSetSpec struct {
 	NetworkAttachments []string `json:"networkAttachments,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={download-cache,configure-network,validate-network,install-os,configure-os,run-os,ovn,neutron-metadata,libvirt,nova,telemetry}
+	// +kubebuilder:default={download-cache,bootstrap,configure-network,validate-network,install-os,configure-os,run-os,ovn,neutron-metadata,libvirt,nova,telemetry}
 	// Services list
 	Services []string `json:"services"`
 }

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
@@ -1862,6 +1862,7 @@ spec:
               services:
                 default:
                 - download-cache
+                - bootstrap
                 - configure-network
                 - validate-network
                 - install-os

--- a/config/samples/dataplane_v1beta1_openstackdataplanedeployment_pre_ceph_hci.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanedeployment_pre_ceph_hci.yaml
@@ -8,6 +8,7 @@ spec:
   # Create this deployment before Ceph is deployed
   # on EDPM nodes in an HCI scenario.
   servicesOverride:
+    - bootstrap
     - configure-network
     - validate-network
     - install-os

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset.yaml
@@ -9,6 +9,7 @@ spec:
     - name: ANSIBLE_ENABLE_TASK_DEBUGGER
       value: "True"
   services:
+    - bootstrap
     - download-cache
     - configure-network
     - validate-network

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal.yaml
@@ -11,6 +11,7 @@ spec:
       value: "True"
   services:
     - download-cache
+    - bootstrap
     - configure-network
     - validate-network
     - install-os

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal_with_ipam.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal_with_ipam.yaml
@@ -10,6 +10,7 @@ spec:
       value: "True"
   services:
     - download-cache
+    - bootstrap
     - configure-network
     - validate-network
     - install-os

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_bgp.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_bgp.yaml
@@ -10,6 +10,7 @@ spec:
       value: "True"
   services:
     - download-cache
+    - bootstrap
     - configure-network
     - validate-network
     - frr

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ceph.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ceph.yaml
@@ -188,6 +188,7 @@ spec:
   # Create a nova-custom-ceph service which uses a ConfigMap
   # containing libvirt overrides for Ceph RBD.
   services:
+    - bootstrap
     - configure-network
     - validate-network
     - install-os

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ceph_hci.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ceph_hci.yaml
@@ -190,6 +190,7 @@ spec:
   # full service list is defined here only so the non-custom
   # services will be defined by the operator.
   services:
+    - bootstrap
     - configure-network
     - validate-network
     - install-os

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_customnetworks.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_customnetworks.yaml
@@ -15,6 +15,7 @@ spec:
       value: false
   services:
     - download-cache
+    - bootstrap
     - configure-network
     - validate-network
     - install-os

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_networker.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_networker.yaml
@@ -10,6 +10,7 @@ spec:
       value: "True"
   services:
     - download-cache
+    - bootstrap
     - configure-network
     - validate-network
     - install-os

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_sriov.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_sriov.yaml
@@ -10,6 +10,7 @@ spec:
       value: "True"
   services:
     - download-cache
+    - bootstrap
     - configure-network
     - validate-network
     - install-os

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_with_ipam.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_with_ipam.yaml
@@ -10,6 +10,7 @@ spec:
       value: "True"
   preProvisioned: true
   services:
+    - bootstrap
     - configure-network
     - validate-network
     - install-os

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_bootstrap.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_bootstrap.yaml
@@ -1,0 +1,13 @@
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneService
+metadata:
+  labels:
+    app.kubernetes.io/name: openstackdataplaneservice
+    app.kubernetes.io/instance: openstackdataplaneservice-bootstrap
+    app.kubernetes.io/part-of: dataplane-operator
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: dataplane-operator
+  name: bootstrap
+spec:
+  label: dataplane-deployment-bootstrap
+  playbook: osp.edpm.bootstrap

--- a/docs/composable_services.md
+++ b/docs/composable_services.md
@@ -30,6 +30,7 @@ The default list of services as they will appear on the `services` field on an
 
     services:
       - download-cache
+      - bootstrap
       - configure-network
       - validate-network
       - install-os
@@ -290,6 +291,7 @@ service to execute for the `edpm-compute` `NodeSet`.
       services:
         - hello-world
         - download-cache
+        - bootstrap
         - configure-network
         - validate-network
         - install-os

--- a/tests/functional/openstackdataplanenodeset_controller_test.go
+++ b/tests/functional/openstackdataplanenodeset_controller_test.go
@@ -159,6 +159,7 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 				Nodes:              map[string]dataplanev1.NodeSection{},
 				Services: []string{
 					"download-cache",
+					"bootstrap",
 					"configure-network",
 					"validate-network",
 					"install-os",

--- a/tests/kuttl/tests/dataplane-create-test/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-create-test/00-assert.yaml
@@ -37,20 +37,15 @@ spec:
         edpm_chrony_ntp_servers:
         - clock.redhat.com
         edpm_iscsid_image: '{{ registry_url }}/openstack-iscsid:{{ image_tag }}'
-        edpm_logrotate_crond_image: '{{ registry_url }}/openstack-cron:{{ image_tag
-          }}'
+        edpm_logrotate_crond_image: '{{ registry_url }}/openstack-cron:{{ image_tag }}'
         edpm_network_config_hide_sensitive_logs: false
         edpm_network_config_template: templates/single_nic_vlans/single_nic_vlans.j2
         edpm_nodes_validation_validate_controllers_icmp: false
         edpm_nodes_validation_validate_gateway_icmp: false
-        edpm_nova_compute_container_image: '{{ registry_url }}/openstack-nova-compute:{{
-          image_tag }}'
-        edpm_nova_libvirt_container_image: '{{ registry_url }}/openstack-nova-libvirt:{{
-          image_tag }}'
-        edpm_ovn_controller_agent_image: '{{ registry_url }}/openstack-ovn-controller:{{
-          image_tag }}'
-        edpm_neutron_metadata_agent_image: '{{ registry_url }}/openstack-neutron-metadata-agent-ovn:{{
-          image_tag }}'
+        edpm_nova_compute_container_image: '{{ registry_url }}/openstack-nova-compute:{{ image_tag }}'
+        edpm_nova_libvirt_container_image: '{{ registry_url }}/openstack-nova-libvirt:{{ image_tag }}'
+        edpm_ovn_controller_agent_image: '{{ registry_url }}/openstack-ovn-controller:{{ image_tag }}'
+        edpm_neutron_metadata_agent_image: '{{ registry_url }}/openstack-neutron-metadata-agent-ovn:{{ image_tag }}'
         edpm_selinux_mode: enforcing
         edpm_sshd_allowed_ranges:
         - 192.168.122.0/24
@@ -94,6 +89,7 @@ spec:
   preProvisioned: true
   services:
   - download-cache
+  - bootstrap
   - configure-network
   - validate-network
   - install-os

--- a/tests/kuttl/tests/dataplane-create-test/00-dataplane-create.yaml
+++ b/tests/kuttl/tests/dataplane-create-test/00-dataplane-create.yaml
@@ -10,6 +10,7 @@ spec:
       value: "True"
   services:
     - download-cache
+    - bootstrap
     - configure-network
     - validate-network
     - install-os

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/00-assert.yaml
@@ -7,6 +7,7 @@ spec:
   preProvisioned: true
   services:
   - download-cache
+  - bootstrap
   - configure-network
   - validate-network
   - install-os

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/00-dataplane-create.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/00-dataplane-create.yaml
@@ -57,6 +57,7 @@ spec:
   preProvisioned: true
   services:
   - download-cache
+  - bootstrap
   - configure-network
   - validate-network
   - install-os

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/01-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/01-assert.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   services:
   - download-cache
+  - bootstrap
   - configure-network
   - validate-network
   - install-os
@@ -93,6 +94,57 @@ status:
     reason: Ready
     status: "True"
     type: AnsibleExecutionJobReady
+---
+apiVersion: ansibleee.openstack.org/v1alpha1
+kind: OpenStackAnsibleEE
+metadata:
+  name: dataplane-deployment-bootstrap-edpm-compute-no-nodes
+  namespace: openstack
+  ownerReferences:
+  - apiVersion: dataplane.openstack.org/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: OpenStackDataPlaneDeployment
+    name: edpm-compute-no-nodes
+spec:
+  backoffLimit: 6
+  extraMounts:
+  - mounts:
+    - mountPath: /runner/env/ssh_key
+      name: ssh-key
+      subPath: ssh_key
+    - mountPath: /runner/inventory/hosts
+      name: inventory
+      subPath: inventory
+    volumes:
+    - name: ssh-key
+      secret:
+        items:
+        - key: ssh-privatekey
+          path: ssh_key
+        secretName: dataplane-ansible-ssh-private-key-secret
+    - name: inventory
+      secret:
+        items:
+        - key: inventory
+          path: inventory
+        secretName: dataplanenodeset-edpm-compute-no-nodes
+  name: openstackansibleee
+  restartPolicy: Never
+  playbook: osp.edpm.bootstrap
+  uid: 1001
+status:
+  JobStatus: Succeeded
+  conditions:
+  - message: AnsibleExecutionJob complete
+    reason: Ready
+    status: "True"
+    type: Ready
+  - message: AnsibleExecutionJob complete
+    reason: Ready
+    status: "True"
+    type: AnsibleExecutionJobReady
+
 ---
 apiVersion: ansibleee.openstack.org/v1alpha1
 kind: OpenStackAnsibleEE


### PR DESCRIPTION
Since in the `configure-network` playbook there were a lot of roles unrelated to the network configuration, we moved those roles into another playbook called `bootstrap` that should be called as the first role (right after `download-cache`, if/when used) in the deployment process.

https://issues.redhat.com/browse/OSP-28971