### PR TITLE
Bumping actions to use node.js-20

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -20,8 +20,7 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: 1.20.x
-
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           # this fetches all branches. Needed because we need gh-pages branch for deploy to work
           fetch-depth: 0

--- a/.github/workflows/release-dataplane-operator.yaml
+++ b/.github/workflows/release-dataplane-operator.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Tag image
       uses: tinact/docker.image-retag@1.0.2


### PR DESCRIPTION
As per the guidance from github[0] I'm bumping all of the affected actions to new versions.
There may be tangential benefit in new features, but most of all we are going to be using something that is actually supported.

[0] github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
