### PR TITLE
Added `check-fips-status` service

### DIFF
--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_fips_status.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_fips_status.yaml
@@ -1,0 +1,7 @@
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneService
+metadata:
+  name: fips-status
+spec:
+  label: fips-status
+  playbook: osp.edpm.fips_status


### PR DESCRIPTION
In order to check the status of FIPS enablement on compute nodes, we need to call the `fips_status` playbook added with the related edpm-ansible PR[1]

[1] https://github.com/openstack-k8s-operators/edpm-ansible/pull/564

Depends-On: https://github.com/openstack-k8s-operators/edpm-ansible/pull/564