### PR TITLE
Bump k8s version for envtest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ OPERATOR_SDK_VERSION ?= v1.31.0
 DEFAULT_IMG ?= quay.io/openstack-k8s-operators/dataplane-operator:latest
 IMG ?= $(DEFAULT_IMG)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.26
+ENVTEST_K8S_VERSION = 1.27
 
 CRDDESC_OVERRIDE ?= :maxDescLen=0
 


### PR DESCRIPTION
This change bumps the version of k8s used in Envtests to match the version used in OCP4.14