### PR TITLE
Remove check for BaremetalHosts in defaulting webhook

### DIFF
--- a/api/v1beta1/openstackdataplanenodeset_webhook.go
+++ b/api/v1beta1/openstackdataplanenodeset_webhook.go
@@ -66,7 +66,7 @@ func (spec *OpenStackDataPlaneNodeSetSpec) Default() {
 		spec.BaremetalSetTemplate.DeploymentSSHSecret = spec.NodeTemplate.AnsibleSSHPrivateKeySecret
 	}
 
-	if !spec.PreProvisioned && spec.BaremetalSetTemplate.BaremetalHosts == nil {
+	if !spec.PreProvisioned {
 		nodeSetHostMap := make(map[string]baremetalv1.InstanceSpec)
 		for _, node := range spec.Nodes {
 			instanceSpec := baremetalv1.InstanceSpec{}

--- a/tests/functional/openstackdataplanenodeset_webhook_test.go
+++ b/tests/functional/openstackdataplanenodeset_webhook_test.go
@@ -28,15 +28,14 @@ var _ = Describe("DataplaneNodeSet Webhook", func() {
 		BeforeEach(func() {
 			nodeSetSpec := DefaultDataPlaneNoNodeSetSpec()
 			nodeSetSpec["preProvisioned"] = false
+			nodeSetSpec["nodes"] = map[string]interface{}{
+				"compute-0": map[string]interface{}{
+					"hostName": "compute-0"},
+			}
 			nodeSetSpec["baremetalSetTemplate"] = baremetalv1.OpenStackBaremetalSetSpec{
 				CloudUserName: "test-user",
 				BmhLabelSelector: map[string]string{
 					"app": "test-openstack",
-				},
-				BaremetalHosts: map[string]baremetalv1.InstanceSpec{
-					"compute-0": {
-						CtlPlaneIP: "192.168.1.12",
-					},
 				},
 			}
 			DeferCleanup(th.DeleteInstance, CreateDataplaneNodeSet(dataplaneNodeSetName, nodeSetSpec))


### PR DESCRIPTION
This creates a problem during update to scale-up as the spec passed to defaulting webhook contains earlier BaremetalHosts.