### PR TITLE
Update the openstack services containers names in CR

### DIFF
--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset.yaml
@@ -134,6 +134,13 @@ spec:
          edpm_nova_compute_container_image: "{{ registry_url }}/{{ image_prefix }}-nova-compute:{{ image_tag }}"
          edpm_nova_libvirt_container_image: "{{ registry_url }}/{{ image_prefix }}-nova-libvirt:{{ image_tag }}"
          edpm_neutron_metadata_agent_image: "{{ registry_url }}/{{ image_prefix }}-neutron-metadata-agent-ovn:{{ image_tag }}"
+         edpm_neutron_ovn_agent_image: "{{ registry_url }}/{{ image_prefix }}-neutron-ovn-agent:{{ image_tag }}"
+         edpm_ovn_bgp_agent_image: "{{ registry_url }}/{{ image_prefix }}-ovn-bgp-agent:{{ image_tag }}"
+         edpm_neutron_dhcp_image: "{{ registry_url }}/{{ image_prefix }}-neutron-dhcp-agent:{{ image_tag }}"
+         edpm_neutron_sriov_image: "{{ registry_url }}/{{ image_prefix }}-neutron-sriov-agent:{{ image_tag }}"
+         edpm_frr_image: "{{ registry_url }}/{{ image_prefix }}-frr:{{ image_tag }}"
+         edpm_multipathd_image: "{{ registry_url }}/{{ image_prefix }}-multipathd:{{ image_tag }}"
+
          gather_facts: false
          enable_debug: false
          # edpm firewall, change the allowed CIDR if needed

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal.yaml
@@ -156,6 +156,12 @@ spec:
         edpm_nova_compute_container_image: "{{ registry_url }}/{{ image_prefix }}-nova-compute:{{ image_tag }}"
         edpm_nova_libvirt_container_image: "{{ registry_url }}/{{ image_prefix }}-nova-libvirt:{{ image_tag }}"
         edpm_neutron_metadata_agent_image: "{{ registry_url }}/{{ image_prefix }}-neutron-metadata-agent-ovn:{{ image_tag }}"
+        edpm_neutron_ovn_agent_image: "{{ registry_url }}/{{ image_prefix }}-neutron-ovn-agent:{{ image_tag }}"
+        edpm_ovn_bgp_agent_image: "{{ registry_url }}/{{ image_prefix }}-ovn-bgp-agent:{{ image_tag }}"
+        edpm_neutron_dhcp_image: "{{ registry_url }}/{{ image_prefix }}-neutron-dhcp-agent:{{ image_tag }}"
+        edpm_neutron_sriov_image: "{{ registry_url }}/{{ image_prefix }}-neutron-sriov-agent:{{ image_tag }}"
+        edpm_frr_image: "{{ registry_url }}/{{ image_prefix }}-frr:{{ image_tag }}"
+        edpm_multipathd_image: "{{ registry_url }}/{{ image_prefix }}-multipathd:{{ image_tag }}"
 
         gather_facts: false
         enable_debug: false

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal_with_ipam.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal_with_ipam.yaml
@@ -105,6 +105,13 @@ spec:
          edpm_nova_compute_container_image: "{{ registry_url }}/{{ image_prefix }}-nova-compute:{{ image_tag }}"
          edpm_nova_libvirt_container_image: "{{ registry_url }}/{{ image_prefix }}-nova-libvirt:{{ image_tag }}"
          edpm_neutron_metadata_agent_image: "{{ registry_url }}/{{ image_prefix }}-neutron-metadata-agent-ovn:{{ image_tag }}"
+         edpm_neutron_ovn_agent_image: "{{ registry_url }}/{{ image_prefix }}-neutron-ovn-agent:{{ image_tag }}"
+         edpm_ovn_bgp_agent_image: "{{ registry_url }}/{{ image_prefix }}-ovn-bgp-agent:{{ image_tag }}"
+         edpm_neutron_dhcp_image: "{{ registry_url }}/{{ image_prefix }}-neutron-dhcp-agent:{{ image_tag }}"
+         edpm_neutron_sriov_image: "{{ registry_url }}/{{ image_prefix }}-neutron-sriov-agent:{{ image_tag }}"
+         edpm_frr_image: "{{ registry_url }}/{{ image_prefix }}-frr:{{ image_tag }}"
+         edpm_multipathd_image: "{{ registry_url }}/{{ image_prefix }}-multipathd:{{ image_tag }}"
+
          gather_facts: false
          enable_debug: false
          # edpm firewall, change the allowed CIDR if needed

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_bgp.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_bgp.yaml
@@ -150,6 +150,13 @@ spec:
          edpm_nova_compute_container_image: "{{ registry_url }}/{{ image_prefix }}-nova-compute:{{ image_tag }}"
          edpm_nova_libvirt_container_image: "{{ registry_url }}/{{ image_prefix }}-nova-libvirt:{{ image_tag }}"
          edpm_neutron_metadata_agent_image: "{{ registry_url }}/{{ image_prefix }}-neutron-metadata-agent-ovn:{{ image_tag }}"
+         edpm_neutron_ovn_agent_image: "{{ registry_url }}/{{ image_prefix }}-neutron-ovn-agent:{{ image_tag }}"
+         edpm_ovn_bgp_agent_image: "{{ registry_url }}/{{ image_prefix }}-ovn-bgp-agent:{{ image_tag }}"
+         edpm_neutron_dhcp_image: "{{ registry_url }}/{{ image_prefix }}-neutron-dhcp-agent:{{ image_tag }}"
+         edpm_neutron_sriov_image: "{{ registry_url }}/{{ image_prefix }}-neutron-sriov-agent:{{ image_tag }}"
+         edpm_frr_image: "{{ registry_url }}/{{ image_prefix }}-frr:{{ image_tag }}"
+         edpm_multipathd_image: "{{ registry_url }}/{{ image_prefix }}-multipathd:{{ image_tag }}"
+
          gather_facts: false
          enable_debug: false
          # edpm firewall, change the allowed CIDR if needed

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ceph.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ceph.yaml
@@ -32,6 +32,12 @@ spec:
         edpm_iscsid_image: '{{ registry_url }}/{{ image_prefix }}-iscsid:{{ image_tag }}'
         edpm_logrotate_crond_image: '{{ registry_url }}/{{ image_prefix }}-cron:{{ image_tag
           }}'
+        edpm_neutron_ovn_agent_image: "{{ registry_url }}/{{ image_prefix }}-neutron-ovn-agent:{{ image_tag }}"
+        edpm_ovn_bgp_agent_image: "{{ registry_url }}/{{ image_prefix }}-ovn-bgp-agent:{{ image_tag }}"
+        edpm_neutron_dhcp_image: "{{ registry_url }}/{{ image_prefix }}-neutron-dhcp-agent:{{ image_tag }}"
+        edpm_neutron_sriov_image: "{{ registry_url }}/{{ image_prefix }}-neutron-sriov-agent:{{ image_tag }}"
+        edpm_frr_image: "{{ registry_url }}/{{ image_prefix }}-frr:{{ image_tag }}"
+        edpm_multipathd_image: "{{ registry_url }}/{{ image_prefix }}-multipathd:{{ image_tag }}"
         edpm_network_config_hide_sensitive_logs: false
         edpm_network_config_template: |
           ---

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ceph_hci.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ceph_hci.yaml
@@ -32,6 +32,12 @@ spec:
         edpm_iscsid_image: '{{ registry_url }}/{{ image_prefix }}-iscsid:{{ image_tag }}'
         edpm_logrotate_crond_image: '{{ registry_url }}/{{ image_prefix }}-cron:{{ image_tag
           }}'
+        edpm_neutron_ovn_agent_image: "{{ registry_url }}/{{ image_prefix }}-neutron-ovn-agent:{{ image_tag }}"
+        edpm_ovn_bgp_agent_image: "{{ registry_url }}/{{ image_prefix }}-ovn-bgp-agent:{{ image_tag }}"
+        edpm_neutron_dhcp_image: "{{ registry_url }}/{{ image_prefix }}-neutron-dhcp-agent:{{ image_tag }}"
+        edpm_neutron_sriov_image: "{{ registry_url }}/{{ image_prefix }}-neutron-sriov-agent:{{ image_tag }}"
+        edpm_frr_image: "{{ registry_url }}/{{ image_prefix }}-frr:{{ image_tag }}"
+        edpm_multipathd_image: "{{ registry_url }}/{{ image_prefix }}-multipathd:{{ image_tag }}"
         edpm_network_config_hide_sensitive_logs: false
         edpm_network_config_template: |
           ---

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_networker.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_networker.yaml
@@ -128,6 +128,13 @@ spec:
          edpm_ovn_controller_agent_image: "{{ registry_url }}/{{ image_prefix }}-ovn-controller:{{ image_tag }}"
          edpm_iscsid_image: "{{ registry_url }}/{{ image_prefix }}-iscsid:{{ image_tag }}"
          edpm_logrotate_crond_image: "{{ registry_url }}/{{ image_prefix }}-cron:{{ image_tag }}"
+         edpm_neutron_ovn_agent_image: "{{ registry_url }}/{{ image_prefix }}-neutron-ovn-agent:{{ image_tag }}"
+         edpm_ovn_bgp_agent_image: "{{ registry_url }}/{{ image_prefix }}-ovn-bgp-agent:{{ image_tag }}"
+         edpm_neutron_dhcp_image: "{{ registry_url }}/{{ image_prefix }}-neutron-dhcp-agent:{{ image_tag }}"
+         edpm_neutron_sriov_image: "{{ registry_url }}/{{ image_prefix }}-neutron-sriov-agent:{{ image_tag }}"
+         edpm_frr_image: "{{ registry_url }}/{{ image_prefix }}-frr:{{ image_tag }}"
+         edpm_multipathd_image: "{{ registry_url }}/{{ image_prefix }}-multipathd:{{ image_tag }}"
+
          edpm_enable_chassis_gw: true
          gather_facts: false
          enable_debug: false

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_nmstate.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_nmstate.yaml
@@ -154,6 +154,13 @@ spec:
         edpm_nova_compute_container_image: "{{ registry_url }}/{{ image_prefix }}-nova-compute:{{ image_tag }}"
         edpm_nova_libvirt_container_image: "{{ registry_url }}/{{ image_prefix }}-nova-libvirt:{{ image_tag }}"
         edpm_neutron_metadata_agent_image: "{{ registry_url }}/{{ image_prefix }}-neutron-metadata-agent-ovn:{{ image_tag }}"
+        edpm_neutron_ovn_agent_image: "{{ registry_url }}/{{ image_prefix }}-neutron-ovn-agent:{{ image_tag }}"
+        edpm_ovn_bgp_agent_image: "{{ registry_url }}/{{ image_prefix }}-ovn-bgp-agent:{{ image_tag }}"
+        edpm_neutron_dhcp_image: "{{ registry_url }}/{{ image_prefix }}-neutron-dhcp-agent:{{ image_tag }}"
+        edpm_neutron_sriov_image: "{{ registry_url }}/{{ image_prefix }}-neutron-sriov-agent:{{ image_tag }}"
+        edpm_frr_image: "{{ registry_url }}/{{ image_prefix }}-frr:{{ image_tag }}"
+        edpm_multipathd_image: "{{ registry_url }}/{{ image_prefix }}-multipathd:{{ image_tag }}"
+
         gather_facts: false
         enable_debug: false
         # edpm firewall, change the allowed CIDR if needed

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_sriov.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_sriov.yaml
@@ -131,6 +131,12 @@ spec:
          edpm_nova_compute_container_image: "{{ registry_url }}/{{ image_prefix }}-nova-compute:{{ image_tag }}"
          edpm_nova_libvirt_container_image: "{{ registry_url }}/{{ image_prefix }}-nova-libvirt:{{ image_tag }}"
          edpm_neutron_sriov_image: "{{ registry_url }}/{{ image_prefix }}-neutron-sriov-agent:{{ image_tag }}"
+         edpm_neutron_ovn_agent_image: "{{ registry_url }}/{{ image_prefix }}-neutron-ovn-agent:{{ image_tag }}"
+         edpm_ovn_bgp_agent_image: "{{ registry_url }}/{{ image_prefix }}-ovn-bgp-agent:{{ image_tag }}"
+         edpm_neutron_dhcp_image: "{{ registry_url }}/{{ image_prefix }}-neutron-dhcp-agent:{{ image_tag }}"
+         edpm_neutron_sriov_image: "{{ registry_url }}/{{ image_prefix }}-neutron-sriov-agent:{{ image_tag }}"
+         edpm_frr_image: "{{ registry_url }}/{{ image_prefix }}-frr:{{ image_tag }}"
+         edpm_multipathd_image: "{{ registry_url }}/{{ image_prefix }}-multipathd:{{ image_tag }}"
          gather_facts: false
          enable_debug: false
          # edpm firewall, change the allowed CIDR if needed

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_with_ipam.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_with_ipam.yaml
@@ -118,6 +118,12 @@ spec:
          edpm_nova_compute_container_image: "{{ registry_url }}/{{ image_prefix }}-nova-compute:{{ image_tag }}"
          edpm_nova_libvirt_container_image: "{{ registry_url }}/{{ image_prefix }}-nova-libvirt:{{ image_tag }}"
          edpm_neutron_metadata_agent_image: "{{ registry_url }}/{{ image_prefix }}-neutron-metadata-agent-ovn:{{ image_tag }}"
+         edpm_neutron_ovn_agent_image: "{{ registry_url }}/{{ image_prefix }}-neutron-ovn-agent:{{ image_tag }}"
+         edpm_ovn_bgp_agent_image: "{{ registry_url }}/{{ image_prefix }}-ovn-bgp-agent:{{ image_tag }}"
+         edpm_neutron_dhcp_image: "{{ registry_url }}/{{ image_prefix }}-neutron-dhcp-agent:{{ image_tag }}"
+         edpm_neutron_sriov_image: "{{ registry_url }}/{{ image_prefix }}-neutron-sriov-agent:{{ image_tag }}"
+         edpm_frr_image: "{{ registry_url }}/{{ image_prefix }}-frr:{{ image_tag }}"
+         edpm_multipathd_image: "{{ registry_url }}/{{ image_prefix }}-multipathd:{{ image_tag }}"
          gather_facts: false
          enable_debug: false
          # edpm firewall, change the allowed CIDR if needed


### PR DESCRIPTION
During EDPM deployment, we pull multiple openstack services containers. Most of them are not listed in CR.

During deployment in periodic line, unlisted openstack services containers gets pulled from quay.io instead of quay.rdoproject.org.

This pr updates the list of missing openstack services containers with proper address so that correct content gets pulled from proper location.