### PR TITLE
Use struct for deployment

### DIFF
--- a/controllers/openstackdataplanedeployment_controller.go
+++ b/controllers/openstackdataplanedeployment_controller.go
@@ -212,20 +212,24 @@ func (r *OpenStackDataPlaneDeploymentReconciler) Reconcile(ctx context.Context, 
 			}
 		}
 
+		deployer := deployment.Deployer{
+			Ctx:             ctx,
+			Helper:          helper,
+			NodeSet:         &nodeSet,
+			Deployment:      instance,
+			Status:          &instance.Status,
+			AeeSpec:         &ansibleEESpec,
+			InventorySecret: nodeSetSecretInv,
+		}
+
 		// When ServicesOverride is set on the OpenStackDataPlaneDeployment,
 		// deploy those services for each OpenStackDataPlaneNodeSet. Otherwise,
 		// deploy with the OpenStackDataPlaneNodeSet's Services.
 		var deployResult *ctrl.Result
 		if len(instance.Spec.ServicesOverride) != 0 {
-			deployResult, err = deployment.Deploy(
-				ctx, helper, &nodeSet, instance,
-				nodeSetSecretInv, &instance.Status, ansibleEESpec,
-				instance.Spec.ServicesOverride)
+			deployResult, err = deployer.Deploy(instance.Spec.ServicesOverride)
 		} else {
-			deployResult, err = deployment.Deploy(
-				ctx, helper, &nodeSet, instance,
-				nodeSetSecretInv, &instance.Status, ansibleEESpec,
-				nodeSet.Spec.Services)
+			deployResult, err = deployer.Deploy(nodeSet.Spec.Services)
 		}
 
 		if err != nil {

--- a/pkg/deployment/service.go
+++ b/pkg/deployment/service.go
@@ -26,7 +26,6 @@ import (
 	yaml "gopkg.in/yaml.v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	dataplanev1 "github.com/openstack-k8s-operators/dataplane-operator/api/v1beta1"
@@ -43,10 +42,10 @@ type ServiceYAML struct {
 }
 
 // DeployService service deployment
-func DeployService(ctx context.Context, helper *helper.Helper, obj client.Object, sshKeySecret string, inventorySecret string, aeeSpec dataplanev1.AnsibleEESpec, foundService dataplanev1.OpenStackDataPlaneService) error {
-	err := dataplaneutil.AnsibleExecution(ctx, helper, obj, &foundService, sshKeySecret, inventorySecret, aeeSpec)
+func (d *Deployer) DeployService(foundService dataplanev1.OpenStackDataPlaneService) error {
+	err := dataplaneutil.AnsibleExecution(d.Ctx, d.Helper, d.Deployment, &foundService, d.NodeSet.Spec.NodeTemplate.AnsibleSSHPrivateKeySecret, d.InventorySecret, d.AeeSpec)
 	if err != nil {
-		helper.GetLogger().Error(err, fmt.Sprintf("Unable to execute Ansible for %s", foundService.Name))
+		d.Helper.GetLogger().Error(err, fmt.Sprintf("Unable to execute Ansible for %s", foundService.Name))
 		return err
 	}
 

--- a/pkg/util/ansible_execution.go
+++ b/pkg/util/ansible_execution.go
@@ -43,7 +43,7 @@ func AnsibleExecution(
 	service *dataplanev1.OpenStackDataPlaneService,
 	sshKeySecret string,
 	inventorySecret string,
-	aeeSpec dataplanev1.AnsibleEESpec,
+	aeeSpec *dataplanev1.AnsibleEESpec,
 ) error {
 	var err error
 	var cmdLineArguments strings.Builder
@@ -192,7 +192,7 @@ func GetAnsibleExecution(ctx context.Context, helper *helper.Helper, obj client.
 	} else if len(ansibleEEs.Items) == 1 {
 		ansibleEE = &ansibleEEs.Items[0]
 	} else {
-		return nil, fmt.Errorf("Multiple OpenStackAnsibleEE's found with label %s=%s", label, obj.GetUID())
+		return nil, fmt.Errorf("multiple OpenStackAnsibleEE's found with label %s=%s", label, obj.GetUID())
 	}
 
 	return ansibleEE, nil


### PR DESCRIPTION
Rather than passing copies of variables and structs to multiple different functions throughout the deployment process. This change defines a struct called Deployer. This struct is initialized with the data it needs throughout the deployment process and independent functions are switched to methods of this struct.

This reduces the required length and complexity of function signatures. Objectively making it easier to follow the flow of code throughout the deployment process.