### PR TITLE
Readd networkAttachments to nodeset sample

### DIFF
--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset.yaml
@@ -18,6 +18,8 @@ spec:
     - nova
     - telemetry
   preProvisioned: true
+  networkAttachments:
+  - ctlplane
   nodes:
       edpm-compute-0:
         hostName: edpm-compute-0


### PR DESCRIPTION
This got dropped in [1] from just one dataplane nodeset sample, this patch readds it.

https://github.com/openstack-k8s-operators/dataplane-operator/pull/501