### PR TITLE
Add nic-config samples folder

### DIFF
--- a/config/samples/nic-config-samples/bonds_vlans/bonds_vlans.j2
+++ b/config/samples/nic-config-samples/bonds_vlans/bonds_vlans.j2
@@ -1,0 +1,39 @@
+---
+{% set mtu_list = [ctlplane_mtu] %}
+{% for network in role_networks %}
+{{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+{%- endfor %}
+{% set min_viable_mtu = mtu_list | max %}
+network_config:
+- type: interface
+  name: nic1
+  mtu: {{ ctlplane_mtu }}
+  use_dhcp: false
+  addresses:
+  - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+  routes: {{ ctlplane_host_routes }}
+- type: ovs_bridge
+  name: {{ neutron_physical_bridge_name }}
+  dns_servers: {{ ctlplane_dns_nameservers }}
+  domain: {{ edpm_dns_search_domains }}
+  members:
+  - type: ovs_bond
+    name: bond1
+    mtu: {{ min_viable_mtu }}
+    ovs_options: {{ edpm_bond_interface_ovs_options }}
+    members:
+    - type: interface
+      name: nic2
+      mtu: {{ min_viable_mtu }}
+      primary: true
+    - type: interface
+      name: nic3
+      mtu: {{ min_viable_mtu }}
+{% for network in role_networks %}
+  - type: vlan
+    mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+    vlan_id: {{ lookup('vars', networks_lower[network] ~ '_vlan_id') }}
+    addresses:
+    - ip_netmask: {{ lookup('vars', networks_lower[network] ~ '_ip') }}/{{ lookup('vars', networks_lower[network] ~ '_cidr') }}
+    routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
+{% endfor %}

--- a/config/samples/nic-config-samples/bonds_vlans/bonds_vlans_dpdk.j2
+++ b/config/samples/nic-config-samples/bonds_vlans/bonds_vlans_dpdk.j2
@@ -1,0 +1,55 @@
+---
+{% set mtu_list = [ctlplane_mtu] %}
+{% for network in role_networks %}
+{{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+{%- endfor %}
+{% set min_viable_mtu = mtu_list | max %}
+network_config:
+- type: interface
+  name: nic1
+  mtu: {{ ctlplane_mtu }}
+  use_dhcp: false
+  addresses:
+  - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+  routes: {{ ctlplane_host_routes }}
+- type: linux_bond
+  name: bond_api
+  mtu: {{ min_viable_mtu }}
+  bonding_options: {{ edpm_bond_interface_ovs_options }}
+  use_dhcp: false
+  dns_servers: {{ ctlplane_dns_nameservers }}
+  members:
+  - type: interface
+    name: nic2
+    mtu: {{ min_viable_mtu }}
+    primary: true
+  - type: interface
+    name: nic3
+    mtu: {{ min_viable_mtu }}
+{% for network in role_networks %}
+- type: vlan
+  device: bond_api
+  mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+  vlan_id: {{ lookup('vars', networks_lower[network] ~ '_vlan_id') }}
+  addresses:
+  - ip_netmask: {{ lookup('vars', networks_lower[network] ~ '_ip') }}/{{ lookup('vars', networks_lower[network] ~ '_cidr') }}
+  routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
+{% endfor %}
+{# Used as a provider network with external DHCP #}
+- type: ovs_user_bridge
+  name: br-dpdk0
+  members:
+  - type: ovs_dpdk_bond
+    name: dpdkbond0
+    rx_queue: {{ num_dpdk_interface_rx_queues }}
+    members:
+    - type: ovs_dpdk_port
+      name: dpdk0
+      members:
+      - type: interface
+        name: nic4
+    - type: ovs_dpdk_port
+      name: dpdk1
+      members:
+      - type: interface
+        name: nic5

--- a/config/samples/nic-config-samples/bonds_vlans/bonds_vlans_storage.j2
+++ b/config/samples/nic-config-samples/bonds_vlans/bonds_vlans_storage.j2
@@ -1,0 +1,39 @@
+---
+{% set mtu_list = [ctlplane_mtu] %}
+{% for network in role_networks %}
+{{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+{%- endfor %}
+{% set min_viable_mtu = mtu_list | max %}
+network_config:
+- type: interface
+  name: nic1
+  mtu: {{ ctlplane_mtu }}
+  use_dhcp: false
+  addresses:
+  - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+  routes: {{ ctlplane_host_routes }}
+- type: ovs_bridge
+  name: br-bond
+  dns_servers: {{ ctlplane_dns_nameservers }}
+  domain: {{ edpm_dns_search_domains }}
+  members:
+  - type: ovs_bond
+    name: bond1
+    mtu: {{ min_viable_mtu }}
+    ovs_options: {{ edpm_bond_interface_ovs_options }}
+    members:
+    - type: interface
+      name: nic2
+      mtu: {{ min_viable_mtu }}
+      primary: true
+    - type: interface
+      name: nic3
+      mtu: {{ min_viable_mtu }}
+{% for network in role_networks %}
+  - type: vlan
+    mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+    vlan_id: {{ lookup('vars', networks_lower[network] ~ '_vlan_id') }}
+    addresses:
+    - ip_netmask: {{ lookup('vars', networks_lower[network] ~ '_ip') }}/{{ lookup('vars', networks_lower[network] ~ '_cidr') }}
+    routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
+{% endfor %}

--- a/config/samples/nic-config-samples/bonds_vlans/controller_no_external.j2
+++ b/config/samples/nic-config-samples/bonds_vlans/controller_no_external.j2
@@ -1,0 +1,39 @@
+---
+{% set mtu_list = [ctlplane_mtu] %}
+{% for network in role_networks %}
+{{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+{%- endfor %}
+{% set min_viable_mtu = mtu_list | max %}
+network_config:
+- type: interface
+  name: nic1
+  mtu: {{ ctlplane_mtu }}
+  use_dhcp: false
+  addresses:
+  - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+  routes: {{ ctlplane_host_routes }}
+- type: ovs_bridge
+  name: {{ neutron_physical_bridge_name }}
+  dns_servers: {{ ctlplane_dns_nameservers }}
+  domain: {{ edpm_dns_search_domains }}
+  members:
+  - type: ovs_bond
+    name: bond1
+    mtu: {{ min_viable_mtu }}
+    ovs_options: {{ edpm_bond_interface_ovs_options }}
+    members:
+    - type: interface
+      name: nic2
+      mtu: {{ min_viable_mtu }}
+      primary: true
+    - type: interface
+      name: nic3
+      mtu: {{ min_viable_mtu }}
+{% for network in role_networks if network != 'External' %}
+  - type: vlan
+    mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+    vlan_id: {{ lookup('vars', networks_lower[network] ~ '_vlan_id') }}
+    addresses:
+    - ip_netmask: {{ lookup('vars', networks_lower[network] ~ '_ip') }}/{{ lookup('vars', networks_lower[network] ~ '_cidr') }}
+    routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
+{% endfor %}

--- a/config/samples/nic-config-samples/multiple_nics/multiple_nics.j2
+++ b/config/samples/nic-config-samples/multiple_nics/multiple_nics.j2
@@ -1,0 +1,43 @@
+---
+network_config:
+- type: interface
+  name: nic1
+  mtu: {{ ctlplane_mtu }}
+  dns_servers: {{ ctlplane_dns_nameservers }}
+  domain: {{ edpm_dns_search_domains }}
+  routes: {{ ctlplane_host_routes }}
+  use_dhcp: false
+  addresses:
+  - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+{% for network in networks_all if network not in networks_skip_config %}
+{% if network not in ["External", "Tenant"] and network in role_networks %}
+- type: interface
+  name: nic{{ loop.index +1 }}
+  mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+  use_dhcp: false
+  addresses:
+  - ip_netmask:
+      {{ lookup('vars', networks_lower[network] ~ '_ip') }}/{{ lookup('vars', networks_lower[network] ~ '_cidr') }}
+  routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
+{% elif network in role_networks or 'external_bridge' in role_tags %}
+- type: ovs_bridge
+{% if network == 'External' %}
+  name: {{ neutron_physical_bridge_name }}
+{% else %}
+  name: {{ 'br-' ~ networks_lower[network] }}
+{% endif %}
+  mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+  dns_servers: {{ ctlplane_dns_nameservers }}
+  use_dhcp: false
+  addresses:
+  - ip_netmask:
+      {{ lookup('vars', networks_lower[network] ~ '_ip') }}/{{ lookup('vars', networks_lower[network] ~ '_cidr') }}
+  routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
+  members:
+  - type: interface
+    name: nic{{loop.index + 1}}
+    mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+    use_dhcp: false
+    primary: true
+{% endif %}
+{% endfor %}

--- a/config/samples/nic-config-samples/multiple_nics/multiple_nics_dpdk.j2
+++ b/config/samples/nic-config-samples/multiple_nics/multiple_nics_dpdk.j2
@@ -1,0 +1,62 @@
+---
+network_config:
+- type: interface
+  name: nic1
+  mtu: {{ ctlplane_mtu }}
+  dns_servers: {{ ctlplane_dns_nameservers }}
+  domain: {{ edpm_dns_search_domains }}
+  routes: {{ ctlplane_host_routes }}
+  use_dhcp: false
+  addresses:
+  - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+{% set nics_used = [1] %}
+{% for network in networks_all if network not in networks_skip_config %}
+{% if network not in ["External", "Tenant"] and network in role_networks %}
+- type: interface
+  name: nic{{ loop.index +1 }}
+  mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+  use_dhcp: false
+  addresses:
+  - ip_netmask:
+      {{ lookup('vars', networks_lower[network] ~ '_ip') }}/{{ lookup('vars', networks_lower[network] ~ '_cidr') }}
+  routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
+{% elif network in role_networks or 'external_bridge' in role_tags %}
+- type: ovs_bridge
+{% if network == 'External' %}
+  name: {{ neutron_physical_bridge_name }}
+{% else %}
+  name: {{ 'br-' ~ networks_lower[network] }}
+{% endif %}
+  mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+  dns_servers: {{ ctlplane_dns_nameservers }}
+  use_dhcp: false
+  addresses:
+  - ip_netmask:
+      {{ lookup('vars', networks_lower[network] ~ '_ip') }}/{{ lookup('vars', networks_lower[network] ~ '_cidr') }}
+  routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
+  members:
+  - type: interface
+    name: nic{{loop.index + 1}}
+    mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+    use_dhcp: false
+    primary: true
+{% endif %}
+{% set _ = nics_used.append(loop.index) %}
+{% endfor %}
+- type: ovs_user_bridge
+  name: br-dpdk0
+  members:
+  - type: ovs_dpdk_bond
+    name: dpdkbond0
+    rx_queue: {{ num_dpdk_interface_rx_queues }}
+    members:
+    - type: ovs_dpdk_port
+      name: dpdk0
+      members:
+      - type: interface
+        name: nic{{nics_used[-1] + 1}}
+    - type: ovs_dpdk_port
+      name: dpdk1
+      members:
+      - type: interface
+        name: nic{{nics_used[-1] + 2}}

--- a/config/samples/nic-config-samples/multiple_nics/multiple_nics_dvr.j2
+++ b/config/samples/nic-config-samples/multiple_nics/multiple_nics_dvr.j2
@@ -1,0 +1,56 @@
+---
+network_config:
+- type: interface
+  name: nic1
+  mtu: {{ ctlplane_mtu }}
+  dns_servers: {{ ctlplane_dns_nameservers }}
+  domain: {{ edpm_dns_search_domains }}
+  routes: {{ ctlplane_host_routes }}
+  use_dhcp: false
+  addresses:
+  - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+{% for network in networks_all if network not in networks_skip_config|default([]) %}
+{% if network == 'External' %}
+- type: ovs_bridge
+  name: {{ neutron_physical_bridge_name }}
+  mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+  dns_servers: {{ ctlplane_dns_nameservers }}
+  use_dhcp: false
+{% if network in role_networks %}
+  addresses:
+  - ip_netmask:
+      {{ lookup('vars', networks_lower[network] ~ '_ip') }}/{{ lookup('vars', networks_lower[network] ~ '_cidr') }}
+  routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
+{% endif %}
+  members:
+  - type: interface
+    name:  nic{{ loop.index +1 }}
+    mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+    primary: true
+{% elif network not in ["External", "Tenant"] and network in role_networks %}
+- type: interface
+  name: nic{{ loop.index +1 }}
+  mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+  use_dhcp: false
+  addresses:
+  - ip_netmask:
+      {{ lookup('vars', networks_lower[network] ~ '_ip') }}/{{ lookup('vars', networks_lower[network] ~ '_cidr') }}
+  routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
+{% elif network == 'Tenant' and network in role_networks %}
+- type: ovs_bridge
+  name: {{ 'br-' ~ networks_lower[network] }}
+  mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+  dns_servers: {{ ctlplane_dns_nameservers }}
+  use_dhcp: false
+  addresses:
+  - ip_netmask:
+      {{ lookup('vars', networks_lower[network] ~ '_ip') }}/{{ lookup('vars', networks_lower[network] ~ '_cidr') }}
+  routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
+  members:
+  - type: interface
+    name: nic{{loop.index + 1}}
+    mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+    use_dhcp: false
+    primary: true
+{% endif %}
+{% endfor %}

--- a/config/samples/nic-config-samples/multiple_nics_vlans/multiple_nics_vlans.j2
+++ b/config/samples/nic-config-samples/multiple_nics_vlans/multiple_nics_vlans.j2
@@ -1,0 +1,50 @@
+---
+network_config:
+- type: interface
+  name: nic1
+  mtu: {{ ctlplane_mtu }}
+  dns_servers: {{ ctlplane_dns_nameservers }}
+  domain: {{ edpm_dns_search_domains }}
+  routes: {{ ctlplane_host_routes }}
+  use_dhcp: false
+  addresses:
+  - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+{% for network in networks_all if network not in networks_skip_config %}
+{% if network not in ["External", "Tenant"] and network in role_networks %}
+- type: interface
+  name: nic{{ loop.index + 1 }}
+  mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+  use_dhcp: false
+- type: vlan
+  device: nic{{ loop.index + 1 }}
+  mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+  vlan_id: {{ lookup('vars', networks_lower[network] ~ '_vlan_id') }}
+  addresses:
+  - ip_netmask:
+      {{ lookup('vars', networks_lower[network] ~ '_ip') }}/{{ lookup('vars', networks_lower[network] ~ '_cidr') }}
+  routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
+{% elif network in role_networks or 'external_bridge' in role_tags %}
+- type: ovs_bridge
+{% if network == 'External' %}
+  name: {{ neutron_physical_bridge_name }}
+{% else %}
+  name: {{ 'br-' ~ networks_lower[network] }}
+{% endif %}
+  mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+  dns_servers: {{ ctlplane_dns_nameservers }}
+  use_dhcp: false
+  members:
+  - type: interface
+    name: nic{{ loop.index + 1 }}
+    mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+    use_dhcp: false
+    primary: true
+  - type: vlan
+    mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+    vlan_id: {{ lookup('vars', networks_lower[network] ~ '_vlan_id') }}
+    addresses:
+    - ip_netmask:
+        {{ lookup('vars', networks_lower[network] ~ '_ip') }}/{{ lookup('vars', networks_lower[network] ~ '_cidr') }}
+    routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
+{% endif %}
+{% endfor %}

--- a/config/samples/nic-config-samples/multiple_nics_vlans/multiple_nics_vlans_dpdk.j2
+++ b/config/samples/nic-config-samples/multiple_nics_vlans/multiple_nics_vlans_dpdk.j2
@@ -1,0 +1,69 @@
+---
+network_config:
+- type: interface
+  name: nic1
+  mtu: {{ ctlplane_mtu }}
+  dns_servers: {{ ctlplane_dns_nameservers }}
+  domain: {{ edpm_dns_search_domains }}
+  routes: {{ ctlplane_host_routes }}
+  use_dhcp: false
+  addresses:
+  - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+{% set nics_used = [1] %}
+{% for network in networks_all if network not in networks_skip_config %}
+{% if network not in ["External", "Tenant"] and network in role_networks %}
+- type: interface
+  name: nic{{ loop.index + 1 }}
+  mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+  use_dhcp: false
+- type: vlan
+  device: nic{{ loop.index + 1 }}
+  mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+  vlan_id: {{ lookup('vars', networks_lower[network] ~ '_vlan_id') }}
+  addresses:
+  - ip_netmask:
+      {{ lookup('vars', networks_lower[network] ~ '_ip') }}/{{ lookup('vars', networks_lower[network] ~ '_cidr') }}
+  routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
+{% elif network in role_networks or 'external_bridge' in role_tags %}
+- type: ovs_bridge
+{% if network == 'External' %}
+  name: {{ neutron_physical_bridge_name }}
+{% else %}
+  name: {{ 'br-' ~ networks_lower[network] }}
+{% endif %}
+  mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+  dns_servers: {{ ctlplane_dns_nameservers }}
+  use_dhcp: false
+  members:
+  - type: interface
+    name: nic{{ loop.index + 1 }}
+    mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+    use_dhcp: false
+    primary: true
+  - type: vlan
+    mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+    vlan_id: {{ lookup('vars', networks_lower[network] ~ '_vlan_id') }}
+    addresses:
+    - ip_netmask:
+        {{ lookup('vars', networks_lower[network] ~ '_ip') }}/{{ lookup('vars', networks_lower[network] ~ '_cidr') }}
+    routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
+{% endif %}
+{% set _ = nics_used.append(loop.index) %}
+{% endfor %}
+- type: ovs_user_bridge
+  name: br-dpdk0
+  members:
+  - type: ovs_dpdk_bond
+    name: dpdkbond0
+    rx_queue: {{ num_dpdk_interface_rx_queues }}
+    members:
+    - type: ovs_dpdk_port
+      name: dpdk0
+      members:
+      - type: interface
+        name: nic{{nics_used[-1] + 1}}
+    - type: ovs_dpdk_port
+      name: dpdk1
+      members:
+      - type: interface
+        name: nic{{nics_used[-1] + 2}}

--- a/config/samples/nic-config-samples/multiple_nics_vlans/multiple_nics_vlans_dvr.j2
+++ b/config/samples/nic-config-samples/multiple_nics_vlans/multiple_nics_vlans_dvr.j2
@@ -1,0 +1,66 @@
+---
+network_config:
+- type: interface
+  name: nic1
+  mtu: {{ ctlplane_mtu }}
+  dns_servers: {{ ctlplane_dns_nameservers }}
+  domain: {{ edpm_dns_search_domains }}
+  routes: {{ ctlplane_host_routes }}
+  use_dhcp: false
+  addresses:
+  - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+{% for network in networks_all if network not in networks_skip_config|default([]) %}
+{% if network == 'External' %}
+- type: ovs_bridge
+  name: {{ neutron_physical_bridge_name }}
+  mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+  dns_servers: {{ ctlplane_dns_nameservers }}
+  use_dhcp: false
+  members:
+  - type: interface
+    name: nic{{ loop.index + 1 }}
+    mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+    primary: true
+{% if network in role_networks %}
+  - type: vlan
+    mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+    vlan_id: {{ lookup('vars', networks_lower[network] ~ '_vlan_id') }}
+    addresses:
+    - ip_netmask:
+        {{ lookup('vars', networks_lower[network] ~ '_ip') }}/{{ lookup('vars', networks_lower[network] ~ '_cidr') }}
+    routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
+{% endif %}
+{% elif network not in ["External", "Tenant"] and network in role_networks %}
+- type: interface
+  name: nic{{ loop.index + 1 }}
+  mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+  use_dhcp: false
+- type: vlan
+  device: nic{{ loop.index + 1 }}
+  mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+  vlan_id: {{ lookup('vars', networks_lower[network] ~ '_vlan_id') }}
+  addresses:
+  - ip_netmask:
+      {{ lookup('vars', networks_lower[network] ~ '_ip') }}/{{ lookup('vars', networks_lower[network] ~ '_cidr') }}
+  routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
+{% elif network == 'Tenant' and network in role_networks %}
+- type: ovs_bridge
+  name: {{ 'br-' ~ networks_lower[network] }}
+  mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+  dns_servers: {{ ctlplane_dns_nameservers }}
+  use_dhcp: false
+  members:
+  - type: interface
+    name: nic{{ loop.index + 1 }}
+    mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+    use_dhcp: false
+    primary: true
+  - type: vlan
+    mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+    vlan_id: {{ lookup('vars', networks_lower[network] ~ '_vlan_id') }}
+    addresses:
+    - ip_netmask:
+        {{ lookup('vars', networks_lower[network] ~ '_ip') }}/{{ lookup('vars', networks_lower[network] ~ '_cidr') }}
+    routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
+{% endif %}
+{% endfor %}

--- a/config/samples/nic-config-samples/single_nic_vlans/controller_no_external.j2
+++ b/config/samples/nic-config-samples/single_nic_vlans/controller_no_external.j2
@@ -1,0 +1,31 @@
+---
+{% set mtu_list = [ctlplane_mtu] %}
+{% for network in role_networks %}
+{{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+{%- endfor %}
+{% set min_viable_mtu = mtu_list | max %}
+network_config:
+- type: ovs_bridge
+  name: {{ neutron_physical_bridge_name }}
+  mtu: {{ min_viable_mtu }}
+  use_dhcp: false
+  dns_servers: {{ ctlplane_dns_nameservers }}
+  domain: {{ edpm_dns_search_domains }}
+  addresses:
+  - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+  routes: {{ ctlplane_host_routes }}
+  members:
+  - type: interface
+    name: nic1
+    mtu: {{ min_viable_mtu }}
+    # force the MAC address of the bridge to this interface
+    primary: true
+{% for network in role_networks if network != 'External' %}
+  - type: vlan
+    mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+    vlan_id: {{ lookup('vars', networks_lower[network] ~ '_vlan_id') }}
+    addresses:
+    - ip_netmask:
+        {{ lookup('vars', networks_lower[network] ~ '_ip') }}/{{ lookup('vars', networks_lower[network] ~ '_cidr') }}
+    routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
+{% endfor %}

--- a/config/samples/nic-config-samples/single_nic_vlans/single_nic_vlans.j2
+++ b/config/samples/nic-config-samples/single_nic_vlans/single_nic_vlans.j2
@@ -1,0 +1,31 @@
+---
+{% set mtu_list = [ctlplane_mtu] %}
+{% for network in role_networks %}
+{{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+{%- endfor %}
+{% set min_viable_mtu = mtu_list | max %}
+network_config:
+- type: ovs_bridge
+  name: {{ neutron_physical_bridge_name }}
+  mtu: {{ min_viable_mtu }}
+  use_dhcp: false
+  dns_servers: {{ ctlplane_dns_nameservers }}
+  domain: {{ edpm_dns_search_domains }}
+  addresses:
+  - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+  routes: {{ ctlplane_host_routes }}
+  members:
+  - type: interface
+    name: nic1
+    mtu: {{ min_viable_mtu }}
+    # force the MAC address of the bridge to this interface
+    primary: true
+{% for network in role_networks %}
+  - type: vlan
+    mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+    vlan_id: {{ lookup('vars', networks_lower[network] ~ '_vlan_id') }}
+    addresses:
+    - ip_netmask:
+        {{ lookup('vars', networks_lower[network] ~ '_ip') }}/{{ lookup('vars', networks_lower[network] ~ '_cidr') }}
+    routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
+{% endfor %}

--- a/config/samples/nic-config-samples/single_nic_vlans/single_nic_vlans_bgp.j2
+++ b/config/samples/nic-config-samples/single_nic_vlans/single_nic_vlans_bgp.j2
@@ -1,0 +1,29 @@
+---
+{% set mtu_list = [ctlplane_mtu] %}
+{% for network in role_networks %}
+{{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+{%- endfor %}
+{% set min_viable_mtu = mtu_list | max %}
+network_config:
+- type: interface
+  name: nic1
+  mtu: {{ ctlplane_mtu }}
+  dns_servers: {{ ctlplane_dns_nameservers }}
+  domain: {{ edpm_dns_search_domains }}
+  routes: {{ ctlplane_host_routes }}
+  use_dhcp: false
+  addresses:
+  - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+{% for network in role_networks %}
+- type: vlan
+  device: nic1
+  mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+  vlan_id: {{ lookup('vars', networks_lower[network] ~ '_vlan_id') }}
+  addresses:
+  - ip_netmask:
+      {{ lookup('vars', networks_lower[network] ~ '_ip') }}/{{ lookup('vars', networks_lower[network] ~ '_cidr') }}
+  routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
+{% endfor %}
+- type: ovs_bridge
+  name: {{ neutron_physical_bridge_name }}
+  use_dhcp: false

--- a/config/samples/nic-config-samples/single_nic_vlans/single_nic_vlans_bgp_ovn.j2
+++ b/config/samples/nic-config-samples/single_nic_vlans/single_nic_vlans_bgp_ovn.j2
@@ -1,0 +1,57 @@
+---
+{% set mtu_list = [ctlplane_mtu] %}
+{% for network in role_networks %}
+{{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+{%- endfor %}
+{% set min_viable_mtu = mtu_list | max %}
+network_config:
+- type: interface
+  name: nic1
+  mtu: {{ ctlplane_mtu }}
+  dns_servers: {{ ctlplane_dns_nameservers }}
+  domain: {{ dns_search_domains }}
+  use_dhcp: false
+  addresses:
+  - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+{% for network in role_networks %}
+- type: vlan
+  device: nic1
+  mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+  vlan_id: {{ lookup('vars', networks_lower[network] ~ '_vlan_id') }}
+  addresses:
+  - ip_netmask:
+      {{ lookup('vars', networks_lower[network] ~ '_ip') }}/{{ lookup('vars', networks_lower[network] ~ '_cidr') }}
+  routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
+{% endfor %}
+- type: ovs_bridge
+  name: br-provider
+  use_dhcp: false
+- type: ovs_bridge
+  name: {{ neutron_physical_bridge_name }}
+  mtu: {{ min_viable_mtu }}
+  use_dhcp: false
+  addresses:
+  - ip_netmask: {{ lookup('vars', 'bgp_net1_ip') }}/30
+  members:
+  - type: interface
+    name: nic2
+    mtu: {{ min_viable_mtu }}
+    # force the MAC address of the bridge to this interface
+    primary: true
+- type: ovs_bridge
+  name: {{ neutron_physical_bridge_name }}-2
+  mtu: {{ min_viable_mtu }}
+  use_dhcp: false
+  addresses:
+  - ip_netmask: {{ lookup('vars', 'bgp_net2_ip') }}/30
+  members:
+  - type: interface
+    name: nic3
+    mtu: {{ min_viable_mtu }}
+    # force the MAC address of the bridge to this interface
+    primary: true
+- type: interface
+  name: lo
+  addresses:
+  - ip_netmask: {{ lookup('vars', 'bgp_main_net_ip') }}/32
+  - ip_netmask: {{ lookup('vars', 'bgp_main_net6_ip') }}/128

--- a/config/samples/nic-config-samples/single_nic_vlans/single_nic_vlans_storage.j2
+++ b/config/samples/nic-config-samples/single_nic_vlans/single_nic_vlans_storage.j2
@@ -1,0 +1,31 @@
+---
+{% set mtu_list = [ctlplane_mtu] %}
+{% for network in role_networks %}
+{{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+{%- endfor %}
+{% set min_viable_mtu = mtu_list | max %}
+network_config:
+- type: ovs_bridge
+  name: br-storage
+  mtu: {{ min_viable_mtu }}
+  use_dhcp: false
+  dns_servers: {{ ctlplane_dns_nameservers }}
+  domain: {{ edpm_dns_search_domains }}
+  addresses:
+  - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+  routes: {{ ctlplane_host_routes }}
+  members:
+  - type: interface
+    name: nic1
+    mtu: {{ min_viable_mtu }}
+    # force the MAC address of the bridge to this interface
+    primary: true
+{% for network in role_networks %}
+  - type: vlan
+    mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+    vlan_id: {{ lookup('vars', networks_lower[network] ~ '_vlan_id') }}
+    addresses:
+    - ip_netmask:
+        {{ lookup('vars', networks_lower[network] ~ '_ip') }}/{{ lookup('vars', networks_lower[network] ~ '_cidr') }}
+    routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
+{% endfor %}

--- a/docs/common_configurations.md
+++ b/docs/common_configurations.md
@@ -90,17 +90,16 @@ The
 [edpm_network_config](https://github.com/openstack-k8s-operators/edpm-ansible/tree/main/roles/edpm_network_config)
 ansible role is responsible for configuring networking on dataplane nodes.
 
-The `edpm_network_config_template` variable specifies the path to an ansible
+The `edpm_network_config_template` variable specifies the contents of a jinja2
 template that describes the networking configuration to be applied. The
 template itself also contains variables that can be used to customize the
 networking configuration for a specific node (IP addresses, interface names,
-routes, etc). Templates provided with the edpm_network_config role are at
-<https://github.com/openstack-k8s-operators/edpm-ansible/tree/main/roles/edpm_network_config/templates>.
+routes, etc). See template examples provided in the nic-config-samples directory:
+<https://github.com/openstack-k8s-operators/dataplane-operator/config/samples/nic-config-samples>.
 
-Custom templates can also be used, but they must be avaialable to ansible in
-the ansible-runner image used by the `configure-network` service. Use the
-[`ExtraMounts`](../composable_services.md/#using-extramounts) field to mount custom
-content into the ansible-runner image.
+These samples can be used inline within the `OpenStackDataPlaneNodeSet` CR
+under then `ansibleVars` section (see our current sample files for examples
+of the inline implementation).
 
 The following is an example
 [`ansibleVars`](openstack_dataplanenodeset.md/#nodesection)


### PR DESCRIPTION
This change copies some of the examples from EDPM Ansible into the dataplane-operator samples. This allows users to better reference the examples that can be in-lined in the NodeSet without having to jump back and forward between edpm-ansible and dataplane-operator. This should reduce confusion and improve user experience while trying to find examples for what they are trying to do.