### PR TITLE
Fix cert secret names

### DIFF
--- a/tests/kuttl/tests/dataplane-deploy-tls-test/01-create-cert-issuers.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-tls-test/01-create-cert-issuers.yaml
@@ -19,4 +19,4 @@ commands:
       oc apply -f ./certs.yaml
       wait_for 100 oc get secret osp-rootca-secret -n openstack
       CA_CRT=$(oc get secret osp-rootca-secret -n openstack -o json|jq -r '.data."ca.crt"')
-      oc create secret generic combined-ca-bundle  -n openstack --from-literal=TLSCABundleFile=$CA_CRT
+      oc create secret generic combined-ca-bundle  -n openstack --from-literal=tls-ca-bundle.pem=$CA_CRT

--- a/tests/kuttl/tests/dataplane-deploy-tls-test/02-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-tls-test/02-assert.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cert-cert-default-service-tls-dnsnames-edpm-compute-0
+  name: cert-default-service-tls-dnsnames-edpm-compute-0
   annotations:
-    cert-manager.io/certificate-name: cert-default-service-tls-dnsnames-edpm-compute-0
+    cert-manager.io/certificate-name: default-service-tls-dnsnames-edpm-compute-0
     cert-manager.io/issuer-group: cert-manager.io
     cert-manager.io/issuer-kind: Issuer
     cert-manager.io/issuer-name: rootca-internal
@@ -19,7 +19,7 @@ kind: TestAssert
 commands:
   - script: |
       template='{{index .metadata.annotations "cert-manager.io/alt-names" }}'
-      names=$(oc get secret cert-cert-default-service-tls-dnsnames-edpm-compute-0 -n openstack -o go-template="$template")
+      names=$(oc get secret cert-default-service-tls-dnsnames-edpm-compute-0 -n openstack -o go-template="$template")
       echo $names > test123.data
       regex="(?=.*(edpm-compute-0\.internalapi\.example\.com))(?=.*(edpm-compute-0\.storage\.example\.com))(?=.*(edpm-compute-0\.tenant\.example\.com))(?=.*(edpm-compute-0\.ctlplane\.example\.com))"
       matches=$(grep -P "$regex" test123.data)

--- a/tests/kuttl/tests/dataplane-deploy-tls-test/03-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-tls-test/03-assert.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cert-cert-custom-service-tls-dns-ips-edpm-compute-0
+  name: cert-custom-service-tls-dns-ips-edpm-compute-0
   annotations:
     cert-manager.io/alt-names: edpm-compute-0.ctlplane.example.com
-    cert-manager.io/certificate-name: cert-custom-service-tls-dns-ips-edpm-compute-0
+    cert-manager.io/certificate-name: custom-service-tls-dns-ips-edpm-compute-0
     cert-manager.io/ip-sans: 192.168.122.100
     cert-manager.io/issuer-group: cert-manager.io
     cert-manager.io/issuer-kind: Issuer
@@ -18,9 +18,9 @@ type: kubernetes.io/tls
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cert-cert-custom-service-tls-dns-edpm-compute-0
+  name: cert-custom-service-tls-dns-edpm-compute-0
   annotations:
-    cert-manager.io/certificate-name: cert-custom-service-tls-dns-edpm-compute-0
+    cert-manager.io/certificate-name: custom-service-tls-dns-edpm-compute-0
     cert-manager.io/issuer-group: cert-manager.io
     cert-manager.io/issuer-kind: Issuer
     cert-manager.io/issuer-name: rootca-internal
@@ -36,7 +36,7 @@ kind: TestAssert
 commands:
   - script: |
       template='{{index .metadata.annotations "cert-manager.io/alt-names" }}'
-      names=$(oc get secret cert-cert-custom-service-tls-dns-edpm-compute-0 -n openstack -o go-template="$template")
+      names=$(oc get secret cert-custom-service-tls-dns-edpm-compute-0 -n openstack -o go-template="$template")
       echo $names > test123.data
       regex="(?=.*(edpm-compute-0\.internalapi\.example\.com))(?=.*(edpm-compute-0\.storage\.example\.com))(?=.*(edpm-compute-0\.tenant\.example\.com))(?=.*(edpm-compute-0\.ctlplane\.example\.com))"
       matches=$(grep -P "$regex" test123.data)


### PR DESCRIPTION
    The code in lib-common already adds "cert-" to the name of the secret
    for the cert.  With our code, we end up with secrets with the name
    "cert-cert-foo" which is redundant and at the least inconsistent with
    the control plane.
    
    Also, it looks like the check for the existence of the secret cert would
    always fail (as it was looking for the wrong secret name), so we fixed it.
    
    Finally, just modified the kuttl test to create a TLS combined-ca-bundle
    more consistent with what we expect from the
    openstack-operator/lib-common.
