### PR TITLE
Adding AnsibleOpts default values

### DIFF
--- a/api/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
@@ -268,7 +268,6 @@ spec:
                       ansiblePort:
                         type: integer
                       ansibleUser:
-                        default: cloud-admin
                         type: string
                       ansibleVars:
                         x-kubernetes-preserve-unknown-fields: true
@@ -1070,7 +1069,6 @@ spec:
                         ansiblePort:
                           type: integer
                         ansibleUser:
-                          default: cloud-admin
                           type: string
                         ansibleVars:
                           x-kubernetes-preserve-unknown-fields: true

--- a/api/v1beta1/common.go
+++ b/api/v1beta1/common.go
@@ -28,7 +28,6 @@ import (
 type AnsibleOpts struct {
 	// AnsibleUser SSH user for Ansible connection
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="cloud-admin"
 	AnsibleUser string `json:"ansibleUser"`
 
 	// AnsibleHost SSH host for Ansible connection

--- a/api/v1beta1/openstackdataplanenodeset_webhook.go
+++ b/api/v1beta1/openstackdataplanenodeset_webhook.go
@@ -61,6 +61,10 @@ func (spec *OpenStackDataPlaneNodeSetSpec) Default() {
 		spec.Nodes[nodeName] = *node.DeepCopy()
 	}
 
+	if spec.NodeTemplate.Ansible.AnsibleUser == "" {
+		spec.NodeTemplate.Ansible.AnsibleUser = "cloud-admin"
+	}
+
 	if spec.BaremetalSetTemplate.DeploymentSSHSecret == "" {
 		spec.BaremetalSetTemplate.DeploymentSSHSecret = spec.NodeTemplate.AnsibleSSHPrivateKeySecret
 	}

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
@@ -268,7 +268,6 @@ spec:
                       ansiblePort:
                         type: integer
                       ansibleUser:
-                        default: cloud-admin
                         type: string
                       ansibleVars:
                         x-kubernetes-preserve-unknown-fields: true
@@ -1070,7 +1069,6 @@ spec:
                         ansiblePort:
                           type: integer
                         ansibleUser:
-                          default: cloud-admin
                           type: string
                         ansibleVars:
                           x-kubernetes-preserve-unknown-fields: true

--- a/tests/functional/openstackdataplanenodeset_controller_test.go
+++ b/tests/functional/openstackdataplanenodeset_controller_test.go
@@ -143,7 +143,7 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 					Networks:                   nil,
 					ManagementNetwork:          "ctlplane",
 					Ansible: dataplanev1.AnsibleOpts{
-						AnsibleUser: "",
+						AnsibleUser: "cloud-admin",
 						AnsibleHost: "",
 						AnsiblePort: 0,
 						AnsibleVars: nil,


### PR DESCRIPTION
If we set the default with kubebuilder markers, it will force us to set the value for each node. 
Instead, we should set the default values using the webhook to ensure the default values are only set on the nodetemplate

