### PR TITLE
Add mechanism to detect relevant spec changes

### DIFF
--- a/api/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
@@ -1910,6 +1910,8 @@ spec:
                   - type
                   type: object
                 type: array
+              configChanged:
+                type: boolean
               deployed:
                 type: boolean
             type: object

--- a/api/v1beta1/openstackdataplanenodeset_types.go
+++ b/api/v1beta1/openstackdataplanenodeset_types.go
@@ -92,6 +92,11 @@ type OpenStackDataPlaneNodeSetStatus struct {
 
 	// CtlplaneSearchDomain
 	CtlplaneSearchDomain string `json:"CtlplaneSearchDomain,omitempty" optional:"true"`
+
+	// +operator-sdk:csv:customresourcedefinitions:type=status,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	// ConfigChanged - Informs us if there are any differences between the deployed spec vs what the most recent version is.
+	// We can use this to inform our decisions about when to re-execute Ansible tasks.
+	ConfigChanged bool `json:"configChanged,omitempty" optional:"true"`
 }
 
 //+kubebuilder:object:root=true

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
@@ -1910,6 +1910,8 @@ spec:
                   - type
                   type: object
                 type: array
+              configChanged:
+                type: boolean
               deployed:
                 type: boolean
             type: object

--- a/docs/openstack_dataplanenodeset.md
+++ b/docs/openstack_dataplanenodeset.md
@@ -142,5 +142,6 @@ OpenStackDataPlaneNodeSetStatus defines the observed state of OpenStackDataPlane
 | deployed | Deployed | bool | false |
 | DNSClusterAddresses | DNSClusterAddresses | []string | false |
 | CtlplaneSearchDomain | CtlplaneSearchDomain | string | false |
+| configChanged | ConfigChanged - Informs us if there are any differences between the deployed spec vs what the most recent version is. We can use this to inform our decisions about when to re-execute Ansible tasks. | bool | false |
 
 [Back to Custom Resources](#custom-resources)


### PR DESCRIPTION
This change adds a Status field called ConfigChanged. We update this field in cases where the current config differs from the previously applied config. This is specifically used to detect changes between spec.nodes and spec.nodeTemplate. If either of those have a variance, then the ConfigChanged status field will be set to true.