### PR TITLE
Reset Nodeset DeploymentReadyCondition

### DIFF
--- a/controllers/openstackdataplanenodeset_controller.go
+++ b/controllers/openstackdataplanenodeset_controller.go
@@ -301,6 +301,11 @@ func (r *OpenStackDataPlaneNodeSetReconciler) Reconcile(ctx context.Context, req
 		instance.Status.Conditions.MarkFalse(condition.DeploymentReadyCondition,
 			condition.RequestedReason, condition.SeverityInfo,
 			condition.DeploymentReadyRunningMessage)
+	} else {
+		logger.Info("Set NodeSet DeploymentReadyCondition false")
+		instance.Status.Conditions.MarkFalse(condition.DeploymentReadyCondition,
+			condition.RequestedReason, condition.SeverityInfo,
+			condition.DeploymentReadyInitMessage)
 	}
 	return ctrl.Result{}, nil
 }
@@ -319,6 +324,9 @@ func checkDeployment(helper *helper.Helper,
 		return false, false, err
 	}
 	for _, deployment := range deployments.Items {
+		if !deployment.DeletionTimestamp.IsZero() {
+			continue
+		}
 		if slices.Contains(
 			deployment.Spec.NodeSets, request.NamespacedName.Name) {
 			if deployment.Status.Deployed {

--- a/tests/kuttl/tests/dataplane-create-test/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-create-test/00-assert.yaml
@@ -92,11 +92,11 @@ spec:
 status:
   conditions:
   - message: Deployment not started
-    reason: NotRequested
+    reason: Requested
     status: "False"
     type: Ready
   - message: Deployment not started
-    reason: NotRequested
+    reason: Requested
     status: "False"
     type: DeploymentReady
   - message: Input data complete

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/00-assert.yaml
@@ -29,11 +29,11 @@ spec:
 status:
   conditions:
   - message: Deployment not started
-    reason: NotRequested
+    reason: Requested
     status: "False"
     type: Ready
   - message: Deployment not started
-    reason: NotRequested
+    reason: Requested
     status: "False"
     type: DeploymentReady
   - message: Input data complete


### PR DESCRIPTION
When a deployment is in progess and you delete a OpneStackDataplanedeployment resource we should reset the DeploymentReadyCondition back to Deployment not Started..

If after a successful deployment, the OpneStackDataplanedeployment resource is deleted for a new deployment it would reset it back too.