### PR TITLE
Add test-all target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,9 @@ PROC_CMD = --procs ${PROCS}
 test: manifests generate fmt vet envtest ginkgo ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" $(GINKGO) --trace --cover --coverpkg=../../pkg/...,../../controllers,../../api/v1beta1 --coverprofile cover.out --covermode=atomic ${PROC_CMD} $(GINKGO_ARGS) ./tests/...
 
+.PHONY: test-all
+test-all: test golint golangci golangci-lint ## Run all tests.
+
 ##@ Build
 
 .PHONY: build


### PR DESCRIPTION
The test-all target includes test, golint golangci golangci-lint so that
there is a single target to run all automated tests and checks (not
including kuttl).

Signed-off-by: James Slagle <jslagle@redhat.com>
