### PR TITLE
Do limited webhook validation for update/patch

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/openstack-k8s-operators/infra-operator/apis v0.3.1-0.20231122104142-3b449040167e
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20231122111552-6bd6025ade37
 	github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20231122111552-6bd6025ade37
-	github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.3.1-0.20231123111448-29e394985a34
+	github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.3.1-0.20231127065111-347f7cf3b2f5
 	k8s.io/api v0.26.11
 	k8s.io/apimachinery v0.26.11
 	sigs.k8s.io/controller-runtime v0.14.7
@@ -47,7 +47,7 @@ require (
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stretchr/testify v1.8.2 // indirect
+	github.com/stretchr/testify v1.8.3 // indirect
 	golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa // indirect
 	golang.org/x/net v0.18.0 // indirect
 	golang.org/x/oauth2 v0.8.0 // indirect

--- a/api/go.sum
+++ b/api/go.sum
@@ -231,8 +231,8 @@ github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.2023112211
 github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20231122111552-6bd6025ade37/go.mod h1:/6//JWNEY68jOMoaoaSI0koL2jzpEKim3m60+jFCbqY=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20231122111552-6bd6025ade37 h1:F/sQ5+TzB1dVf4VyeyLDtcyNQDHnIkqZPK9V+cr/f6s=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20231122111552-6bd6025ade37/go.mod h1:PAcGzUsidkqZLBv7aVf7tJsq9pzxGUwFDvA5Zeaq0a4=
-github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.3.1-0.20231123111448-29e394985a34 h1:7ZSX60sdoF5/CBpQu1PBPfo8RFRuT1lzIpnqrYbjMuo=
-github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.3.1-0.20231123111448-29e394985a34/go.mod h1:JLCVgdpOAk/zcJPJ+od/d0qOb41vkKsi9kzfjSQ6BAU=
+github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.3.1-0.20231127065111-347f7cf3b2f5 h1:eZvqDZn1+TnRwrwT0A0rsuFIhPX6iWLCJNtGA2vGcrM=
+github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.3.1-0.20231127065111-347f7cf3b2f5/go.mod h1:JLCVgdpOAk/zcJPJ+od/d0qOb41vkKsi9kzfjSQ6BAU=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -286,8 +286,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
-github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.3 h1:RP3t2pwF7cMEbC1dqtB6poj3niw/9gnV4Cjg5oW5gtY=
+github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20231122111552-6bd6025ade37
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20231122111552-6bd6025ade37
 	github.com/openstack-k8s-operators/openstack-ansibleee-operator/api v0.3.0
-	github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.3.1-0.20231123111448-29e394985a34
+	github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.3.1-0.20231127065111-347f7cf3b2f5
 	golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.26.11

--- a/go.sum
+++ b/go.sum
@@ -247,8 +247,8 @@ github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.202311221115
 github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20231122111552-6bd6025ade37/go.mod h1:xKsHwzBHiAeEGs0mwxnxs1PRZOYU48bTQ1WFNxICIOI=
 github.com/openstack-k8s-operators/openstack-ansibleee-operator/api v0.3.0 h1:QSAPaJ5pR1LUscHC7V/TSdyKwUKwd+1zjkzeyHkfHF0=
 github.com/openstack-k8s-operators/openstack-ansibleee-operator/api v0.3.0/go.mod h1:UxWKFScj0gVurdBfTwenf2QyRANjFkMWkFz3KPcsWv0=
-github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.3.1-0.20231123111448-29e394985a34 h1:7ZSX60sdoF5/CBpQu1PBPfo8RFRuT1lzIpnqrYbjMuo=
-github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.3.1-0.20231123111448-29e394985a34/go.mod h1:JLCVgdpOAk/zcJPJ+od/d0qOb41vkKsi9kzfjSQ6BAU=
+github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.3.1-0.20231127065111-347f7cf3b2f5 h1:eZvqDZn1+TnRwrwT0A0rsuFIhPX6iWLCJNtGA2vGcrM=
+github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.3.1-0.20231127065111-347f7cf3b2f5/go.mod h1:JLCVgdpOAk/zcJPJ+od/d0qOb41vkKsi9kzfjSQ6BAU=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -304,7 +304,7 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/stretchr/testify v1.8.3 h1:RP3t2pwF7cMEbC1dqtB6poj3niw/9gnV4Cjg5oW5gtY=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=


### PR DESCRIPTION
Currently scale-out is broken with nill pointer error as we can't call ValidateUpdate() from baremetalset webhook. This changes to use a limited validation around spec changes for bmhLabelSelector and HardwareReqs.