### PR TITLE
Getting network name missing in dictionary issue

### DIFF
--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ovs_dpdk.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ovs_dpdk.yaml
@@ -73,7 +73,7 @@ spec:
                   mtu: {{ min_viable_mtu }}
                   # force the MAC address of the bridge to this interface
                   primary: true
-              {% for network in role_networks if network not in ["External", "Tenant"] %}
+              {% for network in role_networks if network not in ["external", "tenant"] %}
                 - type: vlan
                   mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
                   vlan_id: {{ lookup('vars', networks_lower[network] ~ '_vlan_id') }}
@@ -85,11 +85,11 @@ spec:
               - type: ovs_user_bridge
                  name: br-link1
                 use_dhcp: false
-                ovs_extra: "set port br-link1 tag={{ lookup('vars', networks_lower['Tenant'] ~ '_vlan_id') }}"
+                ovs_extra: "set port br-link1 tag={{ lookup('vars', networks_lower['tenant'] ~ '_vlan_id') }}"
                 addresses:
-                - ip_netmask: {{ lookup('vars', networks_lower['Tenant'] ~ '_ip') }}/{{ lookup('vars', networks_lower['Tenant'] ~ '_cidr') }}
+                - ip_netmask: {{ lookup('vars', networks_lower['tenant'] ~ '_ip') }}/{{ lookup('vars', networks_lower['tenant'] ~ '_cidr') }}
 
-                  mtu: {{ lookup('vars', networks_lower['Tenant'] ~ '_mtu') }}
+                  mtu: {{ lookup('vars', networks_lower['tenant'] ~ '_mtu') }}
                   members:
                   - type: ovs_dpdk_port
                     name: dpdk1


### PR DESCRIPTION
This change is to fix network name missing issue during dataplane deployment.