### PR TITLE
remove libvirt image defaulting

### DIFF
--- a/api/v1beta1/openstackdataplanenodeset_types.go
+++ b/api/v1beta1/openstackdataplanenodeset_types.go
@@ -188,7 +188,6 @@ type DataplaneAnsibleImageDefaults struct {
 	Logrotate            string
 	NeutronMetadataAgent string
 	NovaCompute          string
-	NovaLibvirt          string
 	OvnControllerAgent   string
 	OvnBgpAgent          string
 }

--- a/controllers/openstackdataplanenodeset_controller.go
+++ b/controllers/openstackdataplanenodeset_controller.go
@@ -59,8 +59,6 @@ const (
 	NeutronMetadataAgentDefaultImage = "quay.io/podified-antelope-centos9/openstack-neutron-metadata-agent-ovn:current-podified"
 	// NovaComputeDefaultImage -
 	NovaComputeDefaultImage = "quay.io/podified-antelope-centos9/openstack-nova-compute:current-podified"
-	// NovaLibvirtDefaultImage -
-	NovaLibvirtDefaultImage = "quay.io/podified-antelope-centos9/openstack-nova-libvirt:current-podified"
 	// OvnControllerAgentDefaultImage -
 	OvnControllerAgentDefaultImage = "quay.io/podified-antelope-centos9/openstack-ovn-controller:current-podified"
 	// OvnBgpAgentDefaultImage -
@@ -75,7 +73,6 @@ func SetupAnsibleImageDefaults() {
 		Logrotate:            util.GetEnvVar("RELATED_IMAGE_OPENSTACK_EDPM_LOGROTATE_CROND_DEFAULT_IMG", LogrotateDefaultImage),
 		NeutronMetadataAgent: util.GetEnvVar("RELATED_IMAGE_OPENSTACK_EDPM_NEUTRON_METADATA_AGENT_DEFAULT_IMG", NeutronMetadataAgentDefaultImage),
 		NovaCompute:          util.GetEnvVar("RELATED_IMAGE_OPENSTACK_EDPM_NOVA_COMPUTE_DEFAULT_IMG", NovaComputeDefaultImage),
-		NovaLibvirt:          util.GetEnvVar("RELATED_IMAGE_OPENSTACK_EDPM_LIBVIRT_DEFAULT_IMG", NovaLibvirtDefaultImage),
 		OvnControllerAgent:   util.GetEnvVar("RELATED_IMAGE_OPENSTACK_EDPM_OVN_CONTROLLER_AGENT_DEFAULT_IMG", OvnControllerAgentDefaultImage),
 		OvnBgpAgent:          util.GetEnvVar("RELATED_IMAGE_OPENSTACK_EDPM_OVN_BGP_AGENT_IMAGE", OvnBgpAgentDefaultImage),
 	}

--- a/docs/assemblies/custom_resources.adoc
+++ b/docs/assemblies/custom_resources.adoc
@@ -376,11 +376,6 @@ DataplaneAnsibleImageDefaults default images for dataplane services
 | string
 | false
 
-| NovaLibvirt
-|
-| string
-| false
-
 | OvnControllerAgent
 |
 | string

--- a/pkg/deployment/inventory.go
+++ b/pkg/deployment/inventory.go
@@ -166,9 +166,6 @@ func resolveGroupAnsibleVars(template *dataplanev1.NodeTemplate, group *ansible.
 	if template.Ansible.AnsibleVars["edpm_nova_compute_image"] == nil {
 		group.Vars["edpm_nova_compute_image"] = defaultImages.NovaCompute
 	}
-	if template.Ansible.AnsibleVars["edpm_libvirt_image"] == nil {
-		group.Vars["edpm_libvirt_image"] = defaultImages.NovaLibvirt
-	}
 	if template.Ansible.AnsibleVars["edpm_ovn_controller_agent_image"] == nil {
 		group.Vars["edpm_ovn_controller_agent_image"] = defaultImages.OvnControllerAgent
 	}

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -21,7 +21,6 @@ var DefaultEdpmServiceAnsibleVarList = []string{
 	"edpm_logrotate_crond_image",
 	"edpm_neutron_metadata_agent_image",
 	"edpm_nova_compute_image",
-	"edpm_libvirt_image",
 	"edpm_ovn_controller_agent_image",
 	"edpm_ovn_bgp_agent_image",
 }

--- a/tests/functional/openstackdataplanenodeset_controller_test.go
+++ b/tests/functional/openstackdataplanenodeset_controller_test.go
@@ -66,7 +66,6 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 		"edpm_logrotate_crond_image",
 		"edpm_neutron_metadata_agent_image",
 		"edpm_nova_compute_image",
-		"edpm_libvirt_image",
 		"edpm_ovn_controller_agent_image",
 		"edpm_ovn_bgp_agent_image",
 	}


### PR DESCRIPTION
The libvirt service is not installed in a container anymore.
This commit removes the default of the container image url
and updates the related evn-tests.

Related: [OSPRH-960](https://issues.redhat.com//browse/OSPRH-960)
Related: [OSPRH-144](https://issues.redhat.com//browse/OSPRH-144)
