### PR TITLE
Generate config hash for nodeTemplate and nodes sections

### DIFF
--- a/api/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
@@ -1928,12 +1928,16 @@ spec:
                   - type
                   type: object
                 type: array
+              configHash:
+                type: string
               configMapHashes:
                 additionalProperties:
                   type: string
                 type: object
               deployed:
                 type: boolean
+              deployedConfigHash:
+                type: string
               deploymentStatuses:
                 additionalProperties:
                   items:

--- a/api/v1beta1/openstackdataplanenodeset_types.go
+++ b/api/v1beta1/openstackdataplanenodeset_types.go
@@ -115,6 +115,17 @@ type OpenStackDataPlaneNodeSetStatus struct {
 
 	// SecretHashes
 	SecretHashes map[string]string `json:"secretHashes,omitempty" optional:"true"`
+
+	// ConfigHash - holds the curret hash of the NodeTemplate and Node sections of the struct.
+	// This hash is used to determine when new Ansible executions are required to roll
+	// out config changes.
+	ConfigHash string `json:"configHash,omitempty"`
+
+	// DeployedConfigHash - holds the hash of the NodeTemplate and Node sections of the struct
+	// that was last deployed.
+	// This hash is used to determine when new Ansible executions are required to roll
+	// out config changes.
+	DeployedConfigHash string `json:"deployedConfigHash,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
@@ -1928,12 +1928,16 @@ spec:
                   - type
                   type: object
                 type: array
+              configHash:
+                type: string
               configMapHashes:
                 additionalProperties:
                   type: string
                 type: object
               deployed:
                 type: boolean
+              deployedConfigHash:
+                type: string
               deploymentStatuses:
                 additionalProperties:
                   items:

--- a/docs/assemblies/custom_resources.adoc
+++ b/docs/assemblies/custom_resources.adoc
@@ -576,6 +576,16 @@ OpenStackDataPlaneNodeSetStatus defines the observed state of OpenStackDataPlane
 | SecretHashes
 | map[string]string
 | false
+
+| configHash
+| ConfigHash - holds the curret hash of the NodeTemplate and Node sections of the struct. This hash is used to determine when new Ansible executions are required to roll out config changes.
+| string
+| false
+
+| deployedConfigHash
+| DeployedConfigHash - holds the hash of the NodeTemplate and Node sections of the struct that was last deployed. This hash is used to determine when new Ansible executions are required to roll out config changes.
+| string
+| false
 |===
 
 <<custom-resources,Back to Custom Resources>>

--- a/docs/assemblies/deploying.adoc
+++ b/docs/assemblies/deploying.adoc
@@ -245,7 +245,21 @@ NAME             STATUS   MESSAGE
 openstack-edpm   False    Deployment not started
 ----
 
-=== Understanding OpenStackDataPlaneServices
+=== NodeSet Config Changes
+We create a Hash of the inputs located in the OpenStackDataPlaneNodeSet Spec Nodes and NodeTemplate sections.
+This hash is then stored in the `status.configHash` field. If the current value of the configHash is different
+to the deployedConfigHash, then it is necessary to recreate the `OpenStackDataPlaneDeployment` to roll out
+the new changes:
+
+```
+$ oc get osdpns -o yaml | yq '.items[0].status.configHash'
+"n648hd6h88hc7h86hc7h568h585h79h5"
+
+```
+This field can be used to inform user decisions around when a new deploy is needed to reconclie the changes to the NodeSet.
+
+
+### Understanding OpenStackDataPlaneServices
 
 A dataplane is configured with a set of services that define the Ansible plays
 or playbooks that are executed to complete the deployment. The


### PR DESCRIPTION
This change generates a hash of the config contained within the nodeTemplate and nodes sections of the NodeSet spec. This can be used to determine whether or not it's necessary to re-run the Ansible tasks.


This is being proposed as a potential alternative to:
https://github.com/openstack-k8s-operators/dataplane-operator/pull/490
