### PR TITLE
Drop warning about existing netconfig during kuttl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -268,7 +268,6 @@ $(GINKGO): $(LOCALBIN)
 .PHONY: kuttl-test
 kuttl-test: ## Run kuttl tests
 	if oc get dnsmasq dns; then echo "dnsmasq/dns CR can not exist during kuttl tests"; exit 1; fi
-	if oc get netconfig netconfig; then echo "netconfig/netconfig CR can not exist during kuttl tests"; exit 1; fi
 	$(LOCALBIN)/kubectl-kuttl test --config kuttl-test.yaml tests/kuttl/tests $(KUTTL_ARGS)
 
 .PHONY: kuttl


### PR DESCRIPTION
This warning is no longer needed since a netconfig resource is now
created as part of each kuttl test since commit
a9bab7acb46572f9a74187b9a2c942bc10bbfda6, so it's expected to exist.

Signed-off-by: James Slagle <jslagle@redhat.com>
