### PR TITLE
Re-word PreProvisioned description

### DIFF
--- a/api/v1beta1/openstackdataplanenodeset_types.go
+++ b/api/v1beta1/openstackdataplanenodeset_types.go
@@ -44,8 +44,7 @@ type OpenStackDataPlaneNodeSetSpec struct {
 	// +kubebuilder:validation:Optional
 	//
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
-	// PreProvisioned - Whether the nodes are actually pre-provisioned (True) or should be
-	// preprovisioned (False)
+	// PreProvisioned - Set to true if the nodes have been Pre Provisioned.
 	PreProvisioned bool `json:"preProvisioned,omitempty"`
 
 	// Env is a list containing the environment variables to pass to the pod

--- a/docs/assemblies/custom_resources.adoc
+++ b/docs/assemblies/custom_resources.adoc
@@ -497,7 +497,7 @@ OpenStackDataPlaneNodeSetSpec defines the desired state of OpenStackDataPlaneNod
 | true
 
 | preProvisioned
-| \n\nPreProvisioned - Whether the nodes are actually pre-provisioned (True) or should be preprovisioned (False)
+| \n\nPreProvisioned - Set to true if the nodes have been Pre Provisioned.
 | bool
 | false
 


### PR DESCRIPTION
The current wording is a little confusing. This change aims to simplify the description and provide clearer instruction.