### PR TITLE
Don't add ansibleHost when using IPAM

### DIFF
--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal_with_ipam.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal_with_ipam.yaml
@@ -27,8 +27,6 @@ spec:
   nodes:
     edpm-compute-0:
       hostName: edpm-compute-0
-      ansible:
-        ansibleHost: 192.168.122.100
   networkAttachments:
     - ctlplane
   nodeTemplate:


### PR DESCRIPTION
Unless using predictable ip, don't add ansibleHost as it won't be the IP always reserved by IPAM.