### PR TITLE
[doc]Change ssh migration key to ECDSA

### DIFF
--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -374,7 +374,7 @@ configuration before the deployment can be started.
   * The service needs an SSH key-pair provided. Generate an ssh key-pair and store it in a Secret named `nova-migration-ssh-key`.
     ```console
     $ cd "$(mktemp -d)"
-    $ ssh-keygen -f ./id -t ed25519 -N ''
+    $ ssh-keygen -f ./id -t ecdsa-sha2-nistp521 -N ''
     $ oc create secret generic nova-migration-ssh-key \
     -n openstack \
     --from-file=ssh-privatekey=id \


### PR DESCRIPTION
Even though the recent FIPS standard[1] allows ED25519 ssh keys, the current FIPS profile in centos9 stream does not allow it. So the current migration ssh key isn't usable. This PR changes the key type to ECDSA until the profile is updated.

[1] https://csrc.nist.gov/pubs/fips/186-5/final