### PR TITLE
Temporarily fix issuers

### DIFF
--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_libvirt.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_libvirt.yaml
@@ -11,5 +11,5 @@ spec:
       - ips
     networks:
       - ctlplane
-    issuer: osp-rootca-issuer-internal
+    issuer: rootca-internal
   caCerts: combined-ca-bundle

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_nova.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_nova.yaml
@@ -17,5 +17,5 @@ spec:
     - ips
     networks:
     - ctlplane
-    issuer: osp-rootca-issuer-internal
+    issuer: rootca-internal
   caCerts: combined-ca-bundle

--- a/pkg/deployment/cert.go
+++ b/pkg/deployment/cert.go
@@ -35,8 +35,10 @@ import (
 	dataplanev1 "github.com/openstack-k8s-operators/dataplane-operator/api/v1beta1"
 	infranetworkv1 "github.com/openstack-k8s-operators/infra-operator/apis/network/v1beta1"
 	"github.com/openstack-k8s-operators/lib-common/modules/certmanager"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/endpoint"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/secret"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/tls"
 )
 
 // EnsureTLSCerts generates  a secret containing all the certificates for the relevant service
@@ -109,7 +111,9 @@ func EnsureTLSCerts(ctx context.Context, helper *helper.Helper,
 
 		if service.Spec.TLSCert.Issuer == "" {
 			// by default, use the internal root CA
-			issuer = certmanager.RootCAIssuerInternalLabel
+			// issuer = certmanager.RootCAIssuerInternalLabel
+			// TODO(alee) Temporarily set this to the issuer name
+			issuer = tls.DefaultCAPrefix + string(endpoint.EndpointInternal)
 		} else {
 			issuer = service.Spec.TLSCert.Issuer
 		}

--- a/tests/kuttl/tests/dataplane-deploy-tls-test/02-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-tls-test/02-assert.yaml
@@ -6,7 +6,7 @@ metadata:
     cert-manager.io/certificate-name: cert-default-service-tls-dnsnames-edpm-compute-0
     cert-manager.io/issuer-group: cert-manager.io
     cert-manager.io/issuer-kind: Issuer
-    cert-manager.io/issuer-name: osp-rootca-issuer-internal
+    cert-manager.io/issuer-name: rootca-internal
   labels:
     hostname: edpm-compute-0
     service: default-service-tls-dnsnames

--- a/tests/kuttl/tests/dataplane-deploy-tls-test/03-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-tls-test/03-assert.yaml
@@ -8,7 +8,7 @@ metadata:
     cert-manager.io/ip-sans: 192.168.122.100
     cert-manager.io/issuer-group: cert-manager.io
     cert-manager.io/issuer-kind: Issuer
-    cert-manager.io/issuer-name: osp-rootca-issuer-internal
+    cert-manager.io/issuer-name: rootca-internal
   labels:
     hostname: edpm-compute-0
     service: custom-service-tls-dns-ips
@@ -22,7 +22,7 @@ metadata:
     cert-manager.io/certificate-name: cert-custom-service-tls-dns-edpm-compute-0
     cert-manager.io/issuer-group: cert-manager.io
     cert-manager.io/issuer-kind: Issuer
-    cert-manager.io/issuer-name: osp-rootca-issuer-internal
+    cert-manager.io/issuer-name: rootca-internal
   labels:
     hostname: edpm-compute-0
     service: custom-service-tls-dns

--- a/tests/kuttl/tests/dataplane-deploy-tls-test/03-dataplane-deploy-services-override.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-tls-test/03-dataplane-deploy-services-override.yaml
@@ -9,7 +9,7 @@ spec:
     contents:
     - dnsnames
     - ips
-    issuer: osp-rootca-issuer-internal
+    issuer: rootca-internal
     networks:
     - ctlplane
   play: |

--- a/tests/kuttl/tests/dataplane-deploy-tls-test/certs.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-tls-test/certs.yaml
@@ -28,7 +28,7 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: osp-rootca-issuer-internal
+  name: rootca-internal
   namespace: openstack
 spec:
   ca:


### PR DESCRIPTION
The code currently sets the default issuer to
osp-rootca-issuer-internal, which is the label for the issuer - rather than the name of the issuer itself (rootca-internal).

The proper fix for this is to use the label and then call something like GetIssuerByLabel() to get the right issuer - while handling the error if the issuer is not yet available.  We plan to add such a function to lib-common by early next week - and will add code to use it then.

Until then, we can unblock folks trying to test out tls-e by setting the issuer name  correctly.