### PR TITLE
Ensure a valid name for AEE

### DIFF
--- a/pkg/util/ansible_execution.go
+++ b/pkg/util/ansible_execution.go
@@ -56,7 +56,12 @@ func AnsibleExecution(
 		return err
 	}
 	if ansibleEE == nil {
-		executionName := fmt.Sprintf("%s-%s", label, obj.GetName())
+		var executionName string
+		if len(label) > 0 {
+			executionName = fmt.Sprintf("%s-%s", label, obj.GetName())
+		} else {
+			executionName = obj.GetName()
+		}
 		ansibleEE = &ansibleeev1.OpenStackAnsibleEE{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      executionName,


### PR DESCRIPTION
When Label wasn't provided it was breaking the AEE deploy
ref: https://github.com/openstack-k8s-operators/data-plane-adoption/pull/176#issuecomment-1782941506
```
a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character " ref:  https://github.com/openstack-k8s-operators/data-plane-adoption/pull/176#issuecomment-1782941506
```

