### PR TITLE
No dup nodes

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	golang.org/x/exp v0.0.0-20240119083558-1b970713d09a // indirect
+	golang.org/x/exp v0.0.0-20240119083558-1b970713d09a
 	golang.org/x/net v0.20.0 // indirect
 	golang.org/x/oauth2 v0.8.0 // indirect
 	golang.org/x/sys v0.16.0 // indirect

--- a/api/v1beta1/openstackdataplanenodeset_webhook.go
+++ b/api/v1beta1/openstackdataplanenodeset_webhook.go
@@ -102,6 +102,12 @@ var _ webhook.Validator = &OpenStackDataPlaneNodeSet{}
 func (r *OpenStackDataPlaneNodeSet) ValidateCreate() error {
 	openstackdataplanenodesetlog.Info("validate create", "name", r.Name)
 
+	// Currently, this check is only valid for PreProvisioned nodes. Since we can't possibly
+	// have duplicates in Baremetal Deployments, we can exit early here for Baremetal NodeSets.
+	if !r.Spec.PreProvisioned {
+		return nil
+	}
+
 	var errors field.ErrorList
 
 	nodeSetList := &OpenStackDataPlaneNodeSetList{}

--- a/tests/functional/openstackdataplanenodeset_webhook_test.go
+++ b/tests/functional/openstackdataplanenodeset_webhook_test.go
@@ -104,7 +104,7 @@ var _ = Describe("DataplaneNodeSet Webhook", func() {
 				"compute-0": map[string]interface{}{
 					"hostName": "compute-0"},
 			}
-		DeferCleanup(th.DeleteInstance, CreateDataplaneNodeSet(dataplaneNodeSetName, nodeSetSpec))
+			DeferCleanup(th.DeleteInstance, CreateDataplaneNodeSet(dataplaneNodeSetName, nodeSetSpec))
 		})
 
 		It("Should block duplicate node declaration", func() {


### PR DESCRIPTION
This changes adds a webhook validation to ensure that nodes are only present in a single NodeSet. If a user tries to create a new NodeSet with a node that already exists in the cluster, it will be blocked by the webhook.

