### PR TITLE
Parametrizing deploy timeout

### DIFF
--- a/api/bases/dataplane.openstack.org_openstackdataplanedeployments.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplanedeployments.yaml
@@ -50,6 +50,10 @@ spec:
                 type: string
               ansibleTags:
                 type: string
+              deploymentRequeueTime:
+                default: 15
+                minimum: 1
+                type: integer
               nodeSets:
                 items:
                   type: string
@@ -59,6 +63,7 @@ spec:
                   type: string
                 type: array
             required:
+            - deploymentRequeueTime
             - nodeSets
             type: object
           status:

--- a/api/v1beta1/openstackdataplanedeployment_types.go
+++ b/api/v1beta1/openstackdataplanedeployment_types.go
@@ -45,6 +45,11 @@ type OpenStackDataPlaneDeploymentSpec struct {
 	// +kubebuilder:validation:Optional
 	// ServicesOverride list
 	ServicesOverride []string `json:"servicesOverride"`
+
+	// Time before the deployment is requeued in seconds
+	// +kubebuilder:validation:Minimum:=1
+	// +kubebuilder:default:=15
+	DeploymentRequeueTime int `json:"deploymentRequeueTime"`
 }
 
 // OpenStackDataPlaneDeploymentStatus defines the observed state of OpenStackDataPlaneDeployment

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanedeployments.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanedeployments.yaml
@@ -50,6 +50,10 @@ spec:
                 type: string
               ansibleTags:
                 type: string
+              deploymentRequeueTime:
+                default: 15
+                minimum: 1
+                type: integer
               nodeSets:
                 items:
                   type: string
@@ -59,6 +63,7 @@ spec:
                   type: string
                 type: array
             required:
+            - deploymentRequeueTime
             - nodeSets
             type: object
           status:

--- a/controllers/openstackdataplanedeployment_controller.go
+++ b/controllers/openstackdataplanedeployment_controller.go
@@ -135,7 +135,7 @@ func (r *OpenStackDataPlaneDeploymentReconciler) Reconcile(ctx context.Context, 
 			// NodeSet not found, force a requeue
 			if k8s_errors.IsNotFound(err) {
 				logger.Info("NodeSet not found", "NodeSet", nodeSet)
-				return ctrl.Result{RequeueAfter: time.Second * 15}, nil
+				return ctrl.Result{RequeueAfter: time.Second * time.Duration(instance.Spec.DeploymentRequeueTime)}, nil
 			}
 			// Error reading the object - requeue the request.
 			return ctrl.Result{}, err
@@ -147,7 +147,7 @@ func (r *OpenStackDataPlaneDeploymentReconciler) Reconcile(ctx context.Context, 
 	for _, nodeSet := range nodeSets.Items {
 		if !nodeSet.Status.Conditions.IsTrue(dataplanev1.SetupReadyCondition) {
 			logger.Info("NodeSet SetupReadyCondition is not True", "NodeSet", nodeSet.Name)
-			return ctrl.Result{RequeueAfter: time.Second * 15}, nil
+			return ctrl.Result{RequeueAfter: time.Second * time.Duration(instance.Spec.DeploymentRequeueTime)}, nil
 		}
 	}
 

--- a/docs/openstack_dataplanedeployment.md
+++ b/docs/openstack_dataplanedeployment.md
@@ -109,6 +109,7 @@ OpenStackDataPlaneDeploymentSpec defines the desired state of OpenStackDataPlane
 | ansibleLimit | AnsibleLimit for ansible execution | string | false |
 | ansibleSkipTags | AnsibleSkipTags for ansible execution | string | false |
 | servicesOverride | ServicesOverride list | []string | true |
+| deploymentRequeueTime | Time before the deployment is requeued in seconds | int | true |
 
 [Back to Custom Resources](#custom-resources)
 

--- a/tests/functional/openstackdataplanedeployment_controller_test.go
+++ b/tests/functional/openstackdataplanedeployment_controller_test.go
@@ -96,10 +96,11 @@ var _ = Describe("Dataplane Deployment Test", func() {
 		It("Should have Spec fields initialized", func() {
 			dataplaneDeploymentInstance := GetDataplaneDeployment(dataplaneDeploymentName)
 			expectedSpec := dataplanev1.OpenStackDataPlaneDeploymentSpec{
-				NodeSets:        []string{"edpm-compute-nodeset"},
-				AnsibleTags:     "",
-				AnsibleLimit:    "",
-				AnsibleSkipTags: "",
+				NodeSets:              []string{"edpm-compute-nodeset"},
+				AnsibleTags:           "",
+				AnsibleLimit:          "",
+				AnsibleSkipTags:       "",
+				DeploymentRequeueTime: 15,
 			}
 			Expect(dataplaneDeploymentInstance.Spec).Should(Equal(expectedSpec))
 		})


### PR DESCRIPTION
Rather simple adjustment allowing us to use different deployment timeouts should we wish. 
The existing 15 sec is still in place, but now we can choose another constant, for example if we are dealing with constrained env.