### PR TITLE
Add kuttl tests for TLS certs

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -54,6 +54,26 @@ rules:
   - update
   - watch
 - apiGroups:
+  - cert-manager.io
+  resources:
+  - certificates
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cert-manager.io
+  resources:
+  - issuers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - configmaps

--- a/controllers/openstackdataplanedeployment_controller.go
+++ b/controllers/openstackdataplanedeployment_controller.go
@@ -54,6 +54,8 @@ type OpenStackDataPlaneDeploymentReconciler struct {
 //+kubebuilder:rbac:groups=dataplane.openstack.org,resources=openstackdataplaneservices,verbs=get;list;watch
 //+kubebuilder:rbac:groups=ansibleee.openstack.org,resources=openstackansibleees,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=discovery.k8s.io,resources=endpointslices,verbs=get;list;watch;create;update;patch;delete;
+//+kubebuilder:rbac:groups=cert-manager.io,resources=issuers,verbs=get;list;watch;
+//+kubebuilder:rbac:groups=cert-manager.io,resources=certificates,verbs=get;list;watch;create;update;patch;delete;
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/tests/kuttl/tests/dataplane-deploy-tls-test/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-tls-test/00-assert.yaml
@@ -1,0 +1,199 @@
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneService
+metadata:
+  name: default-service-tls-dnsnames
+spec:
+  label: default-service-tls-dnsnames
+  caCerts: combined-ca-bundle
+  tlsCert:
+    contents:
+    - dnsnames
+  play: |
+    - hosts: localhost
+      gather_facts: no
+      name: kuttl play
+      tasks:
+        - name: Sleep
+          command: sleep 1
+          delegate_to: localhost
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneService
+metadata:
+  name: default-install-certs-override
+spec:
+  label: default-install-certs-override
+  addCertMounts: True
+  play: |
+    - hosts: localhost
+      gather_facts: no
+      name: kuttl play
+      tasks:
+        - name: Sleep
+          command: sleep 1
+          delegate_to: localhost
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneNodeSet
+metadata:
+  name: openstack-edpm-tls
+spec:
+  env:
+  - name: ANSIBLE_FORCE_COLOR
+    value: "True"
+  nodes:
+    edpm-compute-0:
+      hostName: edpm-compute-0
+      networks:
+      - name: ctlplane
+        subnetName: subnet1
+        defaultRoute: true
+        fixedIP: 192.168.122.100
+      - name: internalapi
+        subnetName: subnet1
+      - name: storage
+        subnetName: subnet1
+      - name: tenant
+        subnetName: subnet1
+
+  nodeTemplate:
+    ansible:
+      ansiblePort: 22
+      ansibleUser: cloud-admin
+      ansibleVars:
+        timesync_ntp_servers:
+        - hostname: clock.redhat.com
+        edpm_network_config_hide_sensitive_logs: false
+        edpm_network_config_template: templates/single_nic_vlans/single_nic_vlans.j2
+        edpm_nodes_validation_validate_controllers_icmp: false
+        edpm_nodes_validation_validate_gateway_icmp: false
+        edpm_selinux_mode: enforcing
+        edpm_sshd_allowed_ranges:
+        - 192.168.122.0/24
+        edpm_sshd_configure_firewall: true
+        enable_debug: false
+    ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
+  preProvisioned: true
+  tlsEnabled: true
+  services:
+  - default-install-certs-override
+  - default-service-tls-dnsnames
+status:
+  conditions:
+  - message: Deployment not started
+    reason: Requested
+    status: "False"
+    type: Ready
+  - message: Deployment not started
+    reason: Requested
+    status: "False"
+    type: DeploymentReady
+  - message: Input data complete
+    reason: Ready
+    status: "True"
+    type: InputReady
+  - message: NodeSetDNSDataReady ready
+    reason: Ready
+    status: "True"
+    type: NodeSetDNSDataReady
+  - message: NodeSetIPReservationReady ready
+    reason: Ready
+    status: "True"
+    type: NodeSetIPReservationReady
+  - message: Setup complete
+    reason: Ready
+    status: "True"
+    type: SetupReady
+---
+apiVersion: network.openstack.org/v1beta1
+kind: IPSet
+metadata:
+  name: edpm-compute-0
+spec:
+  immutable: false
+  networks:
+  - defaultRoute: true
+    name: ctlplane
+    subnetName: subnet1
+  - name: internalapi
+    subnetName: subnet1
+  - name: storage
+    subnetName: subnet1
+  - name: tenant
+    subnetName: subnet1
+status:
+  conditions:
+  - message: Setup complete
+    reason: Ready
+    status: "True"
+    type: Ready
+  - message: Input data complete
+    reason: Ready
+    status: "True"
+    type: InputReady
+  - message: Reservation successful
+    reason: Ready
+    status: "True"
+    type: ReservationReady
+  reservations:
+  - address: 192.168.122.100
+    cidr: 192.168.122.0/24
+    dnsDomain: ctlplane.example.com
+    gateway: 192.168.122.1
+    mtu: 1500
+    network: ctlplane
+    routes:
+    - destination: 0.0.0.0/0
+      nexthop: 192.168.122.1
+    subnet: subnet1
+  - address: 172.17.0.100
+    cidr: 172.17.0.0/24
+    dnsDomain: internalapi.example.com
+    mtu: 1500
+    network: internalapi
+    subnet: subnet1
+    vlan: 20
+  - address: 172.18.0.100
+    cidr: 172.18.0.0/24
+    dnsDomain: storage.example.com
+    mtu: 1500
+    network: storage
+    subnet: subnet1
+    vlan: 21
+  - address: 172.19.0.100
+    cidr: 172.19.0.0/24
+    dnsDomain: tenant.example.com
+    mtu: 1500
+    network: tenant
+    subnet: subnet1
+    vlan: 22
+---
+apiVersion: network.openstack.org/v1beta1
+kind: DNSData
+metadata:
+  name: openstack-edpm-tls
+spec:
+  dnsDataLabelSelectorValue: dnsdata
+  hosts:
+  - hostnames:
+    - edpm-compute-0.ctlplane.example.com
+    ip: 192.168.122.100
+  - hostnames:
+    - edpm-compute-0.internalapi.example.com
+    ip: 172.17.0.100
+  - hostnames:
+    - edpm-compute-0.storage.example.com
+    ip: 172.18.0.100
+  - hostnames:
+    - edpm-compute-0.tenant.example.com
+    ip: 172.19.0.100
+status:
+  conditions:
+  - message: Setup complete
+    reason: Ready
+    status: "True"
+    type: Ready
+  - message: Input data complete
+    reason: Ready
+    status: "True"
+    type: ServiceConfigReady

--- a/tests/kuttl/tests/dataplane-deploy-tls-test/00-dataplane-create.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-tls-test/00-dataplane-create.yaml
@@ -1,0 +1,97 @@
+apiVersion: network.openstack.org/v1beta1
+kind: DNSMasq
+metadata:
+  name: dnsmasq
+spec:
+  replicas: 1
+  options:
+  - key: server
+    values:
+    - 192.168.122.1
+  debug:
+    service: false
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneService
+metadata:
+  name: default-service-tls-dnsnames
+spec:
+  label: default-service-tls-dnsnames
+  caCerts: combined-ca-bundle
+  tlsCert:
+    contents:
+    - dnsnames
+  play: |
+    - hosts: localhost
+      gather_facts: no
+      name: kuttl play
+      tasks:
+        - name: Sleep
+          command: sleep 1
+          delegate_to: localhost
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneService
+metadata:
+  name: default-install-certs-override
+spec:
+  label: default-install-certs-override
+  addCertMounts: True
+  play: |
+    - hosts: localhost
+      gather_facts: no
+      name: kuttl play
+      tasks:
+        - name: Sleep
+          command: sleep 1
+          delegate_to: localhost
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneNodeSet
+metadata:
+  name: openstack-edpm-tls
+spec:
+  env:
+    - name: ANSIBLE_FORCE_COLOR
+      value: "True"
+  services:
+    - default-install-certs-override
+    - default-service-tls-dnsnames
+  preProvisioned: true
+  tlsEnabled: true
+  nodes:
+    edpm-compute-0:
+      hostName: edpm-compute-0
+      networks:
+      - name: ctlplane
+        subnetName: subnet1
+        defaultRoute: true
+        fixedIP: 192.168.122.100
+      - name: internalapi
+        subnetName: subnet1
+      - name: storage
+        subnetName: subnet1
+      - name: tenant
+        subnetName: subnet1
+  nodeTemplate:
+    ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
+    ansible:
+      ansibleUser: cloud-admin
+      ansiblePort: 22
+      ansibleVars:
+         timesync_ntp_servers:
+           - hostname: clock.redhat.com
+         # edpm_network_config
+         # Default nic config template for a EDPM compute node
+         # These vars are edpm_network_config role vars
+         edpm_network_config_hide_sensitive_logs: false
+         edpm_network_config_template: templates/single_nic_vlans/single_nic_vlans.j2
+         edpm_nodes_validation_validate_controllers_icmp: false
+         edpm_nodes_validation_validate_gateway_icmp: false
+         gather_facts: false
+         enable_debug: false
+         # edpm firewall, change the allowed CIDR if needed
+         edpm_sshd_configure_firewall: true
+         edpm_sshd_allowed_ranges: ['192.168.122.0/24']
+         # SELinux module
+         edpm_selinux_mode: enforcing

--- a/tests/kuttl/tests/dataplane-deploy-tls-test/01-create-cert-issuers.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-tls-test/01-create-cert-issuers.yaml
@@ -1,0 +1,22 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      function wait_for() {
+        timeout=$1
+        shift 1
+        until [ $timeout -le 0 ] || ("$@" &> /dev/null); do
+          echo waiting for "$@"
+          sleep 1
+          timeout=$(( timeout - 1 ))
+        done
+        if [ $timeout -le 0 ]; then
+            return 1
+        fi
+      }
+
+      if oc get secret combined-ca-bundle -n openstack; then  oc delete secret  combined-ca-bundle -n openstack; fi
+      oc apply -f ./certs.yaml
+      wait_for 100 oc get secret osp-rootca-secret -n openstack
+      CA_CRT=$(oc get secret osp-rootca-secret -n openstack -o json|jq -r '.data."ca.crt"')
+      oc create secret generic combined-ca-bundle  -n openstack --from-literal=TLSCABundleFile=$CA_CRT

--- a/tests/kuttl/tests/dataplane-deploy-tls-test/02-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-tls-test/02-assert.yaml
@@ -1,0 +1,155 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cert-cert-default-service-tls-dnsnames-edpm-compute-0
+  annotations:
+    cert-manager.io/certificate-name: cert-default-service-tls-dnsnames-edpm-compute-0
+    cert-manager.io/issuer-group: cert-manager.io
+    cert-manager.io/issuer-kind: Issuer
+    cert-manager.io/issuer-name: osp-rootca-issuer-internal
+  labels:
+    hostname: edpm-compute-0
+    service: default-service-tls-dnsnames
+type: kubernetes.io/tls
+---
+# validate the alt-names - which is a list with elements that can be in any order
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+  - script: |
+      template='{{index .metadata.annotations "cert-manager.io/alt-names" }}'
+      names=$(oc get secret cert-cert-default-service-tls-dnsnames-edpm-compute-0 -n openstack -o go-template="$template")
+      echo $names > test123.data
+      regex="(?=.*(edpm-compute-0\.internalapi\.example\.com))(?=.*(edpm-compute-0\.storage\.example\.com))(?=.*(edpm-compute-0\.tenant\.example\.com))(?=.*(edpm-compute-0\.ctlplane\.example\.com))"
+      matches=$(grep -P "$regex" test123.data)
+      rm test123.data
+      if [ -z "$matches" ]; then
+         echo "bad match: $names"
+         exit 1
+      else
+         exit 0
+      fi
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openstack-edpm-tls-default-service-tls-dnsnames-certs
+  ownerReferences:
+  - apiVersion: dataplane.openstack.org/v1beta1
+    kind: OpenStackDataPlaneNodeSet
+    name: openstack-edpm-tls
+type: Opaque
+---
+apiVersion: ansibleee.openstack.org/v1beta1
+kind: OpenStackAnsibleEE
+metadata:
+  labels:
+    osdpd: openstack-edpm-tls-deployment
+  name: default-install-certs-override-openstack-edpm-tls-deployment
+  namespace: openstack
+  ownerReferences:
+  - apiVersion: dataplane.openstack.org/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: OpenStackDataPlaneDeployment
+    name: openstack-edpm-tls-deployment
+spec:
+  backoffLimit: 6
+  extraMounts:
+  - mounts:
+    - mountPath: /var/lib/openstack/certs/default-service-tls-dnsnames
+      name: openstack-edpm-tls-default-service-tls-dnsnames-certs
+    volumes:
+    - name: openstack-edpm-tls-default-service-tls-dnsnames-certs
+      secret:
+        secretName: openstack-edpm-tls-default-service-tls-dnsnames-certs
+  - mounts:
+    - mountPath: /var/lib/openstack/cacerts/default-service-tls-dnsnames
+      name: default-service-tls-dnsnames-combined-ca-bundle
+    volumes:
+    - name: default-service-tls-dnsnames-combined-ca-bundle
+      secret:
+        secretName: combined-ca-bundle
+  - mounts:
+    - mountPath: /runner/env/ssh_key
+      name: ssh-key
+      subPath: ssh_key
+    - mountPath: /runner/inventory/hosts
+      name: inventory
+      subPath: inventory
+    volumes:
+    - name: ssh-key
+      secret:
+        items:
+        - key: ssh-privatekey
+          path: ssh_key
+        secretName: dataplane-ansible-ssh-private-key-secret
+    - name: inventory
+      secret:
+        items:
+        - key: inventory
+          path: inventory
+        secretName: dataplanenodeset-openstack-edpm-tls
+  name: openstackansibleee
+  restartPolicy: Never
+  uid: 1001
+status:
+  JobStatus: Succeeded
+  conditions:
+  - message: AnsibleExecutionJob complete
+    reason: Ready
+    status: "True"
+    type: Ready
+  - message: AnsibleExecutionJob complete
+    reason: Ready
+    status: "True"
+    type: AnsibleExecutionJobReady
+---
+apiVersion: ansibleee.openstack.org/v1beta1
+kind: OpenStackAnsibleEE
+metadata:
+  labels:
+    osdpd: openstack-edpm-tls-deployment
+  name: default-service-tls-dnsnames-openstack-edpm-tls-deployment
+  namespace: openstack
+  ownerReferences:
+  - apiVersion: dataplane.openstack.org/v1beta1
+    kind: OpenStackDataPlaneDeployment
+    name: openstack-edpm-tls-deployment
+spec:
+  backoffLimit: 6
+  extraMounts:
+  - mounts:
+    - mountPath: /runner/env/ssh_key
+      name: ssh-key
+      subPath: ssh_key
+    - mountPath: /runner/inventory/hosts
+      name: inventory
+      subPath: inventory
+    volumes:
+    - name: ssh-key
+      secret:
+        items:
+        - key: ssh-privatekey
+          path: ssh_key
+        secretName: dataplane-ansible-ssh-private-key-secret
+    - name: inventory
+      secret:
+        items:
+        - key: inventory
+          path: inventory
+        secretName: dataplanenodeset-openstack-edpm-tls
+  name: openstackansibleee
+  restartPolicy: Never
+  uid: 1001
+status:
+  JobStatus: Succeeded
+  conditions:
+  - message: AnsibleExecutionJob complete
+    reason: Ready
+    status: "True"
+    type: Ready
+  - message: AnsibleExecutionJob complete
+    reason: Ready
+    status: "True"
+    type: AnsibleExecutionJobReady

--- a/tests/kuttl/tests/dataplane-deploy-tls-test/02-dataplane-deploy.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-tls-test/02-dataplane-deploy.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneDeployment
+metadata:
+  name: openstack-edpm-tls-deployment
+spec:
+  nodeSets:
+    - openstack-edpm-tls

--- a/tests/kuttl/tests/dataplane-deploy-tls-test/03-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-tls-test/03-assert.yaml
@@ -1,0 +1,244 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cert-cert-custom-service-tls-dns-ips-edpm-compute-0
+  annotations:
+    cert-manager.io/alt-names: edpm-compute-0.ctlplane.example.com
+    cert-manager.io/certificate-name: cert-custom-service-tls-dns-ips-edpm-compute-0
+    cert-manager.io/ip-sans: 192.168.122.100
+    cert-manager.io/issuer-group: cert-manager.io
+    cert-manager.io/issuer-kind: Issuer
+    cert-manager.io/issuer-name: osp-rootca-issuer-internal
+  labels:
+    hostname: edpm-compute-0
+    service: custom-service-tls-dns-ips
+type: kubernetes.io/tls
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cert-cert-custom-service-tls-dns-edpm-compute-0
+  annotations:
+    cert-manager.io/certificate-name: cert-custom-service-tls-dns-edpm-compute-0
+    cert-manager.io/issuer-group: cert-manager.io
+    cert-manager.io/issuer-kind: Issuer
+    cert-manager.io/issuer-name: osp-rootca-issuer-internal
+  labels:
+    hostname: edpm-compute-0
+    service: custom-service-tls-dns
+type: kubernetes.io/tls
+---
+# validate the alt-names - which is a list with elements that can be in any order
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+  - script: |
+      template='{{index .metadata.annotations "cert-manager.io/alt-names" }}'
+      names=$(oc get secret cert-cert-custom-service-tls-dns-edpm-compute-0 -n openstack -o go-template="$template")
+      echo $names > test123.data
+      regex="(?=.*(edpm-compute-0\.internalapi\.example\.com))(?=.*(edpm-compute-0\.storage\.example\.com))(?=.*(edpm-compute-0\.tenant\.example\.com))(?=.*(edpm-compute-0\.ctlplane\.example\.com))"
+      matches=$(grep -P "$regex" test123.data)
+      rm test123.data
+      if [ -z "$matches" ]; then
+         echo "bad match: $names"
+         exit 1
+      else
+         exit 0
+      fi
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openstack-edpm-tls-custom-service-tls-dns-ips-certs
+  ownerReferences:
+  - apiVersion: dataplane.openstack.org/v1beta1
+    kind: OpenStackDataPlaneNodeSet
+    name: openstack-edpm-tls
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openstack-edpm-tls-custom-service-tls-dns-certs
+  ownerReferences:
+  - apiVersion: dataplane.openstack.org/v1beta1
+    kind: OpenStackDataPlaneNodeSet
+    name: openstack-edpm-tls
+type: Opaque
+---
+apiVersion: ansibleee.openstack.org/v1beta1
+kind: OpenStackAnsibleEE
+metadata:
+  labels:
+    osdpd: openstack-edpm-tls-services-override
+  name: install-certs-override-openstack-edpm-tls-services-override
+  namespace: openstack
+  ownerReferences:
+  - apiVersion: dataplane.openstack.org/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: OpenStackDataPlaneDeployment
+    name: openstack-edpm-tls-services-override
+spec:
+  backoffLimit: 6
+  extraMounts:
+  - mounts:
+    - mountPath: /var/lib/openstack/certs/custom-service-tls-dns-ips
+      name: openstack-edpm-tls-custom-service-tls-dns-ips-certs
+    volumes:
+    - name: openstack-edpm-tls-custom-service-tls-dns-ips-certs
+      secret:
+        secretName: openstack-edpm-tls-custom-service-tls-dns-ips-certs
+  - mounts:
+    - mountPath: /var/lib/openstack/cacerts/custom-service-tls-dns-ips
+      name: custom-service-tls-dns-ips-combined-ca-bundle
+    volumes:
+    - name: custom-service-tls-dns-ips-combined-ca-bundle
+      secret:
+        secretName: combined-ca-bundle
+  - mounts:
+    - mountPath: /var/lib/openstack/certs/custom-service-tls-dns
+      name: openstack-edpm-tls-custom-service-tls-dns-certs
+    volumes:
+    - name: openstack-edpm-tls-custom-service-tls-dns-certs
+      secret:
+        secretName: openstack-edpm-tls-custom-service-tls-dns-certs
+  - mounts:
+    - mountPath: /var/lib/openstack/cacerts/custom-service-tls-dns
+      name: custom-service-tls-dns-combined-ca-bundle
+    volumes:
+    - name: custom-service-tls-dns-combined-ca-bundle
+      secret:
+        secretName: combined-ca-bundle
+  - mounts:
+    - mountPath: /runner/env/ssh_key
+      name: ssh-key
+      subPath: ssh_key
+    - mountPath: /runner/inventory/hosts
+      name: inventory
+      subPath: inventory
+    volumes:
+    - name: ssh-key
+      secret:
+        items:
+        - key: ssh-privatekey
+          path: ssh_key
+        secretName: dataplane-ansible-ssh-private-key-secret
+    - name: inventory
+      secret:
+        items:
+        - key: inventory
+          path: inventory
+        secretName: dataplanenodeset-openstack-edpm-tls
+  name: openstackansibleee
+  restartPolicy: Never
+  uid: 1001
+status:
+  JobStatus: Succeeded
+  conditions:
+  - message: AnsibleExecutionJob complete
+    reason: Ready
+    status: "True"
+    type: Ready
+  - message: AnsibleExecutionJob complete
+    reason: Ready
+    status: "True"
+    type: AnsibleExecutionJobReady
+---
+apiVersion: ansibleee.openstack.org/v1beta1
+kind: OpenStackAnsibleEE
+metadata:
+  labels:
+    osdpd: openstack-edpm-tls-services-override
+  name: custom-service-tls-dns-ips-openstack-edpm-tls-services-override
+  namespace: openstack
+  ownerReferences:
+  - apiVersion: dataplane.openstack.org/v1beta1
+    kind: OpenStackDataPlaneDeployment
+    name: openstack-edpm-tls-services-override
+spec:
+  backoffLimit: 6
+  extraMounts:
+  - mounts:
+    - mountPath: /runner/env/ssh_key
+      name: ssh-key
+      subPath: ssh_key
+    - mountPath: /runner/inventory/hosts
+      name: inventory
+      subPath: inventory
+    volumes:
+    - name: ssh-key
+      secret:
+        items:
+        - key: ssh-privatekey
+          path: ssh_key
+        secretName: dataplane-ansible-ssh-private-key-secret
+    - name: inventory
+      secret:
+        items:
+        - key: inventory
+          path: inventory
+        secretName: dataplanenodeset-openstack-edpm-tls
+  name: openstackansibleee
+  restartPolicy: Never
+  uid: 1001
+status:
+  JobStatus: Succeeded
+  conditions:
+  - message: AnsibleExecutionJob complete
+    reason: Ready
+    status: "True"
+    type: Ready
+  - message: AnsibleExecutionJob complete
+    reason: Ready
+    status: "True"
+    type: AnsibleExecutionJobReady
+---
+apiVersion: ansibleee.openstack.org/v1beta1
+kind: OpenStackAnsibleEE
+metadata:
+  labels:
+    osdpd: openstack-edpm-tls-services-override
+  name: custom-service-tls-dns-openstack-edpm-tls-services-override
+  namespace: openstack
+  ownerReferences:
+  - apiVersion: dataplane.openstack.org/v1beta1
+    kind: OpenStackDataPlaneDeployment
+    name: openstack-edpm-tls-services-override
+spec:
+  backoffLimit: 6
+  extraMounts:
+  - mounts:
+    - mountPath: /runner/env/ssh_key
+      name: ssh-key
+      subPath: ssh_key
+    - mountPath: /runner/inventory/hosts
+      name: inventory
+      subPath: inventory
+    volumes:
+    - name: ssh-key
+      secret:
+        items:
+        - key: ssh-privatekey
+          path: ssh_key
+        secretName: dataplane-ansible-ssh-private-key-secret
+    - name: inventory
+      secret:
+        items:
+        - key: inventory
+          path: inventory
+        secretName: dataplanenodeset-openstack-edpm-tls
+  name: openstackansibleee
+  restartPolicy: Never
+  uid: 1001
+status:
+  JobStatus: Succeeded
+  conditions:
+  - message: AnsibleExecutionJob complete
+    reason: Ready
+    status: "True"
+    type: Ready
+  - message: AnsibleExecutionJob complete
+    reason: Ready
+    status: "True"
+    type: AnsibleExecutionJobReady

--- a/tests/kuttl/tests/dataplane-deploy-tls-test/03-dataplane-deploy-services-override.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-tls-test/03-dataplane-deploy-services-override.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneService
+metadata:
+  name: custom-service-tls-dns-ips
+spec:
+  label: custom-service-tls-dns-ips
+  caCerts: combined-ca-bundle
+  tlsCert:
+    contents:
+    - dnsnames
+    - ips
+    issuer: osp-rootca-issuer-internal
+    networks:
+    - ctlplane
+  play: |
+    - hosts: localhost
+      gather_facts: no
+      name: kuttl play
+      tasks:
+        - name: Sleep
+          command: sleep 1
+          delegate_to: localhost
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneService
+metadata:
+  name: custom-service-tls-dns
+spec:
+  label: custom-service-tls-dns
+  caCerts: combined-ca-bundle
+  tlsCert:
+    contents:
+    - dnsnames
+  play: |
+    - hosts: localhost
+      gather_facts: no
+      name: kuttl play
+      tasks:
+        - name: Sleep
+          command: sleep 1
+          delegate_to: localhost
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneService
+metadata:
+  name: install-certs-override
+spec:
+  label: install-certs-override
+  addCertMounts: True
+  play: |
+    - hosts: localhost
+      gather_facts: no
+      name: kuttl play
+      tasks:
+        - name: Sleep
+          command: sleep 1
+          delegate_to: localhost
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneDeployment
+metadata:
+  name: openstack-edpm-tls-services-override
+spec:
+  nodeSets:
+    - openstack-edpm-tls
+  servicesOverride:
+    - install-certs-override
+    - custom-service-tls-dns-ips
+    - custom-service-tls-dns

--- a/tests/kuttl/tests/dataplane-deploy-tls-test/certs.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-tls-test/certs.yaml
@@ -1,0 +1,36 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+  namespace: openstack
+spec:
+  selfSigned: {}
+---
+# RootCA Certificate used to sign certificates
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: osp-rootca
+  namespace: openstack
+spec:
+  isCA: true
+  commonName: osp-rootca
+  secretName: osp-rootca-secret
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Issuer that uses the generated CA certificate to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: osp-rootca-issuer-internal
+  namespace: openstack
+spec:
+  ca:
+    secretName: osp-rootca-secret
+---


### PR DESCRIPTION
This adds kuttl tests for the tls cert functionality in the dataplane operator.

This depends on https://github.com/openstack-k8s-operators/install_yamls/pull/717 to make sure that the certmanager operator is running as well so we can issue certs.