### PR TITLE
Remove env section from samples

### DIFF
--- a/api/v1beta1/openstackdataplanenodeset_types.go
+++ b/api/v1beta1/openstackdataplanenodeset_types.go
@@ -49,6 +49,7 @@ type OpenStackDataPlaneNodeSetSpec struct {
 	PreProvisioned bool `json:"preProvisioned,omitempty"`
 
 	// Env is a list containing the environment variables to pass to the pod
+	// +kubebuilder:validation:Optional
 	Env []corev1.EnvVar `json:"env,omitempty"`
 
 	// +kubebuilder:validation:Optional

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset.yaml
@@ -3,9 +3,6 @@ kind: OpenStackDataPlaneNodeSet
 metadata:
   name: openstack-edpm
 spec:
-  env:
-    - name: ANSIBLE_FORCE_COLOR
-      value: "True"
   services:
     - bootstrap
     - download-cache

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal_with_ipam.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal_with_ipam.yaml
@@ -3,9 +3,6 @@ kind: OpenStackDataPlaneNodeSet
 metadata:
   name: openstack-edpm-ipam
 spec:
-  env:
-    - name: ANSIBLE_FORCE_COLOR
-      value: "True"
   services:
     - download-cache
     - bootstrap

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_bgp.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_bgp.yaml
@@ -3,9 +3,6 @@ kind: OpenStackDataPlaneNodeSet
 metadata:
   name: openstack-edpm
 spec:
-  env:
-    - name: ANSIBLE_FORCE_COLOR
-      value: "True"
   services:
     - download-cache
     - bootstrap

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ceph.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ceph.yaml
@@ -4,11 +4,6 @@ metadata:
   name: openstack-edpm-ceph
   namespace: openstack
 spec:
-  env:
-  - name: ANSIBLE_CALLBACKS_ENABLED
-    value: profile_tasks
-  - name: ANSIBLE_FORCE_COLOR
-    value: "True"
   networkAttachments:
   - ctlplane
   nodeTemplate:

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ceph_hci.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ceph_hci.yaml
@@ -4,11 +4,6 @@ metadata:
   name: openstack-edpm-hci
   namespace: openstack
 spec:
-  env:
-    - name: ANSIBLE_CALLBACKS_ENABLED
-      value: profile_tasks
-    - name: ANSIBLE_FORCE_COLOR
-      value: "True"
   networkAttachments:
   - ctlplane
   nodeTemplate:

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_customnetworks.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_customnetworks.yaml
@@ -4,13 +4,6 @@ kind: OpenStackDataPlaneNodeSet
 metadata:
   name: openstack-edpm-custom-network
 spec:
-  env:
-    - name: ANSIBLE_FORCE_COLOR
-      value: "True"
-    - name: ANSIBLE_VERBOSITY
-      value: 4
-    - name: ANSIBLE_HOST_KEY_CHECKING
-      value: false
   services:
     - download-cache
     - bootstrap

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_networker.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_networker.yaml
@@ -3,9 +3,6 @@ kind: OpenStackDataPlaneNodeSet
 metadata:
   name: openstack-edpm
 spec:
-  env:
-    - name: ANSIBLE_FORCE_COLOR
-      value: "True"
   services:
     - download-cache
     - bootstrap

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_nmstate.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_nmstate.yaml
@@ -3,9 +3,6 @@ kind: OpenStackDataPlaneNodeSet
 metadata:
   name: openstack-edpm
 spec:
-  env:
-  - name: ANSIBLE_FORCE_COLOR
-    value: "True"
   services:
   - bootstrap
   - download-cache

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_sriov.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_sriov.yaml
@@ -3,9 +3,6 @@ kind: OpenStackDataPlaneNodeSet
 metadata:
   name: openstack-edpm-sriov
 spec:
-  env:
-    - name: ANSIBLE_FORCE_COLOR
-      value: "True"
   services:
     - download-cache
     - bootstrap

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_with_ipam.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_with_ipam.yaml
@@ -3,9 +3,6 @@ kind: OpenStackDataPlaneNodeSet
 metadata:
   name: openstack-edpm-ipam
 spec:
-  env:
-    - name: ANSIBLE_FORCE_COLOR
-      value: "True"
   preProvisioned: true
   services:
     - bootstrap


### PR DESCRIPTION
This change removes the Env section from each of the sample files. This reduces the number of parameters that we need to maintain in these sample files moving forward.

Depends-On: https://github.com/openstack-k8s-operators/install_yamls/pull/679