### PR TITLE
Make the network names all lowercase

### DIFF
--- a/api/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
@@ -60,7 +60,7 @@ spec:
                     name:
                       type: string
                     network:
-                      default: CtlPlane
+                      default: ctlplane
                       pattern: ^[a-zA-Z0-9][a-zA-Z0-9\-_]*[a-zA-Z0-9]$
                       type: string
                     port:

--- a/api/v1beta1/openstackdataplaneservice_types.go
+++ b/api/v1beta1/openstackdataplaneservice_types.go
@@ -39,7 +39,7 @@ type KubeService struct {
 	Protocol string `json:"protocol,omitempty"`
 
 	// Network is the network that will be used to connect to the endpoint
-	// +kubebuilder:default=CtlPlane
+	// +kubebuilder:default=ctlplane
 	Network infranetworkv1.NetNameStr `json:"network,omitempty"`
 }
 

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
@@ -60,7 +60,7 @@ spec:
                     name:
                       type: string
                     network:
-                      default: CtlPlane
+                      default: ctlplane
                       pattern: ^[a-zA-Z0-9][a-zA-Z0-9\-_]*[a-zA-Z0-9]$
                       type: string
                     port:

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset.yaml
@@ -54,7 +54,7 @@ spec:
                 dns_servers: {{ ctlplane_dns_nameservers }}
                 domain: {{ dns_search_domains }}
                 addresses:
-                - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+                - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
                 routes: {{ ctlplane_host_routes }}
                 members:
                 - type: interface

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal_with_ipam.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal_with_ipam.yaml
@@ -57,7 +57,7 @@ spec:
                 dns_servers: {{ ctlplane_dns_nameservers }}
                 domain: {{ dns_search_domains }}
                 addresses:
-                - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+                - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
                 routes: {{ ctlplane_host_routes }}
                 members:
                 - type: interface

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_bgp.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_bgp.yaml
@@ -27,10 +27,10 @@ spec:
           ansibleHost: 192.168.122.100
           ansibleVars:
             ctlplane_ip: 192.168.122.100
-            internal_api_ip: 172.17.0.100
+            internalapi_ip: 172.17.0.100
             storage_ip: 172.18.0.100
             tenant_ip: 172.19.0.100
-            fqdn_internal_api: edpm-compute-0.example.com
+            fqdn_internalapi: edpm-compute-0.example.com
   networkAttachments:
     - ctlplane
   nodeTemplate:
@@ -41,8 +41,8 @@ spec:
       ansiblePort: 22
       ansibleVars:
          service_net_map:
-           nova_api_network: internal_api
-           nova_libvirt_network: internal_api
+           nova_api_network: internalapi
+           nova_libvirt_network: internalapi
          timesync_ntp_servers:
            - hostname: pool.ntp.org
          # edpm_network_config
@@ -64,7 +64,7 @@ spec:
                 domain: {{ dns_search_domains }}
                 use_dhcp: false
                 addresses:
-                - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+                - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
               {% for network in role_networks %}
               {% if lookup('vars', networks_lower[network] ~ '_vlan_id', default='') %}
               - type: vlan
@@ -101,7 +101,7 @@ spec:
          neutron_physical_bridge_name: br-ex
          neutron_public_interface_name: eth0
          ctlplane_mtu: 1500
-         ctlplane_subnet_cidr: 24
+         ctlplane_cidr: 24
          ctlplane_gateway_ip: 192.168.122.1
          ctlplane_host_routes:
          - ip_netmask: 0.0.0.0/0
@@ -110,10 +110,10 @@ spec:
          external_vlan_id: 44
          external_cidr: '24'
          external_host_routes: []
-         internal_api_mtu: 1500
-         internal_api_vlan_id: 20
-         internal_api_cidr: '24'
-         internal_api_host_routes: []
+         internalapi_mtu: 1500
+         internalapi_vlan_id: 20
+         internalapi_cidr: '24'
+         internalapi_host_routes: []
          storage_mtu: 1500
          storage_vlan_id: 21
          storage_cidr: '24'
@@ -128,7 +128,7 @@ spec:
          - Tenant
          networks_lower:
            External: external
-           InternalApi: internal_api
+           InternalApi: internalapi
            Storage: storage
            Tenant: tenant
          # edpm_nodes_validation

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_bgp_ovn_cluster.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_bgp_ovn_cluster.yaml
@@ -26,10 +26,10 @@ spec:
           ansibleHost: 192.168.122.100
           ansibleVars:
             ctlplane_ip: 192.168.122.100
-            internal_api_ip: 172.17.0.100
+            internalapi_ip: 172.17.0.100
             storage_ip: 172.18.0.100
             tenant_ip: 172.19.0.100
-            fqdn_internal_api: edpm-compute-0.example.com
+            fqdn_internalapi: edpm-compute-0.example.com
   networkAttachments:
     - ctlplane
   nodeTemplate:
@@ -60,7 +60,7 @@ spec:
                 domain: {{ dns_search_domains }}
                 use_dhcp: false
                 addresses:
-                - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+                - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
               {% for network in role_networks %}
               {% if lookup('vars', networks_lower[network] ~ '_vlan_id', default='') %}
               - type: vlan
@@ -111,7 +111,7 @@ spec:
          neutron_physical_bridge_name: br-ex
          neutron_public_interface_name: eth0
          ctlplane_mtu: 1500
-         ctlplane_subnet_cidr: 24
+         ctlplane_cidr: 24
          ctlplane_gateway_ip: 192.168.122.1
          ctlplane_host_routes:
          - ip_netmask: 0.0.0.0/0
@@ -120,10 +120,10 @@ spec:
          external_vlan_id: 44
          external_cidr: '24'
          external_host_routes: []
-         internal_api_mtu: 1500
-         internal_api_vlan_id: 20
-         internal_api_cidr: '24'
-         internal_api_host_routes: []
+         internalapi_mtu: 1500
+         internalapi_vlan_id: 20
+         internalapi_cidr: '24'
+         internalapi_host_routes: []
          storage_mtu: 1500
          storage_vlan_id: 21
          storage_cidr: '24'
@@ -138,7 +138,7 @@ spec:
          - Tenant
          networks_lower:
            External: external
-           InternalApi: internal_api
+           InternalApi: internalapi
            Storage: storage
            Tenant: tenant
          # edpm_nodes_validation

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ceph.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ceph.yaml
@@ -18,7 +18,7 @@ spec:
         - ip_netmask: 0.0.0.0/0
           next_hop: 192.168.122.1
         ctlplane_mtu: 1500
-        ctlplane_subnet_cidr: 24
+        ctlplane_cidr: 24
         dns_search_domains: []
         timesync_ntp_servers:
         - hostname: pool.ntp.org
@@ -38,7 +38,7 @@ spec:
             dns_servers: {{ ctlplane_dns_nameservers }}
             domain: {{ dns_search_domains }}
             addresses:
-            - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+            - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
             routes: {{ ctlplane_host_routes }}
             members:
             - type: interface
@@ -67,13 +67,13 @@ spec:
         external_mtu: 1500
         external_vlan_id: 44
         gather_facts: false
-        internal_api_cidr: "24"
-        internal_api_host_routes: []
-        internal_api_mtu: 1500
-        internal_api_vlan_id: 20
+        internalapi_cidr: "24"
+        internalapi_host_routes: []
+        internalapi_mtu: 1500
+        internalapi_vlan_id: 20
         networks_lower:
           External: external
-          InternalApi: internal_api
+          InternalApi: internalapi
           Storage: storage
           Tenant: tenant
         neutron_physical_bridge_name: br-ex
@@ -83,8 +83,8 @@ spec:
         - Storage
         - Tenant
         service_net_map:
-          nova_api_network: internal_api
-          nova_libvirt_network: internal_api
+          nova_api_network: internalapi
+          nova_libvirt_network: internalapi
         storage_cidr: "24"
         storage_host_routes: []
         storage_vlan_id: 21

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ceph_hci.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ceph_hci.yaml
@@ -25,7 +25,7 @@ spec:
             dns_servers: {{ ctlplane_dns_nameservers }}
             domain: {{ dns_search_domains }}
             addresses:
-            - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+            - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
             routes: {{ ctlplane_host_routes }}
             members:
             - type: interface

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_customnetworks.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_customnetworks.yaml
@@ -25,11 +25,11 @@ spec:
         ansibleHost: 192.168.1.5
         ansibleVars:
           ctlplane_ip: 192.168.1.5
-          internal_api_ip: 172.17.0.101
+          internalapi_ip: 172.17.0.101
           storage_ip: 172.18.0.101
           tenant_ip: 172.19.0.101
           external_ip: 172.20.12.76
-          fqdn_internal_api: edpm-compute-1.example.com
+          fqdn_internalapi: edpm-compute-1.example.com
           ansible_ssh_transfer_method: scp
   networkAttachments:
     - ctlplane
@@ -58,7 +58,7 @@ spec:
                dns_servers: {{ ctlplane_dns_nameservers }}
                domain: {{ dns_search_domains }}
                addresses:
-               - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+               - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
                routes: {{ ctlplane_host_routes }}
                members:
                - type: interface
@@ -83,7 +83,7 @@ spec:
         neutron_physical_bridge_name: br-ex
         neutron_public_interface_name: enp7s0
         ctlplane_mtu: 1500
-        ctlplane_subnet_cidr: 24
+        ctlplane_cidr: 24
         ctlplane_gateway_ip: 192.168.1.254
         ctlplane_host_routes:
         - ip_netmask: 0.0.0.0/0
@@ -92,10 +92,10 @@ spec:
         external_vlan_id: 4
         external_cidr: '24'
         external_host_routes: []
-        internal_api_mtu: 1500
-        internal_api_vlan_id: 20
-        internal_api_cidr: '24'
-        internal_api_host_routes: []
+        internalapi_mtu: 1500
+        internalapi_vlan_id: 20
+        internalapi_cidr: '24'
+        internalapi_host_routes: []
         storage_mtu: 1500
         storage_vlan_id: 21
         storage_cidr: '24'
@@ -111,7 +111,7 @@ spec:
         - External
         networks_lower:
           External: external
-          InternalApi: internal_api
+          InternalApi: internalapi
           Storage: storage
           Tenant: tenant
         # edpm_nodes_validation
@@ -138,7 +138,7 @@ spec:
           mtu: 1500
           addresses:
             - ip_netmask:
-                {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+                {{ ctlplane_ip }}/{{ ctlplane_cidr }}
         - type: ovs_bridge
           name: {{ neutron_physical_bridge_name }}
           mtu: 1500

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_networker.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_networker.yaml
@@ -21,10 +21,10 @@ spec:
           ansibleHost: 192.168.122.100
           ansibleVars:
             ctlplane_ip: 192.168.122.100
-            internal_api_ip: 172.17.0.100
+            internalapi_ip: 172.17.0.100
             storage_ip: 172.18.0.100
             tenant_ip: 172.19.0.100
-            fqdn_internal_api: edpm-networker-0.example.com
+            fqdn_internalapi: edpm-networker-0.example.com
   networkAttachments:
     - ctlplane
   nodeTemplate:
@@ -35,8 +35,8 @@ spec:
       ansiblePort: 22
       ansibleVars:
          service_net_map:
-           nova_api_network: internal_api
-           nova_libvirt_network: internal_api
+           nova_api_network: internalapi
+           nova_libvirt_network: internalapi
          timesync_ntp_servers:
            - hostname: pool.ntp.org
          # edpm_network_config
@@ -58,7 +58,7 @@ spec:
                 dns_servers: {{ ctlplane_dns_nameservers }}
                 domain: {{ dns_search_domains }}
                 addresses:
-                - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+                - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
                 routes: {{ ctlplane_host_routes }}
                 members:
                 - type: interface
@@ -81,7 +81,7 @@ spec:
          neutron_physical_bridge_name: br-ex
          neutron_public_interface_name: eth0
          ctlplane_mtu: 1500
-         ctlplane_subnet_cidr: 24
+         ctlplane_cidr: 24
          ctlplane_gateway_ip: 192.168.122.1
          ctlplane_host_routes:
          - ip_netmask: 0.0.0.0/0
@@ -90,10 +90,10 @@ spec:
          external_vlan_id: 44
          external_cidr: '24'
          external_host_routes: []
-         internal_api_mtu: 1500
-         internal_api_vlan_id: 20
-         internal_api_cidr: '24'
-         internal_api_host_routes: []
+         internalapi_mtu: 1500
+         internalapi_vlan_id: 20
+         internalapi_cidr: '24'
+         internalapi_host_routes: []
          storage_mtu: 1500
          storage_vlan_id: 21
          storage_cidr: '24'
@@ -108,7 +108,7 @@ spec:
          - Tenant
          networks_lower:
            External: external
-           InternalApi: internal_api
+           InternalApi: internalapi
            Storage: storage
            Tenant: tenant
          # edpm_nodes_validation

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_nmstate.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_nmstate.yaml
@@ -26,10 +26,10 @@ spec:
         ansibleHost: 192.168.122.100
         ansibleVars:
           ctlplane_ip: 192.168.122.100
-          internal_api_ip: 172.17.0.100
+          internalapi_ip: 172.17.0.100
           storage_ip: 172.18.0.100
           tenant_ip: 172.19.0.100
-          fqdn_internal_api: edpm-compute-0.example.com
+          fqdn_internalapi: edpm-compute-0.example.com
   networkAttachments:
   - ctlplane
   nodeTemplate:
@@ -40,8 +40,8 @@ spec:
       ansiblePort: 22
       ansibleVars:
         service_net_map:
-          nova_api_network: internal_api
-          nova_libvirt_network: internal_api
+          nova_api_network: internalapi
+          nova_libvirt_network: internalapi
         timesync_ntp_servers:
           - hostname: pool.ntp.org
         # edpm_network_config
@@ -71,7 +71,7 @@ spec:
                 enabled: true
                 address:
                   - ip: {{ ctlplane_ip }}
-                    prefix-length: {{ ctlplane_subnet_cidr }}
+                    prefix-length: {{ ctlplane_cidr }}
           {% for network in role_networks %}
             - name: {{ "vlan" ~ lookup('vars', networks_lower[network] ~ '_vlan_id') }}
               type: ovs-interface
@@ -109,7 +109,7 @@ spec:
         neutron_physical_bridge_name: br-ex
         neutron_public_interface_name: eth0
         ctlplane_mtu: 1500
-        ctlplane_subnet_cidr: 24
+        ctlplane_cidr: 24
         ctlplane_gateway_ip: 192.168.122.1
         ctlplane_host_routes:
         - ip_netmask: 0.0.0.0/0
@@ -117,9 +117,9 @@ spec:
         external_mtu: 1500
         external_vlan_id: 44
         external_cidr: '24'
-        internal_api_mtu: 1500
-        internal_api_vlan_id: 20
-        internal_api_cidr: '24'
+        internalapi_mtu: 1500
+        internalapi_vlan_id: 20
+        internalapi_cidr: '24'
         storage_mtu: 1500
         storage_vlan_id: 21
         storage_cidr: '24'
@@ -132,7 +132,7 @@ spec:
         - Tenant
         networks_lower:
           External: external
-          InternalApi: internal_api
+          InternalApi: internalapi
           Storage: storage
           Tenant: tenant
         # edpm_nodes_validation

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_sriov.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_sriov.yaml
@@ -23,10 +23,10 @@ spec:
           ansibleHost: 192.168.122.100
           ansibleVars:
             ctlplane_ip: 192.168.122.100
-            internal_api_ip: 172.17.0.100
+            internalapi_ip: 172.17.0.100
             storage_ip: 172.18.0.100
             tenant_ip: 172.19.0.100
-            fqdn_internal_api: edpm-compute-0.example.com
+            fqdn_internalapi: edpm-compute-0.example.com
   networkAttachments:
     - ctlplane
   nodeTemplate:
@@ -37,8 +37,8 @@ spec:
       ansiblePort: 22
       ansibleVars:
          service_net_map:
-           nova_api_network: internal_api
-           nova_libvirt_network: internal_api
+           nova_api_network: internalapi
+           nova_libvirt_network: internalapi
          timesync_ntp_servers:
            - hostname: pool.ntp.org
          # edpm_network_config
@@ -60,7 +60,7 @@ spec:
                 dns_servers: {{ ctlplane_dns_nameservers }}
                 domain: {{ dns_search_domains }}
                 addresses:
-                - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+                - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
                 routes: {{ ctlplane_host_routes }}
                 members:
                 - type: interface
@@ -83,7 +83,7 @@ spec:
          neutron_physical_bridge_name: br-ex
          neutron_public_interface_name: eth0
          ctlplane_mtu: 1500
-         ctlplane_subnet_cidr: 24
+         ctlplane_cidr: 24
          ctlplane_gateway_ip: 192.168.122.1
          ctlplane_host_routes:
          - ip_netmask: 0.0.0.0/0
@@ -92,10 +92,10 @@ spec:
          external_vlan_id: 44
          external_cidr: '24'
          external_host_routes: []
-         internal_api_mtu: 1500
-         internal_api_vlan_id: 20
-         internal_api_cidr: '24'
-         internal_api_host_routes: []
+         internalapi_mtu: 1500
+         internalapi_vlan_id: 20
+         internalapi_cidr: '24'
+         internalapi_host_routes: []
          storage_mtu: 1500
          storage_vlan_id: 21
          storage_cidr: '24'
@@ -110,7 +110,7 @@ spec:
          - Tenant
          networks_lower:
            External: external
-           InternalApi: internal_api
+           InternalApi: internalapi
            Storage: storage
            Tenant: tenant
          # edpm_nodes_validation

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_with_ipam.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_with_ipam.yaml
@@ -58,8 +58,8 @@ spec:
       ansiblePort: 22
       ansibleVars:
          service_net_map:
-           nova_api_network: internal_api
-           nova_libvirt_network: internal_api
+           nova_api_network: internalapi
+           nova_libvirt_network: internalapi
          timesync_ntp_servers:
            - hostname: pool.ntp.org
          # edpm_network_config
@@ -80,7 +80,7 @@ spec:
                 dns_servers: {{ ctlplane_dns_nameservers }}
                 domain: {{ dns_search_domains }}
                 addresses:
-                - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+                - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
                 routes: {{ ctlplane_host_routes }}
                 members:
                 - type: interface

--- a/docs/common_configurations.md
+++ b/docs/common_configurations.md
@@ -110,10 +110,10 @@ field that shows defining the variables that configure the
     ansibleVars:
       edpm_network_config_template: templates/single_nic_vlans/single_nic_vlans.j2
       ctlplane_ip: 192.168.122.100
-      internal_api_ip: 172.17.0.100
+      internalapi_ip: 172.17.0.100
       storage_ip: 172.18.0.100
       tenant_ip: 172.19.0.100
-      fqdn_internal_api: edpm-compute-0.example.com
+      fqdn_internalapi: edpm-compute-0.example.com
 
 This configuration would be applied by the
 [`configure-network`](../composable_services.md/#dataplane-operator-provided-services) service when

--- a/docs/composable_services.md
+++ b/docs/composable_services.md
@@ -318,8 +318,8 @@ service to execute for the `edpm-compute` `NodeSet`.
               ansible_ssh_transfer_method: scp
               ctlplane_ip: 172.20.12.67
               external_ip: 172.20.12.76
-              fqdn_internal_api: edpm-compute-1.example.com
-              internal_api_ip: 172.17.0.101
+              fqdn_internalapi: edpm-compute-1.example.com
+              internalapi_ip: 172.17.0.101
               storage_ip: 172.18.0.101
               tenant_ip: 172.10.0.101
           hostName: edpm-compute-0

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -207,20 +207,20 @@ With the nodes added, the full `openstack-edpm` OpenStackDataPlaneNodeSet
             ansibleHost: 192.168.122.100
             ansibleVars:
               ctlplane_ip: 192.168.122.100
-              internal_api_ip: 172.17.0.100
+              internalapi_ip: 172.17.0.100
               storage_ip: 172.18.0.100
               tenant_ip: 172.19.0.100
-              fqdn_internal_api: edpm-compute-0.example.com
+              fqdn_internalapi: edpm-compute-0.example.com
         edpm-compute-1:
           hostName: edpm-compute-1
           ansible:
             ansibleHost: 192.168.122.101
             ansibleVars:
               ctlplane_ip: 192.168.122.101
-              internal_api_ip: 172.17.0.101
+              internalapi_ip: 172.17.0.101
               storage_ip: 172.18.0.101
               tenant_ip: 172.19.0.101
-              fqdn_internal_api: edpm-compute-1.example.com
+              fqdn_internalapi: edpm-compute-1.example.com
 
 Create the OpenStackDataPlaneNodeSet using the `oc` command.
 

--- a/pkg/deployment/baremetal.go
+++ b/pkg/deployment/baremetal.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -60,7 +61,7 @@ func DeployBaremetalSet(
 				instanceSpec.CtlPlaneIP = node.Ansible.AnsibleHost
 			} else {
 				for _, res := range ipSet.Status.Reservation {
-					if res.Network == CtlPlaneNetwork {
+					if strings.ToLower(string(res.Network)) == CtlPlaneNetwork {
 						instanceSpec.CtlPlaneIP = res.Address
 						baremetalSet.Spec.CtlplaneGateway = *res.Gateway
 						baremetalSet.Spec.BootstrapDNS = dnsAddresses

--- a/pkg/deployment/const.go
+++ b/pkg/deployment/const.go
@@ -18,8 +18,8 @@ package deployment
 
 const (
 
-	// CtlPlaneNetwork - default CtlPlane Network Name in NetConfig
-	CtlPlaneNetwork = "CtlPlane"
+	// CtlPlaneNetwork - default ctlplane Network Name in NetConfig
+	CtlPlaneNetwork = "ctlplane"
 
 	// ValidateNetworkLabel for ValidateNetwork OpenStackAnsibleEE
 	ValidateNetworkLabel = "validate-network"

--- a/pkg/deployment/ipam.go
+++ b/pkg/deployment/ipam.go
@@ -96,12 +96,13 @@ func createOrPatchDNSData(ctx context.Context, helper *helper.Helper,
 					var fqdnNames []string
 					dnsRecord := infranetworkv1.DNSHost{}
 					dnsRecord.IP = res.Address
+					netLower := strings.ToLower(string(res.Network))
 					fqdnName := strings.Join([]string{shortName, res.DNSDomain}, ".")
 					if fqdnName != hostName {
 						fqdnNames = append(fqdnNames, fqdnName)
 						allHostnames[nodeName][res.Network] = fqdnName
 					}
-					if isFQDN(hostName) && res.Network == CtlPlaneNetwork {
+					if isFQDN(hostName) && netLower == CtlPlaneNetwork {
 						fqdnNames = append(fqdnNames, hostName)
 						allHostnames[nodeName][res.Network] = hostName
 					}
@@ -110,7 +111,7 @@ func createOrPatchDNSData(ctx context.Context, helper *helper.Helper,
 					allDNSRecords = append(allDNSRecords, dnsRecord)
 					// Adding only ctlplane domain for ansibleee.
 					// TODO (rabi) This is not very efficient.
-					if res.Network == CtlPlaneNetwork && ctlplaneSearchDomain == "" {
+					if netLower == CtlPlaneNetwork && ctlplaneSearchDomain == "" {
 						ctlplaneSearchDomain = res.DNSDomain
 					}
 				}

--- a/tests/kuttl/tests/dataplane-create-test/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-create-test/00-assert.yaml
@@ -13,8 +13,8 @@ spec:
         ansibleUser: cloud-admin
         ansibleVars:
           ctlplane_ip: 192.168.122.100
-          fqdn_internal_api: edpm-compute-0.example.com
-          internal_api_ip: 172.17.0.100
+          fqdn_internalapi: edpm-compute-0.example.com
+          internalapi_ip: 172.17.0.100
           storage_ip: 172.18.0.100
           tenant_ip: 172.19.0.100
       hostName: edpm-compute-0
@@ -30,7 +30,7 @@ spec:
         - ip_netmask: 0.0.0.0/0
           next_hop: 192.168.122.1
         ctlplane_mtu: 1500
-        ctlplane_subnet_cidr: 24
+        ctlplane_cidr: 24
         dns_search_domains: []
         timesync_ntp_servers:
         - hostname: clock.redhat.com
@@ -48,13 +48,13 @@ spec:
         external_mtu: 1500
         external_vlan_id: 44
         gather_facts: false
-        internal_api_cidr: "24"
-        internal_api_host_routes: []
-        internal_api_mtu: 1500
-        internal_api_vlan_id: 20
+        internalapi_cidr: "24"
+        internalapi_host_routes: []
+        internalapi_mtu: 1500
+        internalapi_vlan_id: 20
         networks_lower:
           External: external
-          InternalApi: internal_api
+          InternalApi: internalapi
           Storage: storage
           Tenant: tenant
         neutron_physical_bridge_name: br-ex
@@ -64,8 +64,8 @@ spec:
         - Storage
         - Tenant
         service_net_map:
-          nova_api_network: internal_api
-          nova_libvirt_network: internal_api
+          nova_api_network: internalapi
+          nova_libvirt_network: internalapi
         storage_cidr: "24"
         storage_host_routes: []
         storage_mtu: 1500

--- a/tests/kuttl/tests/dataplane-create-test/00-dataplane-create.yaml
+++ b/tests/kuttl/tests/dataplane-create-test/00-dataplane-create.yaml
@@ -27,10 +27,10 @@ spec:
           ansibleUser: cloud-admin
           ansibleVars:
             ctlplane_ip: 192.168.122.100
-            internal_api_ip: 172.17.0.100
+            internalapi_ip: 172.17.0.100
             storage_ip: 172.18.0.100
             tenant_ip: 172.19.0.100
-            fqdn_internal_api: edpm-compute-0.example.com
+            fqdn_internalapi: edpm-compute-0.example.com
   nodeTemplate:
     ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
     managementNetwork: ctlplane
@@ -39,8 +39,8 @@ spec:
       ansiblePort: 22
       ansibleVars:
          service_net_map:
-           nova_api_network: internal_api
-           nova_libvirt_network: internal_api
+           nova_api_network: internalapi
+           nova_libvirt_network: internalapi
          timesync_ntp_servers:
            - hostname: clock.redhat.com
          # edpm_network_config
@@ -53,7 +53,7 @@ spec:
          neutron_physical_bridge_name: br-ex
          neutron_public_interface_name: eth0
          ctlplane_mtu: 1500
-         ctlplane_subnet_cidr: 24
+         ctlplane_cidr: 24
          ctlplane_gateway_ip: 192.168.122.1
          ctlplane_host_routes:
          - ip_netmask: 0.0.0.0/0
@@ -62,10 +62,10 @@ spec:
          external_vlan_id: 44
          external_cidr: '24'
          external_host_routes: []
-         internal_api_mtu: 1500
-         internal_api_vlan_id: 20
-         internal_api_cidr: '24'
-         internal_api_host_routes: []
+         internalapi_mtu: 1500
+         internalapi_vlan_id: 20
+         internalapi_cidr: '24'
+         internalapi_host_routes: []
          storage_mtu: 1500
          storage_vlan_id: 21
          storage_cidr: '24'
@@ -80,7 +80,7 @@ spec:
          - Tenant
          networks_lower:
            External: external
-           InternalApi: internal_api
+           InternalApi: internalapi
            Storage: storage
            Tenant: tenant
          # edpm_nodes_validation


### PR DESCRIPTION
Make the network names all lowercase (not snakecase) to align them with the network names used in ctlplane services.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/1050