### PR TITLE
Update samples for max_fail_percentage and any_errors_fatal

### DIFF
--- a/config/samples/dataplane_v1beta1_openstackdataplaneservice.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplaneservice.yaml
@@ -1,12 +1,9 @@
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneService
 metadata:
-  labels:
-    app.kubernetes.io/name: openstackdataplaneservice
-    app.kubernetes.io/instance: openstackdataplaneservice-sample
-    app.kubernetes.io/part-of: dataplane-operator
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: dataplane-operator
   name: openstackdataplaneservice-sample
 spec:
-  # TODO(user): Add fields here
+  label: your-label-here
+  playbook: playbook-to-execute
+  ansibleAnyErrorsFatal: true
+  ansibleMaxFailPercentage: 10


### PR DESCRIPTION
This change adds examples for how to define max_fail_percentage and any_errors_fatal. These were added by:
https://github.com/openstack-k8s-operators/dataplane-operator/pull/519