### PR TITLE
Update ctlplane_cidr variable to ctlplane_subnet_cidr

### DIFF
--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset.yaml
@@ -54,7 +54,7 @@ spec:
                 dns_servers: {{ ctlplane_dns_nameservers }}
                 domain: {{ dns_search_domains }}
                 addresses:
-                - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+                - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
                 routes: {{ ctlplane_host_routes }}
                 members:
                 - type: interface

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal_with_ipam.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal_with_ipam.yaml
@@ -57,7 +57,7 @@ spec:
                 dns_servers: {{ ctlplane_dns_nameservers }}
                 domain: {{ dns_search_domains }}
                 addresses:
-                - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+                - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
                 routes: {{ ctlplane_host_routes }}
                 members:
                 - type: interface

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_bgp.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_bgp.yaml
@@ -64,7 +64,7 @@ spec:
                 domain: {{ dns_search_domains }}
                 use_dhcp: false
                 addresses:
-                - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+                - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
               {% for network in role_networks %}
               {% if lookup('vars', networks_lower[network] ~ '_vlan_id', default='') %}
               - type: vlan
@@ -101,7 +101,7 @@ spec:
          neutron_physical_bridge_name: br-ex
          neutron_public_interface_name: eth0
          ctlplane_mtu: 1500
-         ctlplane_cidr: 24
+         ctlplane_subnet_cidr: 24
          ctlplane_gateway_ip: 192.168.122.1
          ctlplane_host_routes:
          - ip_netmask: 0.0.0.0/0

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_bgp_ovn_cluster.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_bgp_ovn_cluster.yaml
@@ -60,7 +60,7 @@ spec:
                 domain: {{ dns_search_domains }}
                 use_dhcp: false
                 addresses:
-                - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+                - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
               {% for network in role_networks %}
               {% if lookup('vars', networks_lower[network] ~ '_vlan_id', default='') %}
               - type: vlan
@@ -111,7 +111,7 @@ spec:
          neutron_physical_bridge_name: br-ex
          neutron_public_interface_name: eth0
          ctlplane_mtu: 1500
-         ctlplane_cidr: 24
+         ctlplane_subnet_cidr: 24
          ctlplane_gateway_ip: 192.168.122.1
          ctlplane_host_routes:
          - ip_netmask: 0.0.0.0/0

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ceph.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ceph.yaml
@@ -18,7 +18,7 @@ spec:
         - ip_netmask: 0.0.0.0/0
           next_hop: 192.168.122.1
         ctlplane_mtu: 1500
-        ctlplane_cidr: 24
+        ctlplane_subnet_cidr: 24
         dns_search_domains: []
         timesync_ntp_servers:
         - hostname: pool.ntp.org
@@ -38,7 +38,7 @@ spec:
             dns_servers: {{ ctlplane_dns_nameservers }}
             domain: {{ dns_search_domains }}
             addresses:
-            - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+            - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
             routes: {{ ctlplane_host_routes }}
             members:
             - type: interface

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ceph_hci.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ceph_hci.yaml
@@ -25,7 +25,7 @@ spec:
             dns_servers: {{ ctlplane_dns_nameservers }}
             domain: {{ dns_search_domains }}
             addresses:
-            - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+            - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
             routes: {{ ctlplane_host_routes }}
             members:
             - type: interface

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_customnetworks.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_customnetworks.yaml
@@ -58,7 +58,7 @@ spec:
                dns_servers: {{ ctlplane_dns_nameservers }}
                domain: {{ dns_search_domains }}
                addresses:
-               - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+               - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
                routes: {{ ctlplane_host_routes }}
                members:
                - type: interface
@@ -83,7 +83,7 @@ spec:
         neutron_physical_bridge_name: br-ex
         neutron_public_interface_name: enp7s0
         ctlplane_mtu: 1500
-        ctlplane_cidr: 24
+        ctlplane_subnet_cidr: 24
         ctlplane_gateway_ip: 192.168.1.254
         ctlplane_host_routes:
         - ip_netmask: 0.0.0.0/0
@@ -138,7 +138,7 @@ spec:
           mtu: 1500
           addresses:
             - ip_netmask:
-                {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+                {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
         - type: ovs_bridge
           name: {{ neutron_physical_bridge_name }}
           mtu: 1500

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_networker.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_networker.yaml
@@ -58,7 +58,7 @@ spec:
                 dns_servers: {{ ctlplane_dns_nameservers }}
                 domain: {{ dns_search_domains }}
                 addresses:
-                - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+                - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
                 routes: {{ ctlplane_host_routes }}
                 members:
                 - type: interface
@@ -81,7 +81,7 @@ spec:
          neutron_physical_bridge_name: br-ex
          neutron_public_interface_name: eth0
          ctlplane_mtu: 1500
-         ctlplane_cidr: 24
+         ctlplane_subnet_cidr: 24
          ctlplane_gateway_ip: 192.168.122.1
          ctlplane_host_routes:
          - ip_netmask: 0.0.0.0/0

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_nmstate.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_nmstate.yaml
@@ -71,7 +71,7 @@ spec:
                 enabled: true
                 address:
                   - ip: {{ ctlplane_ip }}
-                    prefix-length: {{ ctlplane_cidr }}
+                    prefix-length: {{ ctlplane_subnet_cidr }}
           {% for network in role_networks %}
             - name: {{ "vlan" ~ lookup('vars', networks_lower[network] ~ '_vlan_id') }}
               type: ovs-interface
@@ -109,7 +109,7 @@ spec:
         neutron_physical_bridge_name: br-ex
         neutron_public_interface_name: eth0
         ctlplane_mtu: 1500
-        ctlplane_cidr: 24
+        ctlplane_subnet_cidr: 24
         ctlplane_gateway_ip: 192.168.122.1
         ctlplane_host_routes:
         - ip_netmask: 0.0.0.0/0

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_sriov.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_sriov.yaml
@@ -60,7 +60,7 @@ spec:
                 dns_servers: {{ ctlplane_dns_nameservers }}
                 domain: {{ dns_search_domains }}
                 addresses:
-                - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+                - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
                 routes: {{ ctlplane_host_routes }}
                 members:
                 - type: interface
@@ -83,7 +83,7 @@ spec:
          neutron_physical_bridge_name: br-ex
          neutron_public_interface_name: eth0
          ctlplane_mtu: 1500
-         ctlplane_cidr: 24
+         ctlplane_subnet_cidr: 24
          ctlplane_gateway_ip: 192.168.122.1
          ctlplane_host_routes:
          - ip_netmask: 0.0.0.0/0

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_with_ipam.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_with_ipam.yaml
@@ -80,7 +80,7 @@ spec:
                 dns_servers: {{ ctlplane_dns_nameservers }}
                 domain: {{ dns_search_domains }}
                 addresses:
-                - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+                - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
                 routes: {{ ctlplane_host_routes }}
                 members:
                 - type: interface

--- a/tests/kuttl/tests/dataplane-create-test/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-create-test/00-assert.yaml
@@ -30,7 +30,7 @@ spec:
         - ip_netmask: 0.0.0.0/0
           next_hop: 192.168.122.1
         ctlplane_mtu: 1500
-        ctlplane_cidr: 24
+        ctlplane_subnet_cidr: 24
         dns_search_domains: []
         timesync_ntp_servers:
         - hostname: clock.redhat.com

--- a/tests/kuttl/tests/dataplane-create-test/00-dataplane-create.yaml
+++ b/tests/kuttl/tests/dataplane-create-test/00-dataplane-create.yaml
@@ -53,7 +53,7 @@ spec:
          neutron_physical_bridge_name: br-ex
          neutron_public_interface_name: eth0
          ctlplane_mtu: 1500
-         ctlplane_cidr: 24
+         ctlplane_subnet_cidr: 24
          ctlplane_gateway_ip: 192.168.122.1
          ctlplane_host_routes:
          - ip_netmask: 0.0.0.0/0


### PR DESCRIPTION
This change updates the ctlplane_cidr variable to be ctlplane_subnet_cidr in line with the changes to variable names made: https://github.com/openstack-k8s-operators/dataplane-operator/pull/614