### PR TITLE
Generate certificates for ceph_hci_pre service

### DIFF
--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_ceph_hci_pre.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_ceph_hci_pre.yaml
@@ -5,3 +5,6 @@ metadata:
 spec:
   label: ceph-hci-pre
   playbook: osp.edpm.ceph_hci_pre
+  hasTLSCerts: True
+  issuers:
+    default: osp-rootca-issuer-internal


### PR DESCRIPTION
By using the feature [1] to generate certs, this PR will enable tlsCertsEnabled for ceph_hci_pre service which should generate certs for the service on each node in the nodeset.

[1] https://github.com/openstack-k8s-operators/dataplane-operator/pull/553