### PR TITLE
Add image_prefix ansible vars in dataplane crs

### DIFF
--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset.yaml
@@ -127,12 +127,13 @@ spec:
          dns_search_domains: []
          registry_url: quay.io/podified-antelope-centos9
          image_tag: current-podified
-         edpm_ovn_controller_agent_image: "{{ registry_url }}/openstack-ovn-controller:{{ image_tag }}"
-         edpm_iscsid_image: "{{ registry_url }}/openstack-iscsid:{{ image_tag }}"
-         edpm_logrotate_crond_image: "{{ registry_url }}/openstack-cron:{{ image_tag }}"
-         edpm_nova_compute_container_image: "{{ registry_url }}/openstack-nova-compute:{{ image_tag }}"
-         edpm_nova_libvirt_container_image: "{{ registry_url }}/openstack-nova-libvirt:{{ image_tag }}"
-         edpm_neutron_metadata_agent_image: "{{ registry_url }}/openstack-neutron-metadata-agent-ovn:{{ image_tag }}"
+         image_prefix: openstack
+         edpm_ovn_controller_agent_image: "{{ registry_url }}/{{ image_prefix }}-ovn-controller:{{ image_tag }}"
+         edpm_iscsid_image: "{{ registry_url }}/{{ image_prefix }}-iscsid:{{ image_tag }}"
+         edpm_logrotate_crond_image: "{{ registry_url }}/{{ image_prefix }}-cron:{{ image_tag }}"
+         edpm_nova_compute_container_image: "{{ registry_url }}/{{ image_prefix }}-nova-compute:{{ image_tag }}"
+         edpm_nova_libvirt_container_image: "{{ registry_url }}/{{ image_prefix }}-nova-libvirt:{{ image_tag }}"
+         edpm_neutron_metadata_agent_image: "{{ registry_url }}/{{ image_prefix }}-neutron-metadata-agent-ovn:{{ image_tag }}"
          gather_facts: false
          enable_debug: false
          # edpm firewall, change the allowed CIDR if needed

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal.yaml
@@ -149,12 +149,13 @@ spec:
 
         registry_url: quay.io/podified-antelope-centos9
         image_tag: current-podified
-        edpm_ovn_controller_agent_image: "{{ registry_url }}/openstack-ovn-controller:{{ image_tag }}"
-        edpm_iscsid_image: "{{ registry_url }}/openstack-iscsid:{{ image_tag }}"
-        edpm_logrotate_crond_image: "{{ registry_url }}/openstack-cron:{{ image_tag }}"
-        edpm_nova_compute_container_image: "{{ registry_url }}/openstack-nova-compute:{{ image_tag }}"
-        edpm_nova_libvirt_container_image: "{{ registry_url }}/openstack-nova-libvirt:{{ image_tag }}"
-        edpm_neutron_metadata_agent_image: "{{ registry_url }}/openstack-neutron-metadata-agent-ovn:{{ image_tag }}"
+        image_prefix: openstack
+        edpm_ovn_controller_agent_image: "{{ registry_url }}/{{ image_prefix }}-ovn-controller:{{ image_tag }}"
+        edpm_iscsid_image: "{{ registry_url }}/{{ image_prefix }}-iscsid:{{ image_tag }}"
+        edpm_logrotate_crond_image: "{{ registry_url }}/{{ image_prefix }}-cron:{{ image_tag }}"
+        edpm_nova_compute_container_image: "{{ registry_url }}/{{ image_prefix }}-nova-compute:{{ image_tag }}"
+        edpm_nova_libvirt_container_image: "{{ registry_url }}/{{ image_prefix }}-nova-libvirt:{{ image_tag }}"
+        edpm_neutron_metadata_agent_image: "{{ registry_url }}/{{ image_prefix }}-neutron-metadata-agent-ovn:{{ image_tag }}"
 
         gather_facts: false
         enable_debug: false

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal_with_ipam.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal_with_ipam.yaml
@@ -98,12 +98,13 @@ spec:
          edpm_nodes_validation_validate_gateway_icmp: false
          registry_url: quay.io/podified-antelope-centos9
          image_tag: current-podified
-         edpm_ovn_controller_agent_image: "{{ registry_url }}/openstack-ovn-controller:{{ image_tag }}"
-         edpm_iscsid_image: "{{ registry_url }}/openstack-iscsid:{{ image_tag }}"
-         edpm_logrotate_crond_image: "{{ registry_url }}/openstack-cron:{{ image_tag }}"
-         edpm_nova_compute_container_image: "{{ registry_url }}/openstack-nova-compute:{{ image_tag }}"
-         edpm_nova_libvirt_container_image: "{{ registry_url }}/openstack-nova-libvirt:{{ image_tag }}"
-         edpm_neutron_metadata_agent_image: "{{ registry_url }}/openstack-neutron-metadata-agent-ovn:{{ image_tag }}"
+         image_prefix: openstack
+         edpm_ovn_controller_agent_image: "{{ registry_url }}/{{ image_prefix }}-ovn-controller:{{ image_tag }}"
+         edpm_iscsid_image: "{{ registry_url }}/{{ image_prefix }}-iscsid:{{ image_tag }}"
+         edpm_logrotate_crond_image: "{{ registry_url }}/{{ image_prefix }}-cron:{{ image_tag }}"
+         edpm_nova_compute_container_image: "{{ registry_url }}/{{ image_prefix }}-nova-compute:{{ image_tag }}"
+         edpm_nova_libvirt_container_image: "{{ registry_url }}/{{ image_prefix }}-nova-libvirt:{{ image_tag }}"
+         edpm_neutron_metadata_agent_image: "{{ registry_url }}/{{ image_prefix }}-neutron-metadata-agent-ovn:{{ image_tag }}"
          gather_facts: false
          enable_debug: false
          # edpm firewall, change the allowed CIDR if needed

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_bgp.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_bgp.yaml
@@ -143,12 +143,13 @@ spec:
          dns_search_domains: []
          registry_url: quay.io/podified-antelope-centos9
          image_tag: current-podified
-         edpm_ovn_controller_agent_image: "{{ registry_url }}/openstack-ovn-controller:{{ image_tag }}"
-         edpm_iscsid_image: "{{ registry_url }}/openstack-iscsid:{{ image_tag }}"
-         edpm_logrotate_crond_image: "{{ registry_url }}/openstack-cron:{{ image_tag }}"
-         edpm_nova_compute_container_image: "{{ registry_url }}/openstack-nova-compute:{{ image_tag }}"
-         edpm_nova_libvirt_container_image: "{{ registry_url }}/openstack-nova-libvirt:{{ image_tag }}"
-         edpm_neutron_metadata_agent_image: "{{ registry_url }}/openstack-neutron-metadata-agent-ovn:{{ image_tag }}"
+         image_prefix: openstack
+         edpm_ovn_controller_agent_image: "{{ registry_url }}/{{ image_prefix }}-ovn-controller:{{ image_tag }}"
+         edpm_iscsid_image: "{{ registry_url }}/{{ image_prefix }}-iscsid:{{ image_tag }}"
+         edpm_logrotate_crond_image: "{{ registry_url }}/{{ image_prefix }}-cron:{{ image_tag }}"
+         edpm_nova_compute_container_image: "{{ registry_url }}/{{ image_prefix }}-nova-compute:{{ image_tag }}"
+         edpm_nova_libvirt_container_image: "{{ registry_url }}/{{ image_prefix }}-nova-libvirt:{{ image_tag }}"
+         edpm_neutron_metadata_agent_image: "{{ registry_url }}/{{ image_prefix }}-neutron-metadata-agent-ovn:{{ image_tag }}"
          gather_facts: false
          enable_debug: false
          # edpm firewall, change the allowed CIDR if needed

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ceph.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ceph.yaml
@@ -29,8 +29,8 @@ spec:
         dns_search_domains: []
         edpm_chrony_ntp_servers:
         - pool.ntp.org
-        edpm_iscsid_image: '{{ registry_url }}/openstack-iscsid:{{ image_tag }}'
-        edpm_logrotate_crond_image: '{{ registry_url }}/openstack-cron:{{ image_tag
+        edpm_iscsid_image: '{{ registry_url }}/{{ image_prefix }}-iscsid:{{ image_tag }}'
+        edpm_logrotate_crond_image: '{{ registry_url }}/{{ image_prefix }}-cron:{{ image_tag
           }}'
         edpm_network_config_hide_sensitive_logs: false
         edpm_network_config_template: |
@@ -67,13 +67,13 @@ spec:
           {% endfor %}
         edpm_nodes_validation_validate_controllers_icmp: false
         edpm_nodes_validation_validate_gateway_icmp: false
-        edpm_nova_compute_container_image: '{{ registry_url }}/openstack-nova-compute:{{
+        edpm_nova_compute_container_image: '{{ registry_url }}/{{ image_prefix }}-nova-compute:{{
           image_tag }}'
-        edpm_nova_libvirt_container_image: '{{ registry_url }}/openstack-nova-libvirt:{{
+        edpm_nova_libvirt_container_image: '{{ registry_url }}/{{ image_prefix }}-nova-libvirt:{{
           image_tag }}'
-        edpm_ovn_controller_agent_image: '{{ registry_url }}/openstack-ovn-controller:{{
+        edpm_ovn_controller_agent_image: '{{ registry_url }}/{{ image_prefix }}-ovn-controller:{{
           image_tag }}'
-        edpm_ovn_metadata_agent_image: '{{ registry_url }}/openstack-neutron-metadata-agent-ovn:{{
+        edpm_ovn_metadata_agent_image: '{{ registry_url }}/{{ image_prefix }}-neutron-metadata-agent-ovn:{{
           image_tag }}'
         edpm_selinux_mode: enforcing
         edpm_sshd_allowed_ranges:
@@ -86,6 +86,7 @@ spec:
         external_vlan_id: 44
         gather_facts: false
         image_tag: current-podified
+        image_prefix: openstack
         internal_api_cidr: "24"
         internal_api_host_routes: []
         internal_api_mtu: 1500

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ceph_hci.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ceph_hci.yaml
@@ -29,8 +29,8 @@ spec:
         dns_search_domains: []
         edpm_chrony_ntp_servers:
         - pool.ntp.org
-        edpm_iscsid_image: '{{ registry_url }}/openstack-iscsid:{{ image_tag }}'
-        edpm_logrotate_crond_image: '{{ registry_url }}/openstack-cron:{{ image_tag
+        edpm_iscsid_image: '{{ registry_url }}/{{ image_prefix }}-iscsid:{{ image_tag }}'
+        edpm_logrotate_crond_image: '{{ registry_url }}/{{ image_prefix }}-cron:{{ image_tag
           }}'
         edpm_network_config_hide_sensitive_logs: false
         edpm_network_config_template: |
@@ -67,13 +67,13 @@ spec:
           {% endfor %}
         edpm_nodes_validation_validate_controllers_icmp: false
         edpm_nodes_validation_validate_gateway_icmp: false
-        edpm_nova_compute_container_image: '{{ registry_url }}/openstack-nova-compute:{{
+        edpm_nova_compute_container_image: '{{ registry_url }}/{{ image_prefix }}-nova-compute:{{
           image_tag }}'
-        edpm_nova_libvirt_container_image: '{{ registry_url }}/openstack-nova-libvirt:{{
+        edpm_nova_libvirt_container_image: '{{ registry_url }}/{{ image_prefix }}-nova-libvirt:{{
           image_tag }}'
-        edpm_ovn_controller_agent_image: '{{ registry_url }}/openstack-ovn-controller:{{
+        edpm_ovn_controller_agent_image: '{{ registry_url }}/{{ image_prefix }}-ovn-controller:{{
           image_tag }}'
-        edpm_ovn_metadata_agent_image: '{{ registry_url }}/openstack-neutron-metadata-agent-ovn:{{
+        edpm_ovn_metadata_agent_image: '{{ registry_url }}/{{ image_prefix }}-neutron-metadata-agent-ovn:{{
           image_tag }}'
         edpm_selinux_mode: enforcing
         edpm_sshd_allowed_ranges:
@@ -86,6 +86,7 @@ spec:
         external_vlan_id: 44
         gather_facts: false
         image_tag: current-podified
+        image_prefix: openstack
         internal_api_cidr: "24"
         internal_api_host_routes: []
         internal_api_mtu: 1500

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_networker.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_networker.yaml
@@ -124,9 +124,10 @@ spec:
          dns_search_domains: []
          registry_url: quay.io/podified-antelope-centos9
          image_tag: current-podified
-         edpm_ovn_controller_agent_image: "{{ registry_url }}/openstack-ovn-controller:{{ image_tag }}"
-         edpm_iscsid_image: "{{ registry_url }}/openstack-iscsid:{{ image_tag }}"
-         edpm_logrotate_crond_image: "{{ registry_url }}/openstack-cron:{{ image_tag }}"
+         image_prefix: openstack
+         edpm_ovn_controller_agent_image: "{{ registry_url }}/{{ image_prefix }}-ovn-controller:{{ image_tag }}"
+         edpm_iscsid_image: "{{ registry_url }}/{{ image_prefix }}-iscsid:{{ image_tag }}"
+         edpm_logrotate_crond_image: "{{ registry_url }}/{{ image_prefix }}-cron:{{ image_tag }}"
          edpm_enable_chassis_gw: true
          gather_facts: false
          enable_debug: false

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_sriov.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_sriov.yaml
@@ -125,11 +125,12 @@ spec:
          dns_search_domains: []
          registry_url: quay.io/podified-antelope-centos9
          image_tag: current-podified
-         edpm_iscsid_image: "{{ registry_url }}/openstack-iscsid:{{ image_tag }}"
-         edpm_logrotate_crond_image: "{{ registry_url }}/openstack-cron:{{ image_tag }}"
-         edpm_nova_compute_container_image: "{{ registry_url }}/openstack-nova-compute:{{ image_tag }}"
-         edpm_nova_libvirt_container_image: "{{ registry_url }}/openstack-nova-libvirt:{{ image_tag }}"
-         edpm_neutron_sriov_image: "{{ registry_url }}/openstack-neutron-sriov-agent:{{ image_tag }}"
+         image_prefix: openstack
+         edpm_iscsid_image: "{{ registry_url }}/{{ image_prefix }}-iscsid:{{ image_tag }}"
+         edpm_logrotate_crond_image: "{{ registry_url }}/{{ image_prefix }}-cron:{{ image_tag }}"
+         edpm_nova_compute_container_image: "{{ registry_url }}/{{ image_prefix }}-nova-compute:{{ image_tag }}"
+         edpm_nova_libvirt_container_image: "{{ registry_url }}/{{ image_prefix }}-nova-libvirt:{{ image_tag }}"
+         edpm_neutron_sriov_image: "{{ registry_url }}/{{ image_prefix }}-neutron-sriov-agent:{{ image_tag }}"
          gather_facts: false
          enable_debug: false
          # edpm firewall, change the allowed CIDR if needed

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_with_ipam.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_with_ipam.yaml
@@ -111,12 +111,13 @@ spec:
          edpm_nodes_validation_validate_gateway_icmp: false
          registry_url: quay.io/podified-antelope-centos9
          image_tag: current-podified
-         edpm_ovn_controller_agent_image: "{{ registry_url }}/openstack-ovn-controller:{{ image_tag }}"
-         edpm_iscsid_image: "{{ registry_url }}/openstack-iscsid:{{ image_tag }}"
-         edpm_logrotate_crond_image: "{{ registry_url }}/openstack-cron:{{ image_tag }}"
-         edpm_nova_compute_container_image: "{{ registry_url }}/openstack-nova-compute:{{ image_tag }}"
-         edpm_nova_libvirt_container_image: "{{ registry_url }}/openstack-nova-libvirt:{{ image_tag }}"
-         edpm_neutron_metadata_agent_image: "{{ registry_url }}/openstack-neutron-metadata-agent-ovn:{{ image_tag }}"
+         image_prefix: openstack
+         edpm_ovn_controller_agent_image: "{{ registry_url }}/{{ image_prefix }}-ovn-controller:{{ image_tag }}"
+         edpm_iscsid_image: "{{ registry_url }}/{{ image_prefix }}-iscsid:{{ image_tag }}"
+         edpm_logrotate_crond_image: "{{ registry_url }}/{{ image_prefix }}-cron:{{ image_tag }}"
+         edpm_nova_compute_container_image: "{{ registry_url }}/{{ image_prefix }}-nova-compute:{{ image_tag }}"
+         edpm_nova_libvirt_container_image: "{{ registry_url }}/{{ image_prefix }}-nova-libvirt:{{ image_tag }}"
+         edpm_neutron_metadata_agent_image: "{{ registry_url }}/{{ image_prefix }}-neutron-metadata-agent-ovn:{{ image_tag }}"
          gather_facts: false
          enable_debug: false
          # edpm firewall, change the allowed CIDR if needed


### PR DESCRIPTION
In downstream, the osp18 image name starts with
rhosp18-openstack and upstream one starts with openstack.

If we update the registry and image namespace in dataplane cr, it will still pull the upstream image from defaults because downstream image names are different.

This pr introduces image_prefix var to set image prefix and avoid such issue.