### PR TITLE
Always reset SetupReadyCondition to False

### DIFF
--- a/controllers/openstackdataplanenodeset_controller.go
+++ b/controllers/openstackdataplanenodeset_controller.go
@@ -183,9 +183,7 @@ func (r *OpenStackDataPlaneNodeSetReconciler) Reconcile(ctx context.Context, req
 		return ctrl.Result{}, nil
 	}
 
-	if instance.Status.Conditions.IsUnknown(dataplanev1.SetupReadyCondition) {
-		instance.Status.Conditions.MarkFalse(dataplanev1.SetupReadyCondition, condition.RequestedReason, condition.SeverityInfo, condition.ReadyInitMessage)
-	}
+	instance.Status.Conditions.MarkFalse(dataplanev1.SetupReadyCondition, condition.RequestedReason, condition.SeverityInfo, condition.ReadyInitMessage)
 
 	// Ensure Services
 	err = deployment.EnsureServices(ctx, helper, instance)


### PR DESCRIPTION
We use this condition to trigger deployments for a nodeset. Without this being reset to false, deployments would tigger before nodeset is reconciled for update/patch as the condition would be true.