### PR TITLE
Use the same env var for the ovn-controller as set by ovn-operator

### DIFF
--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -21,7 +21,7 @@ spec:
           value: quay.io/podified-antelope-centos9/openstack-nova-compute:current-podified
         - name: RELATED_IMAGE_OPENSTACK_EDPM_LIBVIRT_DEFAULT_IMG
           value: quay.io/podified-antelope-centos9/openstack-nova-libvirt:current-podified
-        - name: RELATED_IMAGE_OPENSTACK_EDPM_OVN_CONTROLLER_AGENT_DEFAULT_IMG
+        - name: RELATED_IMAGE_OVN_CONTROLLER_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-ovn-controller:current-podified
         - name: RELATED_IMAGE_OPENSTACK_EDPM_NEUTRON_METADATA_AGENT_DEFAULT_IMG
           value: quay.io/podified-antelope-centos9/openstack-neutron-metadata-agent-ovn:current-podified

--- a/controllers/openstackdataplanenodeset_controller.go
+++ b/controllers/openstackdataplanenodeset_controller.go
@@ -76,7 +76,7 @@ func SetupAnsibleImageDefaults() {
 		NeutronMetadataAgent: util.GetEnvVar("RELATED_IMAGE_OPENSTACK_EDPM_NEUTRON_METADATA_AGENT_DEFAULT_IMG", NeutronMetadataAgentDefaultImage),
 		NovaCompute:          util.GetEnvVar("RELATED_IMAGE_OPENSTACK_EDPM_NOVA_COMPUTE_DEFAULT_IMG", NovaComputeDefaultImage),
 		NovaLibvirt:          util.GetEnvVar("RELATED_IMAGE_OPENSTACK_EDPM_LIBVIRT_DEFAULT_IMG", NovaLibvirtDefaultImage),
-		OvnControllerAgent:   util.GetEnvVar("RELATED_IMAGE_OPENSTACK_EDPM_OVN_CONTROLLER_AGENT_DEFAULT_IMG", OvnControllerAgentDefaultImage),
+		OvnControllerAgent:   util.GetEnvVar("RELATED_IMAGE_OVN_CONTROLLER_IMAGE_URL_DEFAULT", OvnControllerAgentDefaultImage),
 		OvnBgpAgent:          util.GetEnvVar("RELATED_IMAGE_OPENSTACK_EDPM_OVN_BGP_AGENT_IMAGE", OvnBgpAgentDefaultImage),
 	}
 }


### PR DESCRIPTION
This patch renames
"RELATED_IMAGE_OPENSTACK_EDPM_OVN_CONTROLLER_AGENT_DEFAULT_IMG" to the "RELATED_IMAGE_OVN_CONTROLLER_IMAGE_URL_DEFAULT" which is the same as used by the ovn-operator to set ovn-controller image used on the control plane.
OVN requires to use same versions of the ovn-controller and ovn-northd always so using same envVar will make sure that there will be no mismatch there.

Jira: #[OSPRH-1504](https://issues.redhat.com//browse/OSPRH-1504)