### PR TITLE
Add reboot-os service to dataplane-operator

### DIFF
--- a/api/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
@@ -1869,6 +1869,7 @@ spec:
                 - install-os
                 - configure-os
                 - run-os
+                - reboot-os
                 - ovn
                 - neutron-metadata
                 - libvirt

--- a/api/v1beta1/openstackdataplanenodeset_types.go
+++ b/api/v1beta1/openstackdataplanenodeset_types.go
@@ -58,7 +58,7 @@ type OpenStackDataPlaneNodeSetSpec struct {
 	NetworkAttachments []string `json:"networkAttachments,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={download-cache,bootstrap,configure-network,validate-network,install-os,configure-os,run-os,ovn,neutron-metadata,libvirt,nova,telemetry}
+	// +kubebuilder:default={download-cache,bootstrap,configure-network,validate-network,install-os,configure-os,run-os,reboot-os,ovn,neutron-metadata,libvirt,nova,telemetry}
 	// Services list
 	Services []string `json:"services"`
 

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
@@ -1869,6 +1869,7 @@ spec:
                 - install-os
                 - configure-os
                 - run-os
+                - reboot-os
                 - ovn
                 - neutron-metadata
                 - libvirt

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset.yaml
@@ -11,6 +11,7 @@ spec:
     - install-os
     - configure-os
     - run-os
+    - reboot-os
     - ovn
     - neutron-metadata
     - libvirt

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal_with_ipam.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal_with_ipam.yaml
@@ -11,6 +11,7 @@ spec:
     - install-os
     - configure-os
     - run-os
+    - reboot-os
     - ovn
     - neutron-metadata
     - libvirt

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_bgp.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_bgp.yaml
@@ -12,6 +12,7 @@ spec:
     - install-os
     - configure-os
     - run-os
+    - reboot-os
     - ovn
     - neutron-metadata
     - ovn-bgp-agent

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_customnetworks.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_customnetworks.yaml
@@ -12,6 +12,7 @@ spec:
     - install-os
     - configure-os
     - run-os
+    - reboot-os
     - ovn
     - neutron-metadata
     - libvirt

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_networker.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_networker.yaml
@@ -11,6 +11,7 @@ spec:
     - install-os
     - configure-os
     - run-os
+    - reboot-os
     - ovn
     - telemetry
   preProvisioned: true

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_nmstate.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_nmstate.yaml
@@ -11,6 +11,7 @@ spec:
   - install-os
   - configure-os
   - run-os
+  - reboot-os
   - ovn
   - neutron-metadata
   - libvirt

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_sriov.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_sriov.yaml
@@ -11,6 +11,7 @@ spec:
     - install-os
     - configure-os
     - run-os
+    - reboot-os
     - neutron-sriov
     - libvirt
     - nova

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_with_ipam.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_with_ipam.yaml
@@ -11,6 +11,7 @@ spec:
     - install-os
     - configure-os
     - run-os
+    - reboot-os
     - ovn
     - neutron-metadata
     - libvirt

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_os_reboot.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_os_reboot.yaml
@@ -1,0 +1,7 @@
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneService
+metadata:
+  name: reboot-os
+spec:
+  label: reboot-os
+  playbook: osp.edpm.reboot

--- a/tests/functional/openstackdataplanenodeset_controller_test.go
+++ b/tests/functional/openstackdataplanenodeset_controller_test.go
@@ -164,6 +164,7 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 					"install-os",
 					"configure-os",
 					"run-os",
+					"reboot-os",
 					"ovn",
 					"neutron-metadata",
 					"libvirt",


### PR DESCRIPTION
Add reboot-os service to sample services and add it to default services list.

Depends-On: https://github.com/openstack-k8s-operators/edpm-ansible/pull/503