### PR TITLE
Don't use nodeName in inventory

### DIFF
--- a/pkg/deployment/ipam.go
+++ b/pkg/deployment/ipam.go
@@ -18,7 +18,6 @@ package deployment
 
 import (
 	"context"
-	"regexp"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -85,12 +84,7 @@ func createOrPatchDNSData(ctx context.Context, helper *helper.Helper,
 		allHostnames[nodeName] = map[infranetworkv1.NetNameStr]string{}
 		allIPs[nodeName] = map[infranetworkv1.NetNameStr]string{}
 
-		if isFQDN(hostName) {
-			shortName = strings.Split(hostName, ".")[0]
-		} else {
-			shortName = hostName
-		}
-
+		shortName = strings.Split(hostName, ".")[0]
 		if len(nets) == 0 {
 			nets = instance.Spec.NodeTemplate.Networks
 		}
@@ -291,13 +285,4 @@ func CheckDNSService(ctx context.Context, helper *helper.Helper,
 	dnsClusterAddresses := dnsmasqList.Items[0].Status.DNSClusterAddresses
 	dnsAddresses := dnsmasqList.Items[0].Status.DNSAddresses
 	return dnsAddresses, dnsClusterAddresses, true, nil
-}
-
-func isFQDN(hostname string) bool {
-	// Regular expression to match a valid FQDN
-	// This regex assumes that the hostname and domain name segments only contain letters, digits, hyphens, and periods.
-	regex := `^([a-zA-Z0-9-]+\.)*[a-zA-Z0-9-]+\.[a-zA-Z]{2,}$`
-
-	match, _ := regexp.MatchString(regex, hostname)
-	return match
 }

--- a/pkg/deployment/utils.go
+++ b/pkg/deployment/utils.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployment
+
+import (
+	"regexp"
+)
+
+// isFQDN Helper to check if a hostname is fqdn
+func isFQDN(hostname string) bool {
+	// Regular expression to match a valid FQDN
+	// This regex assumes that the hostname and domain name segments only contain letters, digits, hyphens, and periods.
+	regex := `^([a-zA-Z0-9-]+\.)*[a-zA-Z0-9-]+\.[a-zA-Z]{2,}$`
+
+	match, _ := regexp.MatchString(regex, hostname)
+	return match
+}


### PR DESCRIPTION
We use nodeName to generate number of ansible vars in inventory and that causes issues when using pre-provisioned nodes with a different hostname.