### PR TITLE
Pass instanceSpec.CtlPlaneIP in CIDR notation

### DIFF
--- a/tests/functional/openstackdataplanenodeset_webhook_test.go
+++ b/tests/functional/openstackdataplanenodeset_webhook_test.go
@@ -70,7 +70,7 @@ var _ = Describe("DataplaneNodeSet Webhook", func() {
 				},
 				BaremetalHosts: map[string]baremetalv1.InstanceSpec{
 					"compute-0": {
-						CtlPlaneIP: "192.168.1.12",
+						CtlPlaneIP: "192.168.1.12/24",
 					},
 				},
 			}
@@ -87,7 +87,7 @@ var _ = Describe("DataplaneNodeSet Webhook", func() {
 					},
 					BaremetalHosts: map[string]baremetalv1.InstanceSpec{
 						"compute-0": {
-							CtlPlaneIP: "192.168.1.12",
+							CtlPlaneIP: "192.168.1.12/24",
 						},
 					},
 				}


### PR DESCRIPTION
Get the ipPrefix from the Cidr in the ipSet reservation, combine address and prefix when setting CtlPlaneIP in the instanceSpec.

Depends-On: https://github.com/openstack-k8s-operators/openstack-baremetal-operator/pull/129