### PR TITLE
Drop kubebuilder markers on AnsibleEESpec

### DIFF
--- a/api/v1beta1/common.go
+++ b/api/v1beta1/common.go
@@ -116,25 +116,18 @@ type NodeTemplate struct {
 
 // AnsibleEESpec is a specification of the ansible EE attributes
 type AnsibleEESpec struct {
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={ctlplane}
 	// NetworkAttachments is a list of NetworkAttachment resource names to pass to the ansibleee resource
 	// which allows to connect the ansibleee runner to the given network
 	NetworkAttachments []string `json:"networkAttachments"`
-	// +kubebuilder:validation:Optional
 	// OpenStackAnsibleEERunnerImage image to use as the ansibleEE runner image
 	OpenStackAnsibleEERunnerImage string `json:"openStackAnsibleEERunnerImage,omitempty"`
-	// +kubebuilder:validation:Optional
 	// AnsibleTags for ansible execution
 	AnsibleTags string `json:"ansibleTags,omitempty"`
-	// +kubebuilder:validation:Optional
 	// AnsibleLimit for ansible execution
 	AnsibleLimit string `json:"ansibleLimit,omitempty"`
-	// +kubebuilder:validation:Optional
 	// AnsibleSkipTags for ansible execution
 	AnsibleSkipTags string `json:"ansibleSkipTags,omitempty"`
 	// ExtraMounts containing files which can be mounted into an Ansible Execution Pod
-	// +kubebuilder:validation:Optional
 	ExtraMounts []storage.VolMounts `json:"extraMounts,omitempty"`
 	// Env is a list containing the environment variables to pass to the pod
 	Env []corev1.EnvVar `json:"env,omitempty"`


### PR DESCRIPTION
The AnsibleEESpec struct is not part the CRD API. The struct is created
by the code later for use. Therefore, kubebuilder markers have no effect
on its fields. The only marker that was not already set on other fields
was the default for NetworkAttachments, which is moved to the
NetworkAttachments field on OpenStackDataPlaneNodeSetSpec struct.

Signed-off-by: James Slagle <jslagle@redhat.com>
