### PR TITLE
Add sample config for the networker deployment

### DIFF
--- a/config/samples/dataplane_v1beta1_openstackdataplanedeployment_networker.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanedeployment_networker.yaml
@@ -1,0 +1,7 @@
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneDeployment
+metadata:
+  name: openstack-edpm-networker
+spec:
+  nodeSets:
+    - openstack-edpm-networker

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_networker.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_networker.yaml
@@ -1,7 +1,7 @@
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneNodeSet
 metadata:
-  name: openstack-edpm
+  name: openstack-edpm-networker
 spec:
   env:
     - name: ANSIBLE_FORCE_COLOR
@@ -15,11 +15,10 @@ spec:
     - configure-os
     - run-os
     - ovn
-    - telemetry
   preProvisioned: true
   nodes:
-      edpm-compute-0:
-        hostName: edpm-compute-0
+      edpm-networker-0:
+        hostName: edpm-networker-0
         ansible:
           ansibleHost: 192.168.122.100
           ansibleVars:
@@ -27,7 +26,7 @@ spec:
             internal_api_ip: 172.17.0.100
             storage_ip: 172.18.0.100
             tenant_ip: 172.19.0.100
-            fqdn_internal_api: edpm-compute-0.example.com
+            fqdn_internal_api: edpm-networker-0.example.com
   networkAttachments:
     - ctlplane
   nodeTemplate:
@@ -43,7 +42,7 @@ spec:
          timesync_ntp_servers:
            - hostname: pool.ntp.org
          # edpm_network_config
-         # Default nic config template for a EDPM compute node
+         # Default nic config template for a EDPM networker node
          # These vars are edpm_network_config role vars
          edpm_network_config_hide_sensitive_logs: false
          edpm_network_config_template: |


### PR DESCRIPTION
This patch adds config sample for the dataplane deployment with networker node.
It also renames sample nodeset with networker nodes from "openstack-edpm" to "openstack-edpm-networker" and renames host names in that sample file to be "edpm-networker-..." instead of "edpm-compute-...".