### PR TITLE
Drop service label field from config/services resources

### DIFF
--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_bootstrap.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_bootstrap.yaml
@@ -9,5 +9,4 @@ metadata:
     app.kubernetes.io/created-by: dataplane-operator
   name: bootstrap
 spec:
-  label: bootstrap
   playbook: osp.edpm.bootstrap

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_ceph_client.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_ceph_client.yaml
@@ -3,5 +3,4 @@ kind: OpenStackDataPlaneService
 metadata:
   name: ceph-client
 spec:
-  label: ceph-client
   playbook: osp.edpm.ceph_client

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_ceph_hci_pre.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_ceph_hci_pre.yaml
@@ -3,5 +3,4 @@ kind: OpenStackDataPlaneService
 metadata:
   name: ceph-hci-pre
 spec:
-  label: ceph-hci-pre
   playbook: osp.edpm.ceph_hci_pre

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_configure_network.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_configure_network.yaml
@@ -9,5 +9,4 @@ metadata:
     app.kubernetes.io/created-by: dataplane-operator
   name: configure-network
 spec:
-  label: configure-network
   playbook: osp.edpm.configure_network

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_configure_os.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_configure_os.yaml
@@ -3,5 +3,4 @@ kind: OpenStackDataPlaneService
 metadata:
   name: configure-os
 spec:
-  label: configure-os
   playbook: osp.edpm.configure_os

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_configure_ovs_dpdk.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_configure_ovs_dpdk.yaml
@@ -9,5 +9,4 @@ metadata:
     app.kubernetes.io/created-by: dataplane-operator
   name: configure-ovs-dpdk
 spec:
-  label: configure-ovs-dpdk
   playbook: osp.edpm.configure_ovs_dpdk

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_ddp_package_option.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_ddp_package_option.yaml
@@ -3,5 +3,4 @@ kind: OpenStackDataPlaneService
 metadata:
   name: ddp-package-option
 spec:
-  label: ddp-package-option
   playbook: osp.edpm.select_kernel_ddp_package

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_download_cache.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_download_cache.yaml
@@ -9,5 +9,4 @@ metadata:
     app.kubernetes.io/created-by: dataplane-operator
   name: download-cache
 spec:
-  label: download-cache
   playbook: osp.edpm.download_cache

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_frr.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_frr.yaml
@@ -3,5 +3,4 @@ kind: OpenStackDataPlaneService
 metadata:
   name: frr
 spec:
-  label: frr
   playbook: osp.edpm.frr

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_install_certs.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_install_certs.yaml
@@ -9,6 +9,5 @@ metadata:
     app.kubernetes.io/created-by: dataplane-operator
   name: install-certs
 spec:
-  label: install-certs
   playbook: osp.edpm.install_certs
   addCertMounts: True

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_install_os.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_install_os.yaml
@@ -3,5 +3,4 @@ kind: OpenStackDataPlaneService
 metadata:
   name: install-os
 spec:
-  label: install-os
   playbook: osp.edpm.install_os

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_libvirt.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_libvirt.yaml
@@ -3,7 +3,6 @@ kind: OpenStackDataPlaneService
 metadata:
   name: libvirt
 spec:
-  label: libvirt
   playbook: osp.edpm.libvirt
   tlsCert:
     contents:

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_logging.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_logging.yaml
@@ -3,7 +3,6 @@ kind: OpenStackDataPlaneService
 metadata:
   name: logging
 spec:
-  label: logging
   secrets:
     - logging-compute-config-data
   playbook: osp.edpm.telemetry_logging

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_neutron_dhcp.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_neutron_dhcp.yaml
@@ -3,7 +3,6 @@ kind: OpenStackDataPlaneService
 metadata:
   name: neutron-dhcp
 spec:
-  label: neutron-dhcp
   playbook: osp.edpm.neutron_dhcp
   secrets:
   - neutron-dhcp-agent-neutron-config

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_neutron_metadata.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_neutron_metadata.yaml
@@ -3,7 +3,6 @@ kind: OpenStackDataPlaneService
 metadata:
   name: neutron-metadata
 spec:
-  label: neutron-metadata
   playbook: osp.edpm.neutron_metadata
   secrets:
   - neutron-ovn-metadata-agent-neutron-config

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_neutron_ovn.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_neutron_ovn.yaml
@@ -3,7 +3,6 @@ kind: OpenStackDataPlaneService
 metadata:
   name: neutron-ovn
 spec:
-  label: neutron-ovn
   playbook: osp.edpm.neutron_ovn
   secrets:
   - neutron-ovn-agent-neutron-config

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_neutron_sriov.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_neutron_sriov.yaml
@@ -3,7 +3,6 @@ kind: OpenStackDataPlaneService
 metadata:
   name: neutron-sriov
 spec:
-  label: neutron-sriov
   playbook: osp.edpm.neutron_sriov
   secrets:
   - neutron-sriov-agent-neutron-config

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_nova.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_nova.yaml
@@ -3,7 +3,6 @@ kind: OpenStackDataPlaneService
 metadata:
   name: nova
 spec:
-  label: nova
   secrets:
     - nova-cell1-compute-config
     # NOTE: this Secret needs to be created before deploying the data plane.

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_os_reboot.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_os_reboot.yaml
@@ -3,5 +3,4 @@ kind: OpenStackDataPlaneService
 metadata:
   name: reboot-os
 spec:
-  label: reboot-os
   playbook: osp.edpm.reboot

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_ovn.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_ovn.yaml
@@ -3,7 +3,6 @@ kind: OpenStackDataPlaneService
 metadata:
   name: ovn
 spec:
-  label: ovn
   playbook: osp.edpm.ovn
   configMaps:
   - ovncontroller-config

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_ovn_bgp_agent.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_ovn_bgp_agent.yaml
@@ -3,7 +3,6 @@ kind: OpenStackDataPlaneService
 metadata:
   name: ovn-bgp-agent
 spec:
-  label: ovn-bgp-agent
   playbook: osp.edpm.ovn_bgp_agent
   secrets:
   - neutron-ovn-agent-neutron-config

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_run_os.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_run_os.yaml
@@ -3,5 +3,4 @@ kind: OpenStackDataPlaneService
 metadata:
   name: run-os
 spec:
-  label: run-os
   playbook: osp.edpm.run_os

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_swift.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_swift.yaml
@@ -3,7 +3,6 @@ kind: OpenStackDataPlaneService
 metadata:
   name: swift
 spec:
-  label: swift
   playbook: osp.edpm.swift
   secrets:
   - swift-conf

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_telemetry.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_telemetry.yaml
@@ -3,7 +3,6 @@ kind: OpenStackDataPlaneService
 metadata:
   name: telemetry
 spec:
-  label: telemetry
   secrets:
     - ceilometer-compute-config-data
   playbook: osp.edpm.telemetry

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_validate_network.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_validate_network.yaml
@@ -9,5 +9,4 @@ metadata:
     app.kubernetes.io/created-by: dataplane-operator
   name: validate-network
 spec:
-  label: validate-network
   playbook: osp.edpm.validate_network


### PR DESCRIPTION
This field was dropped from the CRD in
da3fea2ca6e0b3e833f6cbcd2950c2ba6420d303 but the actual config/services
resources were not updated.

Signed-off-by: James Slagle <jslagle@redhat.com>
