### PR TITLE
Re-run AnsibleEE jobs when config changes.

### DIFF
--- a/api/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
@@ -1910,6 +1910,10 @@ spec:
                   - type
                   type: object
                 type: array
+              configChanged:
+                type: boolean
+              configHash:
+                type: string
               deployed:
                 type: boolean
             type: object

--- a/api/v1beta1/openstackdataplanenodeset_types.go
+++ b/api/v1beta1/openstackdataplanenodeset_types.go
@@ -92,6 +92,16 @@ type OpenStackDataPlaneNodeSetStatus struct {
 
 	// CtlplaneSearchDomain
 	CtlplaneSearchDomain string `json:"CtlplaneSearchDomain,omitempty" optional:"true"`
+
+	// +operator-sdk:csv:customresourcedefinitions:type=status,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+ 	// ConfigChanged - Informs us if there are any differences between the deployed spec vs what the most recent version is.
+ 	// We can use this to inform our decisions about when to re-execute Ansible tasks.
+ 	ConfigChanged bool `json:"configChanged,omitempty" optional:"true"`
+
+	// ConfigHash - holds the hash of the NodeTemplate and Node sections of the struct.
+	// This hash is used to determine when new Ansible executions are required to roll
+	// out config changes.
+	ConfigHash string `json:"configHash,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1beta1/openstackdataplanenodeset_types.go
+++ b/api/v1beta1/openstackdataplanenodeset_types.go
@@ -146,10 +146,20 @@ func (instance *OpenStackDataPlaneNodeSet) InitConditions() {
 
 // GetAnsibleEESpec - get the fields that will be passed to AEE
 func (instance OpenStackDataPlaneNodeSet) GetAnsibleEESpec() AnsibleEESpec {
+	// Build env to include DEPLOY_CONFIG_HASH at the front of the slice
+	var aeeEnv []corev1.EnvVar
+	aeeEnv = append(aeeEnv, corev1.EnvVar{
+		Name: "DEPLOY_CONFIG_HASH",
+		Value: instance.Status.ConfigHash,
+	})
+	for _, envItem := range instance.Spec.Env {
+		aeeEnv = append(aeeEnv, envItem)
+	}
+
 	return AnsibleEESpec{
 		NetworkAttachments: instance.Spec.NetworkAttachments,
 		ExtraMounts:        instance.Spec.NodeTemplate.ExtraMounts,
-		Env:                instance.Spec.Env,
+		Env:                aeeEnv,
 	}
 }
 

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
@@ -1910,6 +1910,10 @@ spec:
                   - type
                   type: object
                 type: array
+              configChanged:
+                type: boolean
+              configHash:
+                type: string
               deployed:
                 type: boolean
             type: object

--- a/docs/openstack_dataplanenodeset.md
+++ b/docs/openstack_dataplanenodeset.md
@@ -142,5 +142,7 @@ OpenStackDataPlaneNodeSetStatus defines the observed state of OpenStackDataPlane
 | deployed | Deployed | bool | false |
 | DNSClusterAddresses | DNSClusterAddresses | []string | false |
 | CtlplaneSearchDomain | CtlplaneSearchDomain | string | false |
+| configChanged | ConfigChanged - Informs us if there are any differences between the deployed spec vs what the most recent version is. We can use this to inform our decisions about when to re-execute Ansible tasks. | bool | false |
+| configHash | ConfigHash - holds the hash of the NodeTemplate and Node sections of the struct. This hash is used to determine when new Ansible executions are required to roll out config changes. | string | false |
 
 [Back to Custom Resources](#custom-resources)

--- a/tests/functional/openstackdataplanenodeset_controller_test.go
+++ b/tests/functional/openstackdataplanenodeset_controller_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package functional
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 
@@ -483,6 +484,43 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 					corev1.ConditionTrue,
 				)
 			}
+		})
+	})
+	When("No last-applied-configuration annotation exists", func() {
+		BeforeEach(func() {
+			DeferCleanup(th.DeleteInstance, CreateDataplaneNodeSet(dataplaneNodeSetName, DefaultDataPlaneNodeSetSpec()))
+		})
+
+		It("Should have configChanged set to false", func() {
+			Expect(GetDataplaneNodeSet(dataplaneNodeSetName).Status.ConfigChanged).Should(BeFalse())
+		})
+	})
+
+	When("A user changes spec field that would require a new Ansible execution", func() {
+		BeforeEach(func() {
+			nodeSetSpec := DefaultDataPlaneNodeSetSpec()
+			nodeSetSpec["nodeTemplate"] = dataplanev1.NodeTemplate{
+				Ansible: dataplanev1.AnsibleOpts{
+					AnsibleVars: map[string]json.RawMessage{
+						"edpm_network_config_hide_sensitive_logs": json.RawMessage([]byte(`"false"`)),
+					},
+				},
+			}
+			DeferCleanup(th.DeleteInstance, CreateDataplaneNodeSet(dataplaneNodeSetName, nodeSetSpec))
+		})
+
+		It("Should set the ConfigChanged Status field", func() {
+			Eventually(func(g Gomega) error {
+				instance := GetDataplaneNodeSet(dataplaneNodeSetName)
+				instance.Spec.NodeTemplate.Ansible.AnsibleVars = map[string]json.RawMessage{
+					"edpm_network_config_hide_sensitive_logs": json.RawMessage([]byte(`"true"`)),
+				}
+				return th.K8sClient.Update(th.Ctx, instance)
+			}).Should(Succeed())
+			Eventually(func(g Gomega) bool {
+				updatedInstance := GetDataplaneNodeSet(dataplaneNodeSetName)
+				return updatedInstance.Status.ConfigChanged
+			}).Should(BeTrue())
 		})
 	})
 })


### PR DESCRIPTION
This change leverages the configHash generated by:
https://github.com/openstack-k8s-operators/dataplane-operator/pull/491

We then write the `configHash` to the `AnsibleEE` `EnvVars` and use this to determine which jobs have been executed using the latest config. If the config changes, then we detect this and update the `NodeSet.Status.ConfigChanged` bool to provide visual confirmation to the user that the change has been registered. We reference this field to trigger the workflow that will:

1. Check each service for the current Deployed Config Hash;
2. Delete `AnsibleEE` CR's that have the old ConfigHash;
3. Create new `AnsibleEE` objects with the new ConfigHash and subsequently roll out the new config to the dataplane nodes.

Currently, we are only checking the `NodeTemplate` and `Nodes` parts of the Spec for changes and ignoring all other fields including ENV. So this would do nothing if the ENV was updated on the nodeSet for example.