### PR TITLE
For baremetal nodes use CloudUserName as AnsibleUser

### DIFF
--- a/api/v1beta1/openstackdataplanenodeset_webhook.go
+++ b/api/v1beta1/openstackdataplanenodeset_webhook.go
@@ -61,7 +61,9 @@ func (spec *OpenStackDataPlaneNodeSetSpec) Default() {
 		spec.Nodes[nodeName] = *node.DeepCopy()
 	}
 
-	if spec.NodeTemplate.Ansible.AnsibleUser == "" {
+	if !spec.PreProvisioned {
+		spec.NodeTemplate.Ansible.AnsibleUser = spec.BaremetalSetTemplate.CloudUserName
+	} else if spec.NodeTemplate.Ansible.AnsibleUser == "" {
 		spec.NodeTemplate.Ansible.AnsibleUser = "cloud-admin"
 	}
 


### PR DESCRIPTION
AnsibleUser being different from CloudUserName would create issues as user won't exist.