### PR TITLE
Don't allow update/patch of deployment

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -98,8 +98,6 @@ rules:
   - delete
   - get
   - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - dataplane.openstack.org

--- a/tests/functional/openstackdataplanedeployment_controller_test.go
+++ b/tests/functional/openstackdataplanedeployment_controller_test.go
@@ -174,12 +174,6 @@ var _ = Describe("Dataplane Deployment Test", func() {
 				condition.InputReadyCondition,
 				corev1.ConditionTrue,
 			)
-			th.ExpectCondition(
-				dataplaneDeploymentName,
-				ConditionGetterFunc(DataplaneDeploymentConditionGetter),
-				dataplanev1.SetupReadyCondition,
-				corev1.ConditionTrue,
-			)
 		})
 	})
 })


### PR DESCRIPTION
Updating/patching of OpenStackDataplaneDeployment resource does not have any effect when it'a already deployed. Also if it's updated during the deployment it can lead to issues. The only way at present is to delete the existing deployment resource and create a new one.

Also, cleans up code around condition handling.