### PR TITLE
Add a sample for deploying with BGP and OVN routing

### DIFF
--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_bgp_ovn_cluster.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_bgp_ovn_cluster.yaml
@@ -1,0 +1,166 @@
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneNodeSet
+metadata:
+  name: openstack-edpm
+spec:
+  services:
+    - download-cache
+    - bootstrap
+    - configure-network
+    - validate-network
+    - frr
+    - install-os
+    - configure-os
+    - run-os
+    - ovn
+    - neutron-metadata
+    - ovn-bgp-agent
+    - libvirt
+    - nova
+    - telemetry
+  preProvisioned: true
+  nodes:
+      edpm-compute-0:
+        hostName: edpm-compute-0
+        ansible:
+          ansibleHost: 192.168.122.100
+          ansibleVars:
+            ctlplane_ip: 192.168.122.100
+            internal_api_ip: 172.17.0.100
+            storage_ip: 172.18.0.100
+            tenant_ip: 172.19.0.100
+            fqdn_internal_api: edpm-compute-0.example.com
+  networkAttachments:
+    - ctlplane
+  nodeTemplate:
+    ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
+    managementNetwork: ctlplane
+    ansible:
+      ansibleUser: cloud-admin
+      ansiblePort: 22
+      ansibleVars:
+         timesync_ntp_servers:
+           - hostname: pool.ntp.org
+         # edpm_network_config
+         # Default nic config template for a EDPM compute node
+         # These vars are edpm_network_config role vars
+         edpm_network_config_hide_sensitive_logs: false
+         edpm_network_config_template: |
+              ---
+              {% set mtu_list = [ctlplane_mtu] %}
+              {% for network in role_networks %}
+              {{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+              {%- endfor %}
+              {% set min_viable_mtu = mtu_list | max %}
+              network_config:
+              - type: interface
+                name: nic1
+                mtu: {{ ctlplane_mtu }}
+                dns_servers: {{ ctlplane_dns_nameservers }}
+                domain: {{ dns_search_domains }}
+                use_dhcp: false
+                addresses:
+                - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+              {% for network in role_networks %}
+              {% if lookup('vars', networks_lower[network] ~ '_vlan_id', default='') %}
+              - type: vlan
+                device: nic1
+                mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+                vlan_id: {{ lookup('vars', networks_lower[network] ~ '_vlan_id') }}
+                addresses:
+                - ip_netmask:
+                    {{ lookup('vars', networks_lower[network] ~ '_ip') }}/{{ lookup('vars', networks_lower[network] ~ '_cidr') }}
+                routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
+              {% endif %}
+              {%- endfor %}
+              - type: ovs_bridge
+                name: br-provider
+                use_dhcp: false
+              - type: ovs_bridge
+                name: {{ neutron_physical_bridge_name }}
+                mtu: {{ min_viable_mtu }}
+                use_dhcp: false
+                addresses:
+                - ip_netmask: {{ lookup('vars', 'bgp_net1_ip') }}/30
+                members:
+                - type: interface
+                  name: nic2
+                  mtu: {{ min_viable_mtu }}
+                  # force the MAC address of the bridge to this interface
+                  primary: true
+              - type: ovs_bridge
+                name: {{ neutron_physical_bridge_name }}-2
+                mtu: {{ min_viable_mtu }}
+                use_dhcp: false
+                addresses:
+                - ip_netmask: {{ lookup('vars', 'bgp_net2_ip') }}/30
+                members:
+                - type: interface
+                  name: nic3
+                  mtu: {{ min_viable_mtu }}
+                  # force the MAC address of the bridge to this interface
+                  primary: true
+              - type: interface
+                name: lo
+                addresses:
+                - ip_netmask: {{ lookup('vars', 'bgp_main_net_ip') }}/32
+                - ip_netmask: {{ lookup('vars', 'bgp_main_net6_ip') }}/128
+
+         # These vars are for the network config templates themselves and are
+         # considered EDPM network defaults.
+         neutron_physical_bridge_name: br-ex
+         neutron_public_interface_name: eth0
+         ctlplane_mtu: 1500
+         ctlplane_subnet_cidr: 24
+         ctlplane_gateway_ip: 192.168.122.1
+         ctlplane_host_routes:
+         - ip_netmask: 0.0.0.0/0
+           next_hop: 192.168.122.1
+         external_mtu: 1500
+         external_vlan_id: 44
+         external_cidr: '24'
+         external_host_routes: []
+         internal_api_mtu: 1500
+         internal_api_vlan_id: 20
+         internal_api_cidr: '24'
+         internal_api_host_routes: []
+         storage_mtu: 1500
+         storage_vlan_id: 21
+         storage_cidr: '24'
+         storage_host_routes: []
+         tenant_mtu: 1500
+         tenant_vlan_id: 22
+         tenant_cidr: '24'
+         tenant_host_routes: []
+         role_networks:
+         - InternalApi
+         - Storage
+         - Tenant
+         networks_lower:
+           External: external
+           InternalApi: internal_api
+           Storage: storage
+           Tenant: tenant
+         # edpm_nodes_validation
+         edpm_nodes_validation_validate_controllers_icmp: false
+         edpm_nodes_validation_validate_gateway_icmp: false
+         ctlplane_dns_nameservers:
+         - 192.168.122.1
+         dns_search_domains: []
+         gather_facts: false
+         enable_debug: false
+         # edpm firewall, change the allowed CIDR if needed
+         edpm_sshd_configure_firewall: true
+         edpm_sshd_allowed_ranges: ['192.168.122.0/24']
+         edpm_frr_bgp_uplinks: ['nic2', 'nic3']
+         edpm_frr_bgp_neighbor_password: f00barZ
+         edpm_frr_bgp_ipv4_src_network: bgp_main_net
+         edpm_frr_bgp_ipv6_src_network: bgp_main_net6
+         edpm_frr_bgp_peers: ['100.64.1.5', '100.65.1.5']
+         edpm_ovn_bgp_agent_expose_tenant_networks: true
+         edpm_ovn_bgp_agent_local_ovn_routing: true
+         edpm_ovn_bridge_mappings: ['bgp:br-provider']
+         edpm_ovn_bgp_agent_local_ovn_external_nics: ['eth1', 'eth2']
+         edpm_ovn_bgp_agent_local_ovn_peer_ips: ['100.64.1.5', '100.65.1.5']
+         edpm_ovn_bgp_agent_exposing_method: ovn
+         edpm_ovn_bgp_agent_provider_networks_pool_prefixes: '172.16.0.0/16'


### PR DESCRIPTION
Kernel routing is used by default when deploying with BGP, but there is a new option to perform that routing directly in OVN, so that datapath acceleration is supported. This is a new template with a sample the configuration required for that.