### PR TITLE
Add missing binaryData fields for ConfigMaps

### DIFF
--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -216,6 +216,9 @@ func (d *Deployer) addServiceExtraMounts(
 		for key := range cm.Data {
 			keys = append(keys, key)
 		}
+		for key := range cm.BinaryData {
+			keys = append(keys, key)
+		}
 		sort.Strings(keys)
 
 		for idx, key := range keys {

--- a/tests/kuttl/tests/dataplane-service-config/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-service-config/00-assert.yaml
@@ -65,6 +65,15 @@ spec:
           path: 20-kuttl-service.conf
         name: kuttl-service-cm-1
   - mounts:
+    - mountPath: /var/lib/openstack/configs/kuttl-service/30-kuttl-service.conf
+      subPath: 30-kuttl-service.conf
+    volumes:
+    - configMap:
+        items:
+        - key: 30-kuttl-service.conf
+          path: 30-kuttl-service.conf
+        name: kuttl-service-cm-2
+  - mounts:
     - mountPath: /runner/env/ssh_key
       name: ssh-key
       subPath: ssh_key

--- a/tests/kuttl/tests/dataplane-service-config/00-create.yaml
+++ b/tests/kuttl/tests/dataplane-service-config/00-create.yaml
@@ -27,6 +27,13 @@ data:
     baz: blippy
     zed: zod
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kuttl-service-cm-2
+binaryData:
+  30-kuttl-service.conf: Cg==
+---
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneService
 metadata:
@@ -44,6 +51,7 @@ spec:
   configMaps:
     - kuttl-service-cm-0
     - kuttl-service-cm-1
+    - kuttl-service-cm-2
 ---
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneNodeSet


### PR DESCRIPTION
ConfigMaps can use binaryData instead of data fields. In that case the OpenStackAnsibleEE spec failed due to missing keys. This patch iterates over these fields as well and adds the missing keys.