### PR TITLE
Removing reference to the roles field

### DIFF
--- a/api/v1beta1/openstackdataplaneservice_types.go
+++ b/api/v1beta1/openstackdataplaneservice_types.go
@@ -55,7 +55,6 @@ type OpenStackDataPlaneServiceSpec struct {
 	Label string `json:"label,omitempty"`
 
 	// Play is an inline playbook contents that ansible will run on execution.
-	// If both Play and Roles are specified, Play takes precedence
 	Play string `json:"play,omitempty"`
 
 	// Playbook is a path to the playbook that ansible will run on this execution

--- a/docs/openstack_dataplaneservice.md
+++ b/docs/openstack_dataplaneservice.md
@@ -119,7 +119,7 @@ OpenStackDataPlaneServiceSpec defines the desired state of OpenStackDataPlaneSer
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | label | Label to use for service. Must follow DNS952 subdomain conventions. Since we are using it to generate the pod name, we need to keep it short. | string | false |
-| play | Play is an inline playbook contents that ansible will run on execution. If both Play and Roles are specified, Play takes precedence | string | false |
+| play | Play is an inline playbook contents that ansible will run on execution. | string | false |
 | playbook | Playbook is a path to the playbook that ansible will run on this execution | string | false |
 | configMaps | ConfigMaps list of ConfigMap names to mount as ExtraMounts for the OpenStackAnsibleEE | []string | false |
 | secrets | Secrets list of Secret names to mount as ExtraMounts for the OpenStackAnsibleEE | []string | false |


### PR DESCRIPTION
We don't have that field for a while now. No need to confuse customers about it.