### PR TITLE
Hash the entire NodeSet spec

### DIFF
--- a/controllers/openstackdataplanenodeset_controller.go
+++ b/controllers/openstackdataplanenodeset_controller.go
@@ -67,13 +67,6 @@ const (
 	OvnBgpAgentDefaultImage = "quay.io/podified-antelope-centos9/openstack-ovn-bgp-agent:current-podified"
 )
 
-// NodeConfigElements is a struct containing just the elements used for Ansible executions
-type NodeConfigElements struct {
-	BaremetalSetTemplate baremetalv1.OpenStackBaremetalSetSpec
-	NodeTemplate         dataplanev1.NodeTemplate
-	Nodes                map[string]dataplanev1.NodeSection
-}
-
 // SetupAnsibleImageDefaults -
 func SetupAnsibleImageDefaults() {
 	dataplaneAnsibleImageDefaults = dataplanev1.DataplaneAnsibleImageDefaults{
@@ -490,12 +483,7 @@ func (r *OpenStackDataPlaneNodeSetReconciler) SetupWithManager(ctx context.Conte
 // GetSpecConfigHash initialises a new struct with only the field we want to check for variances in.
 // We then hash the contents of the new struct using md5 and return the hashed string.
 func (r *OpenStackDataPlaneNodeSetReconciler) GetSpecConfigHash(instance *dataplanev1.OpenStackDataPlaneNodeSet) (string, error) {
-	nodeConfig := &NodeConfigElements{
-		BaremetalSetTemplate: instance.Spec.BaremetalSetTemplate,
-		NodeTemplate:         instance.Spec.NodeTemplate,
-		Nodes:                instance.Spec.Nodes,
-	}
-	configHash, err := util.ObjectHash(&nodeConfig)
+	configHash, err := util.ObjectHash(&instance.Spec)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This change removes the selective fields we were using to create the ConfigHash. Initially, this was implemented to ensure we only captured user provided values from the Spec, while removing those that are populated during reconcile by the controller. For example, the values in the baremetalSetTemplate. However, since we are now including the baremetalSetTemplate in the current hash, there is no need to be selective about the fields we include.

This change removes the selective spec fields and instead hashes the entire NodeSet spec section.