### PR TITLE
Block baremetal set template changes

### DIFF
--- a/api/v1beta1/openstackdataplaneservice_types.go
+++ b/api/v1beta1/openstackdataplaneservice_types.go
@@ -19,8 +19,8 @@ package v1beta1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	infranetworkv1 "github.com/openstack-k8s-operators/infra-operator/apis/network/v1beta1"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 )
 
 // KubeService represents a Kubernetes Service. It is called like this to avoid the extreme overloading of the

--- a/controllers/openstackdataplanenodeset_controller.go
+++ b/controllers/openstackdataplanenodeset_controller.go
@@ -263,14 +263,6 @@ func (r *OpenStackDataPlaneNodeSetReconciler) Reconcile(ctx context.Context, req
 		}
 	}
 
-	// TODO: if the input hash changes or the nodes in the role is updated we should
-	// detect that and redeploy the role that may also require deleting/recreating
-	// the dataplane service AEE CRs based on the updated input/inventory.
-	// for now we just check if the role is already deployed and not being deleted
-	// and leave the triggering to a human to initiate.
-	// This can be done by deleting the dataplane service AEE CRs and then
-	// patching the role to set  dataplane service condition ready to "Unknown"
-	// then patching the Deployed flag to false.
 	if instance.Status.Deployed && instance.DeletionTimestamp.IsZero() {
 		// The role is already deployed and not being deleted, so reconciliation
 		// is already complete.

--- a/tests/functional/openstackdataplanenodeset_webhook_test.go
+++ b/tests/functional/openstackdataplanenodeset_webhook_test.go
@@ -1,0 +1,96 @@
+package functional
+
+import (
+	"fmt"
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/types"
+
+	baremetalv1 "github.com/openstack-k8s-operators/openstack-baremetal-operator/api/v1beta1"
+)
+
+var _ = Describe("DataplaneNodeSet Webhook", func() {
+
+	var dataplaneNodeSetName types.NamespacedName
+
+	BeforeEach(func() {
+		dataplaneNodeSetName = types.NamespacedName{
+			Name:      "edpm-compute-nodeset",
+			Namespace: namespace,
+		}
+		err := os.Setenv("OPERATOR_SERVICES", "../../config/services")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	When("User tries to change forbidden items in the baremetalSetTemplate", func() {
+		BeforeEach(func() {
+			nodeSetSpec := DefaultDataPlaneNoNodeSetSpec()
+			nodeSetSpec["preProvisioned"] = false
+			nodeSetSpec["baremetalSetTemplate"] = baremetalv1.OpenStackBaremetalSetSpec{
+				CloudUserName: "test-user",
+				BmhLabelSelector: map[string]string{
+					"app": "test-openstack",
+				},
+				BaremetalHosts: map[string]baremetalv1.InstanceSpec{
+					"compute-0": {
+						CtlPlaneIP: "192.168.1.12",
+					},
+				},
+			}
+			DeferCleanup(th.DeleteInstance, CreateDataplaneNodeSet(dataplaneNodeSetName, nodeSetSpec))
+		})
+
+		It("Should block changes to the BmhLabelSelector object in baremetalSetTemplate spec", func() {
+			Eventually(func(g Gomega) string {
+				instance := GetDataplaneNodeSet(dataplaneNodeSetName)
+				instance.Spec.BaremetalSetTemplate = baremetalv1.OpenStackBaremetalSetSpec{
+					CloudUserName: "new-user",
+					BmhLabelSelector: map[string]string{
+						"app": "openstack1",
+					},
+				}
+				err := th.K8sClient.Update(th.Ctx, instance)
+				return fmt.Sprintf("%s", err)
+			}).Should(ContainSubstring("Forbidden: cannot change"))
+		})
+	})
+
+	When("A user changes an allowed field in the baremetalSetTemplate", func() {
+		BeforeEach(func() {
+			nodeSetSpec := DefaultDataPlaneNoNodeSetSpec()
+			nodeSetSpec["preProvisioned"] = false
+			nodeSetSpec["baremetalSetTemplate"] = baremetalv1.OpenStackBaremetalSetSpec{
+				CloudUserName: "test-user",
+				BmhLabelSelector: map[string]string{
+					"app": "test-openstack",
+				},
+				BaremetalHosts: map[string]baremetalv1.InstanceSpec{
+					"compute-0": {
+						CtlPlaneIP: "192.168.1.12",
+					},
+				},
+			}
+			DeferCleanup(th.DeleteInstance, CreateDataplaneNodeSet(dataplaneNodeSetName, nodeSetSpec))
+		})
+
+		It("Should allow changes to the CloudUserName", func() {
+			Eventually(func(g Gomega) error {
+				instance := GetDataplaneNodeSet(dataplaneNodeSetName)
+				instance.Spec.BaremetalSetTemplate = baremetalv1.OpenStackBaremetalSetSpec{
+					CloudUserName: "new-user",
+					BmhLabelSelector: map[string]string{
+						"app": "test-openstack",
+					},
+					BaremetalHosts: map[string]baremetalv1.InstanceSpec{
+						"compute-0": {
+							CtlPlaneIP: "192.168.1.12",
+						},
+					},
+				}
+				return th.K8sClient.Update(th.Ctx, instance)
+			}).Should(Succeed())
+		})
+	})
+})


### PR DESCRIPTION
This change ensures users can't change the `baremetalSetTemplate` items after the initial deployment. Since this would require the node to be re-provisioned and this is not something that would be desirable. Instead, the user should delete and re-create the nodeSet if they want to change `baremetalSetTemplate` items.

Related: https://github.com/openstack-k8s-operators/dataplane-operator/pull/486