### PR TITLE
Cleanup bgp sample

### DIFF
--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_bgp.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_bgp.yaml
@@ -33,24 +33,10 @@ spec:
             storage_ip: 172.18.0.100
             tenant_ip: 172.19.0.100
             fqdn_internal_api: edpm-compute-0.example.com
-  networkAttachments:
-    - ctlplane
   nodeTemplate:
     ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
-    managementNetwork: ctlplane
     ansible:
-      ansibleUser: cloud-admin
-      ansiblePort: 22
       ansibleVars:
-         service_net_map:
-           nova_api_network: internal_api
-           nova_libvirt_network: internal_api
-         timesync_ntp_servers:
-           - hostname: pool.ntp.org
-         # edpm_network_config
-         # Default nic config template for a EDPM compute node
-         # These vars are edpm_network_config role vars
-         edpm_network_config_hide_sensitive_logs: false
          edpm_network_config_template: |
               ---
               {% set mtu_list = [ctlplane_mtu] %}
@@ -100,7 +86,6 @@ spec:
 
          # These vars are for the network config templates themselves and are
          # considered EDPM network defaults.
-         neutron_physical_bridge_name: br-ex
          neutron_public_interface_name: eth0
          ctlplane_mtu: 1500
          ctlplane_subnet_cidr: 24
@@ -136,16 +121,9 @@ spec:
          # edpm_nodes_validation
          edpm_nodes_validation_validate_controllers_icmp: false
          edpm_nodes_validation_validate_gateway_icmp: false
-         ctlplane_dns_nameservers:
-         - 192.168.122.1
-         dns_search_domains: []
-         gather_facts: false
-         enable_debug: false
          # edpm firewall, change the allowed CIDR if needed
          edpm_sshd_configure_firewall: true
          edpm_sshd_allowed_ranges: ['192.168.122.0/24']
-         # SELinux module
-         edpm_selinux_mode: enforcing
          edpm_frr_bgp_uplinks: ['nic2', 'nic3']
          edpm_frr_bgp_neighbor_password: f00barZ
          edpm_frr_bgp_ipv4_src_network: bgp_main_net


### PR DESCRIPTION
    This change removes unncessary variables from the BGP sample NodeSet
    config file. We remove the spec.env section, along with variables that
    are either unnecessary for this example, or variables that are just set
    to their defaults.