### PR TITLE
Refer to issuers by label instead of name

### DIFF
--- a/api/v1beta1/openstackdataplaneservice_types.go
+++ b/api/v1beta1/openstackdataplaneservice_types.go
@@ -35,7 +35,8 @@ type OpenstackDataPlaneServiceCert struct {
 	// +kubebuilder:validation:Optional
 	Networks []infranetworkv1.NetNameStr `json:"networks,omitempty"`
 
-	// Issuer to issue the cert
+	// Issuer is the label for the issuer to issue the cert
+	// Only one issuer should have this label
 	// +kubebuilder:validation:Optional
 	Issuer string `json:"issuer,omitempty"`
 }

--- a/config/manifests/bases/dataplane-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/dataplane-operator.clusterserviceversion.yaml
@@ -54,8 +54,7 @@ spec:
         path: nodes.ansible.ansiblePort
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
-      - description: PreProvisioned - Whether the nodes are actually pre-provisioned
-          (True) or should be preprovisioned (False)
+      - description: PreProvisioned - Set to true if the nodes have been Pre Provisioned.
         displayName: Pre Provisioned
         path: preProvisioned
         x-descriptors:

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_libvirt.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_libvirt.yaml
@@ -10,5 +10,5 @@ spec:
       - ips
     networks:
       - ctlplane
-    issuer: rootca-internal
+    issuer: osp-rootca-issuer-internal
   caCerts: combined-ca-bundle

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_nova.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_nova.yaml
@@ -16,5 +16,5 @@ spec:
     - ips
     networks:
     - ctlplane
-    issuer: rootca-internal
+    issuer: osp-rootca-issuer-internal
   caCerts: combined-ca-bundle

--- a/docs/assemblies/custom_resources.adoc
+++ b/docs/assemblies/custom_resources.adoc
@@ -336,7 +336,7 @@ OpenstackDataPlaneServiceCert defines the property of a TLS cert issued for a da
 | false
 
 | issuer
-| Issuer to issue the cert
+| Issuer is the label for the issuer to issue the cert Only one issuer should have this label
 | string
 | false
 |===

--- a/docs/assemblies/tls.adoc
+++ b/docs/assemblies/tls.adoc
@@ -107,10 +107,11 @@ to the SAN.
 
 ==== issuer
 
-This attribute corresponds to the certmanager issuer that will be used to issue the certificate.
-If the issuers attribute is not set (as in the configuarion above for service1), certificates
-will be issued using the default root CA for internal TLS as defined in lib-common.
-(currently set to "osp-rootca-issuer-internal").
+This attribute corresponds to the label for the certmanager issuer that is used to issue the certificate.
+The label can be different from the name of the issuer. There can be only one issuer with the specified label.
+If more than one issuer has the label, an error is generated. If the issuers attribute is not set, as in the
+configuration for `service1`, the certificates are issued with the default root CA for internal TLS as defined
+in `lib-common`, which is set to the label "osp-rootca-issuer-internal" for the `rootca-internal` issuer.
 
 === addCertMounts
 

--- a/tests/kuttl/tests/dataplane-deploy-tls-test/03-dataplane-deploy-services-override.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-tls-test/03-dataplane-deploy-services-override.yaml
@@ -9,7 +9,7 @@ spec:
     contents:
     - dnsnames
     - ips
-    issuer: rootca-internal
+    issuer: osp-rootca-issuer-internal
     networks:
     - ctlplane
   play: |

--- a/tests/kuttl/tests/dataplane-deploy-tls-test/certs.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-tls-test/certs.yaml
@@ -30,6 +30,8 @@ kind: Issuer
 metadata:
   name: rootca-internal
   namespace: openstack
+  labels:
+    osp-rootca-issuer-internal: ""
 spec:
   ca:
     secretName: osp-rootca-secret


### PR DESCRIPTION
This PR changes cert.go to retrieve an issuer by label instead of by name.  We expect labels to be consistent for issuers, rather than names, and labels are defined in lib-common.

Depends-On: https://github.com/openstack-k8s-operators/lib-common/pull/467