### PR TITLE
make network names lowercase in samples

### DIFF
--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset.yaml
@@ -28,14 +28,14 @@ spec:
           ansibleHost: 192.168.122.100
   nodeTemplate:
     networks:
-      - name: CtlPlane
+      - name: ctlplane
         subnetName: subnet1
         defaultRoute: true
-      - name: InternalApi
+      - name: internalapi
         subnetName: subnet1
-      - name: Storage
+      - name: storage
         subnetName: subnet1
-      - name: Tenant
+      - name: tenant
         subnetName: subnet1
     ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
     ansible:

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal_with_ipam.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal_with_ipam.yaml
@@ -31,14 +31,14 @@ spec:
   nodeTemplate:
     ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
     networks:
-      - name: CtlPlane
+      - name: ctlplane
         subnetName: subnet1
         defaultRoute: true
-      - name: InternalApi
+      - name: internalapi
         subnetName: subnet1
-      - name: Storage
+      - name: storage
         subnetName: subnet1
-      - name: Tenant
+      - name: tenant
         subnetName: subnet1
     managementNetwork: ctlplane
     ansible:

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ceph.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ceph.yaml
@@ -123,13 +123,13 @@ spec:
       networks:
       - defaultRoute: true
         fixedIP: 192.168.122.100
-        name: CtlPlane
+        name: ctlplane
         subnetName: subnet1
-      - name: InternalApi
+      - name: internalapi
         subnetName: subnet1
-      - name: Storage
+      - name: storage
         subnetName: subnet1
-      - name: Tenant
+      - name: tenant
         subnetName: subnet1
     edpm-compute-1:
       ansible:
@@ -138,13 +138,13 @@ spec:
       networks:
       - defaultRoute: true
         fixedIP: 192.168.122.101
-        name: CtlPlane
+        name: ctlplane
         subnetName: subnet1
-      - name: InternalApi
+      - name: internalapi
         subnetName: subnet1
-      - name: Storage
+      - name: storage
         subnetName: subnet1
-      - name: Tenant
+      - name: tenant
         subnetName: subnet1
     edpm-compute-2:
       ansible:
@@ -153,13 +153,13 @@ spec:
       networks:
       - defaultRoute: true
         fixedIP: 192.168.122.102
-        name: CtlPlane
+        name: ctlplane
         subnetName: subnet1
-      - name: InternalApi
+      - name: internalapi
         subnetName: subnet1
-      - name: Storage
+      - name: storage
         subnetName: subnet1
-      - name: Tenant
+      - name: tenant
         subnetName: subnet1
   preProvisioned: true
   # Create a nova-custom-ceph service which uses a ConfigMap

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ceph_hci.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ceph_hci.yaml
@@ -65,15 +65,15 @@ spec:
       networks:
       - defaultRoute: true
         fixedIP: 192.168.122.100
-        name: CtlPlane
+        name: ctlplane
         subnetName: subnet1
-      - name: InternalApi
+      - name: internalapi
         subnetName: subnet1
-      - name: Storage
+      - name: storage
         subnetName: subnet1
-      - name: StorageMgmt
+      - name: storagemgmt
         subnetName: subnet1
-      - name: Tenant
+      - name: tenant
         subnetName: subnet1
     edpm-compute-1:
       ansible:
@@ -82,15 +82,15 @@ spec:
       networks:
       - defaultRoute: true
         fixedIP: 192.168.122.101
-        name: CtlPlane
+        name: ctlplane
         subnetName: subnet1
-      - name: InternalApi
+      - name: internalapi
         subnetName: subnet1
-      - name: Storage
+      - name: storage
         subnetName: subnet1
-      - name: StorageMgmt
+      - name: storagemgmt
         subnetName: subnet1
-      - name: Tenant
+      - name: tenant
         subnetName: subnet1
     edpm-compute-2:
       ansible:
@@ -99,15 +99,15 @@ spec:
       networks:
       - defaultRoute: true
         fixedIP: 192.168.122.102
-        name: CtlPlane
+        name: ctlplane
         subnetName: subnet1
-      - name: InternalApi
+      - name: internalapi
         subnetName: subnet1
-      - name: Storage
+      - name: storage
         subnetName: subnet1
-      - name: StorageMgmt
+      - name: storagemgmt
         subnetName: subnet1
-      - name: Tenant
+      - name: tenant
         subnetName: subnet1
   preProvisioned: true
   # Each OpenStackDataPlaneDeployment deployment-pre-ceph and

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_with_ipam.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_with_ipam.yaml
@@ -24,30 +24,30 @@ spec:
         ansible:
           ansibleHost: 192.168.122.100
         networks:
-        - name: CtlPlane
+        - name: ctlplane
           subnetName: subnet1
           defaultRoute: true
           fixedIP: 192.168.122.100
-        - name: InternalApi
+        - name: internalapi
           subnetName: subnet1
-        - name: Storage
+        - name: storage
           subnetName: subnet1
-        - name: Tenant
+        - name: tenant
           subnetName: subnet1
       edpm-compute-1:
         hostName: edpm-compute-1
         ansible:
           ansibleHost: 192.168.122.101
         networks:
-        - name: CtlPlane
+        - name: ctlplane
           subnetName: subnet1
           defaultRoute: true
           fixedIP: 192.168.122.101
-        - name: InternalApi
+        - name: internalapi
           subnetName: subnet1
-        - name: Storage
+        - name: storage
           subnetName: subnet1
-        - name: Tenant
+        - name: tenant
           subnetName: subnet1
   networkAttachments:
     - ctlplane


### PR DESCRIPTION
https://github.com/openstack-k8s-operators/infra-operator/pull/169
changed the names in the netconfig sample to be lower case.
it should have made the infra operator case insensitive
however it does not appear to be working.

This change updates the samples to be lowercase to workaround that.
