### PR TITLE
Remove `download-cache` service from samples

### DIFF
--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset.yaml
@@ -9,7 +9,6 @@ spec:
     - name: ANSIBLE_ENABLE_TASK_DEBUGGER
       value: "True"
   services:
-    - download-cache
     - configure-network
     - validate-network
     - install-os

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal.yaml
@@ -10,7 +10,6 @@ spec:
     - name: ANSIBLE_ENABLE_TASK_DEBUGGER
       value: "True"
   services:
-    - download-cache
     - configure-network
     - validate-network
     - install-os

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal_with_ipam.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal_with_ipam.yaml
@@ -9,7 +9,6 @@ spec:
     - name: ANSIBLE_ENABLE_TASK_DEBUGGER
       value: "True"
   services:
-    - download-cache
     - configure-network
     - validate-network
     - install-os

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_customnetworks.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_customnetworks.yaml
@@ -14,7 +14,6 @@ spec:
     - name: ANSIBLE_HOST_KEY_CHECKING
       value: false
   services:
-    - download-cache
     - configure-network
     - validate-network
     - install-os

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_sriov.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_sriov.yaml
@@ -9,7 +9,6 @@ spec:
     - name: ANSIBLE_ENABLE_TASK_DEBUGGER
       value: "True"
   services:
-    - download-cache
     - configure-network
     - validate-network
     - install-os


### PR DESCRIPTION
Since EL nodes aren't registered with subscription manager during download-cache phase, we avoid to run the service because download of the packages will fail