### PR TITLE
Expose the enabled services to the ansible-runner

### DIFF
--- a/pkg/deployment/inventory.go
+++ b/pkg/deployment/inventory.go
@@ -47,6 +47,8 @@ func GenerateNodeSetInventory(ctx context.Context, helper *helper.Helper,
 		return "", err
 	}
 
+	nodeSetGroup.Vars["edpm_enabled_services"] = instance.Spec.Services
+
 	// add TLS ansible variable
 	if instance.Spec.TLSEnabled != nil && *instance.Spec.TLSEnabled {
 		nodeSetGroup.Vars["edpm_tls_certs_enabled"] = "true"


### PR DESCRIPTION
edpm-ansible can be aware of the enabled services from nodeset inventory