### PR TITLE
Add OpenStackDataPlaneService osdps shortname

### DIFF
--- a/api/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
@@ -13,6 +13,7 @@ spec:
     listKind: OpenStackDataPlaneServiceList
     plural: openstackdataplaneservices
     shortNames:
+    - osdps
     - osdpservice
     - osdpservices
     singular: openstackdataplaneservice

--- a/api/v1beta1/openstackdataplaneservice_types.go
+++ b/api/v1beta1/openstackdataplaneservice_types.go
@@ -95,7 +95,7 @@ type OpenStackDataPlaneServiceStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
-// +kubebuilder:resource:shortName=osdpservice;osdpservices
+// +kubebuilder:resource:shortName=osdps;osdpservice;osdpservices
 //+operator-sdk:csv:customresourcedefinitions:displayName="OpenStack Data Plane Service"
 
 // OpenStackDataPlaneService is the Schema for the openstackdataplaneservices API

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
@@ -13,6 +13,7 @@ spec:
     listKind: OpenStackDataPlaneServiceList
     plural: openstackdataplaneservices
     shortNames:
+    - osdps
     - osdpservice
     - osdpservices
     singular: openstackdataplaneservice


### PR DESCRIPTION
Adds an additional osdps shortname for OpenStackDataPlaneService, to
align with the other dataplane-operator CRDs, which offer shortnames
with single characters per word.

Signed-off-by: James Slagle <jslagle@redhat.com>
