### PR TITLE
Initial code for multiple secrets

### DIFF
--- a/api/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
@@ -1916,6 +1916,9 @@ spec:
                 type: object
               preProvisioned:
                 type: boolean
+              secretMaxSize:
+                default: 1048576
+                type: integer
               services:
                 default:
                 - download-cache

--- a/api/v1beta1/openstackdataplanenodeset_types.go
+++ b/api/v1beta1/openstackdataplanenodeset_types.go
@@ -41,6 +41,12 @@ type OpenStackDataPlaneNodeSetSpec struct {
 	// +kubebuilder:validation:Required
 	Nodes map[string]NodeSection `json:"nodes"`
 
+	// SecretMaxSize - Maximum size in bytes of a Kubernetes secret. This size is currently situated around
+	// 1 MiB (nearly 1 MB).
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=1048576
+	SecretMaxSize int `json:"secretMaxSize" yaml:"secretMaxSize"`
+
 	// +kubebuilder:validation:Optional
 	//
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
@@ -1916,6 +1916,9 @@ spec:
                 type: object
               preProvisioned:
                 type: boolean
+              secretMaxSize:
+                default: 1048576
+                type: integer
               services:
                 default:
                 - download-cache

--- a/docs/assemblies/custom_resources.adoc
+++ b/docs/assemblies/custom_resources.adoc
@@ -531,6 +531,11 @@ OpenStackDataPlaneNodeSetSpec defines the desired state of OpenStackDataPlaneNod
 | map[string]<<nodesection,NodeSection>>
 | true
 
+| secretMaxSize
+| SecretMaxSize - Maximum size in bytes of a Kubernetes secret. This size is currently situated around 1 MiB (nearly 1 MB).
+| int
+| true
+
 | preProvisioned
 | \n\nPreProvisioned - Set to true if the nodes have been Pre Provisioned.
 | bool

--- a/docs/assemblies/tls.adoc
+++ b/docs/assemblies/tls.adoc
@@ -145,19 +145,21 @@ When tlsEnabled is set to True on the nodeset, and tlsCert is defined for the da
 service, certificates will be requested from the certmanager issuer designated in the issuer attribute
 (or a default) as described above.
 
-The contents of the certificate (subject name, subject alternative names, etc.) is defined using the
+The contents of the certificate (subject name, subject alternative names, etc.) are defined using the
 contents and issuer attributes as described above.
 
 The certficates are generated when an OpenstackDataplaneDeployment is created, but before any ansible EE
 pods are created.
 
 When the certificates are created, certmanager stores the certificates in secrets which are named
-"cert-<service_name>-<node_name>".  Each secret contains the certificate, key and cacert.
+"cert-<service_name>-<node_name>-#".  The # symbol represents the secret number, beginning with 0.
+Kubernetes distributions, such as Red Hat Openshift Platform, have a maximum secret size of 1 MiB. If the size
+of the created certificates and keys is larger than the maximum size of a single secret, then multiple secrets
+are created. Each secret receives its number and contains the certificate, key and cacert.
 
-The certificates for all the nodes in the nodeset for a given service are all collected in a secret named
-"<nodeset>-<service_name>-certs".  This secret is the one that is mounted in the ansibleEE when
-when addCertMounts is enabled.  The code here is also slated to be refactored soon to ensure that we are
-able to accomodate large deployments.
+The certificates for all the nodes in the node set for a given service are collected in secrets named
+"<nodeset>-<service_name>-certs-#", where the `#` symbol represents the generated secret number that starts at `0`.
+These secrets are mounted in the ansibleEE when `addCertMounts` is enabled.
 
 === How the certificates are transferred to the compute nodes
 
@@ -167,10 +169,9 @@ that this service will be executed before any other services that require TLS ce
 
 The service:
 
-* Mounts the <nodeset>-<service_name>-certs secrets for all services that have tlsCertsEnabled set to true.
-* Calls the osp.edpm.install_certs role which - for each node - copies all the certificates and keys for that
-node to /var/lib/openstack/certs/<service_name>.  The ca cert bundles are copied to
-/var/lib/openstack/cacerts/<service_name>
+* Mounts the `<nodeset>-<service_name>-certs-#` secrets for all services that have `tlsCertsEnabled` set to "true".
+* For each node, calls the `osp.edpm.install_certs` role which copies all the certificates and keys for that node to
+`/var/lib/openstack/certs/<service_name>`.  The cacert bundles are copied to `/var/lib/openstack/cacerts/<service_name>`.
 
 Code should then be added to each service's ansible role to use the certs as needed.  For example, in
 libvirt's role, we move the certs and keys to standard locations on the compute host.  Other roles may

--- a/pkg/deployment/cert.go
+++ b/pkg/deployment/cert.go
@@ -42,11 +42,10 @@ import (
 	"github.com/openstack-k8s-operators/lib-common/modules/common/secret"
 )
 
-// Helper function to create the data structure that will be used to store the secrets.
+// Generates an organized data structure that is leveraged to create the secrets.
 func createSecretsDataStructure(secretMaxSize int,
 	certsData map[string][]byte,
 ) []map[string][]byte {
-
 	ci := []map[string][]byte{}
 
 	keys := []string{}

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -122,7 +122,8 @@ func DefaultDataPlaneNodeSetSpec(nodeSetName string) map[string]interface{} {
 			"deploymentSSHSecret": "dataplane-ansible-ssh-private-key-secret",
 			"ctlplaneInterface":   "172.20.12.1",
 		},
-		"tlsEnabled": true,
+		"secretMaxSize": 1048576,
+		"tlsEnabled":    true,
 	}
 }
 

--- a/tests/functional/openstackdataplanenodeset_controller_test.go
+++ b/tests/functional/openstackdataplanenodeset_controller_test.go
@@ -164,6 +164,7 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 					Env:                nil,
 					PreProvisioned:     true,
 					NetworkAttachments: nil,
+					SecretMaxSize:      1048576,
 					TLSEnabled:         tlsEnabled,
 					Nodes:              map[string]dataplanev1.NodeSection{},
 					Services: []string{
@@ -293,6 +294,7 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 					Env:                nil,
 					PreProvisioned:     true,
 					NetworkAttachments: nil,
+					SecretMaxSize:      1048576,
 					TLSEnabled:         tlsEnabled,
 					Nodes:              map[string]dataplanev1.NodeSection{},
 					Services: []string{
@@ -691,6 +693,7 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 					Env:                nil,
 					PreProvisioned:     true,
 					NetworkAttachments: nil,
+					SecretMaxSize:      1048576,
 					TLSEnabled:         tlsEnabled,
 					Nodes:              map[string]dataplanev1.NodeSection{},
 					Services: []string{

--- a/tests/kuttl/tests/dataplane-deploy-multiple-secrets/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-multiple-secrets/00-assert.yaml
@@ -1,0 +1,386 @@
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneService
+metadata:
+  name: generic-service1
+spec:
+  caCerts: combined-ca-bundle
+  tlsCert:
+    contents:
+    - dnsnames
+  play: |
+    - hosts: localhost
+      gather_facts: no
+      name: kuttl play
+      tasks:
+        - name: Sleep
+          command: sleep 1
+          delegate_to: localhost
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneService
+metadata:
+  name: install-certs-ovr
+spec:
+  addCertMounts: True
+  play: |
+    - hosts: localhost
+      gather_facts: no
+      name: kuttl play
+      tasks:
+        - name: Sleep
+          command: sleep 1
+          delegate_to: localhost
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneNodeSet
+metadata:
+  name: openstack-edpm-tls
+spec:
+  env:
+  - name: ANSIBLE_FORCE_COLOR
+    value: "True"
+  nodes:
+    edpm-compute-0:
+      hostName: edpm-compute-0
+      networks:
+      - name: ctlplane
+        subnetName: subnet1
+        defaultRoute: true
+        fixedIP: 192.168.122.100
+      - name: internalapi
+        subnetName: subnet1
+        fixedIP: 172.17.0.100
+      - name: storage
+        subnetName: subnet1
+        fixedIP: 172.18.0.100
+      - name: tenant
+        subnetName: subnet1
+        fixedIP: 172.19.0.100
+    edpm-compute-1:
+      hostName: edpm-compute-1
+      networks:
+      - name: ctlplane
+        subnetName: subnet1
+        defaultRoute: true
+        fixedIP: 192.168.122.101
+      - name: internalapi
+        subnetName: subnet1
+        fixedIP: 172.17.0.101
+      - name: storage
+        subnetName: subnet1
+        fixedIP: 172.18.0.101
+      - name: tenant
+        subnetName: subnet1
+        fixedIP: 172.19.0.101
+    edpm-compute-2:
+      hostName: edpm-compute-2
+      networks:
+      - name: ctlplane
+        subnetName: subnet1
+        defaultRoute: true
+        fixedIP: 192.168.122.102
+      - name: internalapi
+        subnetName: subnet1
+        fixedIP: 172.17.0.102
+      - name: storage
+        subnetName: subnet1
+        fixedIP: 172.18.0.102
+      - name: tenant
+        subnetName: subnet1
+        fixedIP: 172.19.0.102
+  nodeTemplate:
+    ansible:
+      ansiblePort: 22
+      ansibleUser: cloud-admin
+      ansibleVars:
+        timesync_ntp_servers:
+        - hostname: clock.redhat.com
+        edpm_network_config_hide_sensitive_logs: false
+        edpm_network_config_template: templates/single_nic_vlans/single_nic_vlans.j2
+        edpm_nodes_validation_validate_controllers_icmp: false
+        edpm_nodes_validation_validate_gateway_icmp: false
+        edpm_selinux_mode: enforcing
+        edpm_sshd_allowed_ranges:
+        - 192.168.122.0/24
+        edpm_sshd_configure_firewall: true
+        enable_debug: false
+    ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
+  preProvisioned: true
+  tlsEnabled: true
+  secretMaxSize: 2880
+  services:
+  - install-certs-ovr
+  - generic-service1
+status:
+  conditions:
+  - message: Deployment not started
+    reason: Requested
+    status: "False"
+    type: Ready
+  - message: Deployment not started
+    reason: Requested
+    status: "False"
+    type: DeploymentReady
+  - message: Input data complete
+    reason: Ready
+    status: "True"
+    type: InputReady
+  - message: NodeSetDNSDataReady ready
+    reason: Ready
+    status: "True"
+    type: NodeSetDNSDataReady
+  - message: NodeSetIPReservationReady ready
+    reason: Ready
+    status: "True"
+    type: NodeSetIPReservationReady
+  - message: ServiceAccount created
+    reason: Ready
+    status: "True"
+    type: ServiceAccountReady
+  - message: Setup complete
+    reason: Ready
+    status: "True"
+    type: SetupReady
+---
+apiVersion: network.openstack.org/v1beta1
+kind: IPSet
+metadata:
+  name: edpm-compute-0
+spec:
+  immutable: false
+  networks:
+  - defaultRoute: true
+    name: ctlplane
+    subnetName: subnet1
+  - name: internalapi
+    subnetName: subnet1
+  - name: storage
+    subnetName: subnet1
+  - name: tenant
+    subnetName: subnet1
+status:
+  conditions:
+  - message: Setup complete
+    reason: Ready
+    status: "True"
+    type: Ready
+  - message: Input data complete
+    reason: Ready
+    status: "True"
+    type: InputReady
+  - message: Reservation successful
+    reason: Ready
+    status: "True"
+    type: ReservationReady
+  reservations:
+  - address: 192.168.122.100
+    cidr: 192.168.122.0/24
+    dnsDomain: ctlplane.example.com
+    gateway: 192.168.122.1
+    mtu: 1500
+    network: ctlplane
+    routes:
+    - destination: 0.0.0.0/0
+      nexthop: 192.168.122.1
+    subnet: subnet1
+  - address: 172.17.0.100
+    cidr: 172.17.0.0/24
+    dnsDomain: internalapi.example.com
+    mtu: 1500
+    network: internalapi
+    subnet: subnet1
+    vlan: 20
+  - address: 172.18.0.100
+    cidr: 172.18.0.0/24
+    dnsDomain: storage.example.com
+    mtu: 1500
+    network: storage
+    subnet: subnet1
+    vlan: 21
+  - address: 172.19.0.100
+    cidr: 172.19.0.0/24
+    dnsDomain: tenant.example.com
+    mtu: 1500
+    network: tenant
+    subnet: subnet1
+    vlan: 22
+---
+apiVersion: network.openstack.org/v1beta1
+kind: IPSet
+metadata:
+  name: edpm-compute-1
+spec:
+  immutable: false
+  networks:
+  - defaultRoute: true
+    name: ctlplane
+    subnetName: subnet1
+  - name: internalapi
+    subnetName: subnet1
+  - name: storage
+    subnetName: subnet1
+  - name: tenant
+    subnetName: subnet1
+status:
+  conditions:
+  - message: Setup complete
+    reason: Ready
+    status: "True"
+    type: Ready
+  - message: Input data complete
+    reason: Ready
+    status: "True"
+    type: InputReady
+  - message: Reservation successful
+    reason: Ready
+    status: "True"
+    type: ReservationReady
+  reservations:
+  - address: 192.168.122.101
+    cidr: 192.168.122.0/24
+    dnsDomain: ctlplane.example.com
+    gateway: 192.168.122.1
+    mtu: 1500
+    network: ctlplane
+    routes:
+    - destination: 0.0.0.0/0
+      nexthop: 192.168.122.1
+    subnet: subnet1
+  - address: 172.17.0.101
+    cidr: 172.17.0.0/24
+    dnsDomain: internalapi.example.com
+    mtu: 1500
+    network: internalapi
+    subnet: subnet1
+    vlan: 20
+  - address: 172.18.0.101
+    cidr: 172.18.0.0/24
+    dnsDomain: storage.example.com
+    mtu: 1500
+    network: storage
+    subnet: subnet1
+    vlan: 21
+  - address: 172.19.0.101
+    cidr: 172.19.0.0/24
+    dnsDomain: tenant.example.com
+    mtu: 1500
+    network: tenant
+    subnet: subnet1
+    vlan: 22
+---
+apiVersion: network.openstack.org/v1beta1
+kind: IPSet
+metadata:
+  name: edpm-compute-2
+spec:
+  immutable: false
+  networks:
+  - defaultRoute: true
+    name: ctlplane
+    subnetName: subnet1
+  - name: internalapi
+    subnetName: subnet1
+  - name: storage
+    subnetName: subnet1
+  - name: tenant
+    subnetName: subnet1
+status:
+  conditions:
+  - message: Setup complete
+    reason: Ready
+    status: "True"
+    type: Ready
+  - message: Input data complete
+    reason: Ready
+    status: "True"
+    type: InputReady
+  - message: Reservation successful
+    reason: Ready
+    status: "True"
+    type: ReservationReady
+  reservations:
+  - address: 192.168.122.102
+    cidr: 192.168.122.0/24
+    dnsDomain: ctlplane.example.com
+    gateway: 192.168.122.1
+    mtu: 1500
+    network: ctlplane
+    routes:
+    - destination: 0.0.0.0/0
+      nexthop: 192.168.122.1
+    subnet: subnet1
+  - address: 172.17.0.102
+    cidr: 172.17.0.0/24
+    dnsDomain: internalapi.example.com
+    mtu: 1500
+    network: internalapi
+    subnet: subnet1
+    vlan: 20
+  - address: 172.18.0.102
+    cidr: 172.18.0.0/24
+    dnsDomain: storage.example.com
+    mtu: 1500
+    network: storage
+    subnet: subnet1
+    vlan: 21
+  - address: 172.19.0.102
+    cidr: 172.19.0.0/24
+    dnsDomain: tenant.example.com
+    mtu: 1500
+    network: tenant
+    subnet: subnet1
+    vlan: 22
+---
+apiVersion: network.openstack.org/v1beta1
+kind: DNSData
+metadata:
+  name: openstack-edpm-tls
+spec:
+  dnsDataLabelSelectorValue: dnsdata
+  hosts:
+  - hostnames:
+      - edpm-compute-0.ctlplane.example.com
+    ip: 192.168.122.100
+  - hostnames:
+      - edpm-compute-0.internalapi.example.com
+    ip: 172.17.0.100
+  - hostnames:
+      - edpm-compute-0.storage.example.com
+    ip: 172.18.0.100
+  - hostnames:
+      - edpm-compute-0.tenant.example.com
+    ip: 172.19.0.100
+  - hostnames:
+      - edpm-compute-1.ctlplane.example.com
+    ip: 192.168.122.101
+  - hostnames:
+      - edpm-compute-1.internalapi.example.com
+    ip: 172.17.0.101
+  - hostnames:
+      - edpm-compute-1.storage.example.com
+    ip: 172.18.0.101
+  - hostnames:
+      - edpm-compute-1.tenant.example.com
+    ip: 172.19.0.101
+  - hostnames:
+      - edpm-compute-2.ctlplane.example.com
+    ip: 192.168.122.102
+  - hostnames:
+      - edpm-compute-2.internalapi.example.com
+    ip: 172.17.0.102
+  - hostnames:
+      - edpm-compute-2.storage.example.com
+    ip: 172.18.0.102
+  - hostnames:
+      - edpm-compute-2.tenant.example.com
+    ip: 172.19.0.102
+status:
+  conditions:
+  - message: Setup complete
+    reason: Ready
+    status: "True"
+    type: Ready
+  - message: Input data complete
+    reason: Ready
+    status: "True"
+    type: ServiceConfigReady

--- a/tests/kuttl/tests/dataplane-deploy-multiple-secrets/00-dataplane-create.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-multiple-secrets/00-dataplane-create.yaml
@@ -1,0 +1,131 @@
+apiVersion: network.openstack.org/v1beta1
+kind: DNSMasq
+metadata:
+  name: dnsmasq
+spec:
+  replicas: 1
+  options:
+  - key: server
+    values:
+    - 192.168.122.1
+  debug:
+    service: false
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneService
+metadata:
+  name: generic-service1
+spec:
+  caCerts: combined-ca-bundle
+  tlsCert:
+    contents:
+    - dnsnames
+  play: |
+    - hosts: localhost
+      gather_facts: no
+      name: kuttl play
+      tasks:
+        - name: Sleep
+          command: sleep 1
+          delegate_to: localhost
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneService
+metadata:
+  name: install-certs-ovr
+spec:
+  addCertMounts: True
+  play: |
+    - hosts: localhost
+      gather_facts: no
+      name: kuttl play
+      tasks:
+        - name: Sleep
+          command: sleep 1
+          delegate_to: localhost
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneNodeSet
+metadata:
+  name: openstack-edpm-tls
+spec:
+  env:
+    - name: ANSIBLE_FORCE_COLOR
+      value: "True"
+  services:
+    - install-certs-ovr
+    - generic-service1
+  preProvisioned: true
+  tlsEnabled: true
+  secretMaxSize: 2880
+  nodes:
+    edpm-compute-0:
+      hostName: edpm-compute-0
+      networks:
+      - name: ctlplane
+        subnetName: subnet1
+        defaultRoute: true
+        fixedIP: 192.168.122.100
+      - name: internalapi
+        subnetName: subnet1
+        fixedIP: 172.17.0.100
+      - name: storage
+        subnetName: subnet1
+        fixedIP: 172.18.0.100
+      - name: tenant
+        subnetName: subnet1
+        fixedIP: 172.19.0.100
+    edpm-compute-1:
+      hostName: edpm-compute-1
+      networks:
+      - name: ctlplane
+        subnetName: subnet1
+        defaultRoute: true
+        fixedIP: 192.168.122.101
+      - name: internalapi
+        subnetName: subnet1
+        fixedIP: 172.17.0.101
+      - name: storage
+        subnetName: subnet1
+        fixedIP: 172.18.0.101
+      - name: tenant
+        subnetName: subnet1
+        fixedIP: 172.19.0.101
+    edpm-compute-2:
+      hostName: edpm-compute-2
+      networks:
+      - name: ctlplane
+        subnetName: subnet1
+        defaultRoute: true
+        fixedIP: 192.168.122.102
+      - name: internalapi
+        subnetName: subnet1
+        fixedIP: 172.17.0.102
+      - name: storage
+        subnetName: subnet1
+        fixedIP: 172.18.0.102
+      - name: tenant
+        subnetName: subnet1
+        fixedIP: 172.19.0.102
+  nodeTemplate:
+    ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
+    ansible:
+      ansibleUser: cloud-admin
+      ansiblePort: 22
+      ansibleVars:
+         timesync_ntp_servers:
+           - hostname: clock.redhat.com
+         # edpm_network_config
+         # Default nic config template for a EDPM compute node
+         # These vars are edpm_network_config role vars
+         edpm_network_config_hide_sensitive_logs: false
+         edpm_network_config_template: templates/single_nic_vlans/single_nic_vlans.j2
+         edpm_nodes_validation_validate_controllers_icmp: false
+         edpm_nodes_validation_validate_gateway_icmp: false
+         gather_facts: false
+         enable_debug: false
+         # edpm firewall, change the allowed CIDR if needed
+         edpm_sshd_configure_firewall: true
+         edpm_sshd_allowed_ranges: ['192.168.122.0/24']
+         # SELinux module
+         edpm_selinux_mode: enforcing

--- a/tests/kuttl/tests/dataplane-deploy-multiple-secrets/01-create-cert-issuers.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-multiple-secrets/01-create-cert-issuers.yaml
@@ -1,0 +1,22 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      function wait_for() {
+        timeout=$1
+        shift 1
+        until [ $timeout -le 0 ] || ("$@" &> /dev/null); do
+          echo waiting for "$@"
+          sleep 1
+          timeout=$(( timeout - 1 ))
+        done
+        if [ $timeout -le 0 ]; then
+            return 1
+        fi
+      }
+
+      if oc get secret combined-ca-bundle -n openstack; then  oc delete secret  combined-ca-bundle -n openstack; fi
+      oc apply -f ./certs.yaml
+      wait_for 100 oc get secret osp-rootca-secret -n openstack
+      CA_CRT=$(oc get secret osp-rootca-secret -n openstack -o json|jq -r '.data."ca.crt"')
+      oc create secret generic combined-ca-bundle  -n openstack --from-literal=TLSCABundleFile=$CA_CRT

--- a/tests/kuttl/tests/dataplane-deploy-multiple-secrets/02-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-multiple-secrets/02-assert.yaml
@@ -1,78 +1,109 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cert-tls-dnsnames-edpm-compute-0
+  name: cert-generic-service1-edpm-compute-0
   annotations:
-    cert-manager.io/certificate-name: tls-dnsnames-edpm-compute-0
+    cert-manager.io/certificate-name: generic-service1-edpm-compute-0
     cert-manager.io/issuer-group: cert-manager.io
     cert-manager.io/issuer-kind: Issuer
     cert-manager.io/issuer-name: rootca-internal
   labels:
     hostname: edpm-compute-0
-    osdp-service: tls-dnsnames
+    osdp-service: generic-service1
     osdpns: openstack-edpm-tls
 type: kubernetes.io/tls
 ---
-apiVersion: cert-manager.io/v1
-kind: Certificate
+apiVersion: v1
+kind: Secret
 metadata:
+  name: cert-generic-service1-edpm-compute-1
+  annotations:
+    cert-manager.io/certificate-name: generic-service1-edpm-compute-1
+    cert-manager.io/issuer-group: cert-manager.io
+    cert-manager.io/issuer-kind: Issuer
+    cert-manager.io/issuer-name: rootca-internal
   labels:
-    hostname: edpm-compute-0
-    osdp-service: tls-dnsnames
+    hostname: edpm-compute-1
+    osdp-service: generic-service1
     osdpns: openstack-edpm-tls
-  name: tls-dnsnames-edpm-compute-0
-  namespace: openstack
-  ownerReferences:
-  - apiVersion: dataplane.openstack.org/v1beta1
-    kind: OpenStackDataPlaneNodeSet
-    name: openstack-edpm-tls
-spec:
-  issuerRef:
-    group: cert-manager.io
-    kind: Issuer
-    name: rootca-internal
-  secretName: cert-tls-dnsnames-edpm-compute-0
-  secretTemplate:
-    labels:
-      hostname: edpm-compute-0
-      osdp-service: tls-dnsnames
-      osdpns: openstack-edpm-tls
+type: kubernetes.io/tls
 ---
-# validate the alt-names and usages - which is a list with elements that can be in any order
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cert-generic-service1-edpm-compute-2
+  annotations:
+    cert-manager.io/certificate-name: generic-service1-edpm-compute-2
+    cert-manager.io/issuer-group: cert-manager.io
+    cert-manager.io/issuer-kind: Issuer
+    cert-manager.io/issuer-name: rootca-internal
+  labels:
+    hostname: edpm-compute-2
+    osdp-service: generic-service1
+    osdpns: openstack-edpm-tls
+type: kubernetes.io/tls
+---
+# validate the alt-names - which is a list with elements that can be in any order
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 commands:
   - script: |
-      template='{{index .spec.dnsNames }}'
-      names=$(oc get certificate tls-dnsnames-edpm-compute-0 -n openstack -o go-template="$template")
+      template='{{index .metadata.annotations "cert-manager.io/alt-names" }}'
+      names=$(oc get secret cert-generic-service1-edpm-compute-0 -n openstack -o go-template="$template")
       echo $names > test123.data
       regex="(?=.*(edpm-compute-0\.internalapi\.example\.com))(?=.*(edpm-compute-0\.storage\.example\.com))(?=.*(edpm-compute-0\.tenant\.example\.com))(?=.*(edpm-compute-0\.ctlplane\.example\.com))"
       matches=$(grep -P "$regex" test123.data)
       rm test123.data
       if [ -z "$matches" ]; then
-         echo "bad dnsnames match: $names"
-         exit 1
-      else
-         exit 0
-      fi
-  - script: |
-      template='{{index .spec.usages }}'
-      usages=$(oc get certificate tls-dnsnames-edpm-compute-0 -n openstack -o go-template="$template")
-      echo $usages > test123.data
-      regex="(?=.*(key encipherment))(?=.*(digital signature))(?=.*(server auth))"
-      matches=$(grep -P "$regex" test123.data)
-      rm test123.data
-      if [ -z "$matches" ]; then
-         echo "bad usages match: $usages"
+         echo "bad match: $names"
          exit 1
       else
          exit 0
       fi
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openstack-edpm-tls-generic-service1-certs-0
+  labels:
+    numberOfSecrets: "3"
+    secretNumber: "0"
+  ownerReferences:
+  - apiVersion: dataplane.openstack.org/v1beta1
+    kind: OpenStackDataPlaneNodeSet
+    name: openstack-edpm-tls
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openstack-edpm-tls-generic-service1-certs-1
+  labels:
+    numberOfSecrets: "3"
+    secretNumber: "1"
+  ownerReferences:
+  - apiVersion: dataplane.openstack.org/v1beta1
+    kind: OpenStackDataPlaneNodeSet
+    name: openstack-edpm-tls
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openstack-edpm-tls-generic-service1-certs-2
+  labels:
+    numberOfSecrets: "3"
+    secretNumber: "2"
+  ownerReferences:
+  - apiVersion: dataplane.openstack.org/v1beta1
+    kind: OpenStackDataPlaneNodeSet
+    name: openstack-edpm-tls
+type: Opaque
+---
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  name: install-certs-ovrd-openstack-edpm-tls-openstack-edpm-tls
+  name: install-certs-ovr-openstack-edpm-tls-openstack-edpm-tls
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -84,19 +115,23 @@ spec:
   backoffLimit: 6
   extraMounts:
   - mounts:
-    - mountPath: /var/lib/openstack/certs/tls-dnsnames
-      name: openstack-edpm-tls-tls-dnsnames-certs-0
+    - mountPath: /var/lib/openstack/certs/generic-service1
+      name: openstack-edpm-tls-generic-service1-certs-0
     volumes:
-    - name: openstack-edpm-tls-tls-dnsnames-certs-0
+    - name: openstack-edpm-tls-generic-service1-certs-0
       projected:
         sources:
         - secret:
-            name: openstack-edpm-tls-tls-dnsnames-certs-0
+            name: openstack-edpm-tls-generic-service1-certs-0
+        - secret:
+            name: openstack-edpm-tls-generic-service1-certs-1
+        - secret:
+            name: openstack-edpm-tls-generic-service1-certs-2
   - mounts:
-    - mountPath: /var/lib/openstack/cacerts/tls-dnsnames
-      name: tls-dnsnames-combined-ca-bundle
+    - mountPath: /var/lib/openstack/cacerts/generic-service1
+      name: generic-service1-combined-ca-bundle
     volumes:
-    - name: tls-dnsnames-combined-ca-bundle
+    - name: generic-service1-combined-ca-bundle
       secret:
         secretName: combined-ca-bundle
   - mounts:
@@ -137,7 +172,7 @@ status:
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  name: tls-dnsnames-openstack-edpm-tls-openstack-edpm-tls
+  name: generic-service1-openstack-edpm-tls-openstack-edpm-tls
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1

--- a/tests/kuttl/tests/dataplane-deploy-multiple-secrets/02-dataplane-deploy.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-multiple-secrets/02-dataplane-deploy.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneDeployment
+metadata:
+  name: openstack-edpm-tls
+spec:
+  nodeSets:
+    - openstack-edpm-tls
+  services:
+    - generic-service1

--- a/tests/kuttl/tests/dataplane-deploy-multiple-secrets/certs.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-multiple-secrets/certs.yaml
@@ -1,0 +1,38 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+  namespace: openstack
+spec:
+  selfSigned: {}
+---
+# RootCA Certificate used to sign certificates
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: osp-rootca
+  namespace: openstack
+spec:
+  isCA: true
+  commonName: osp-rootca
+  secretName: osp-rootca-secret
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Issuer that uses the generated CA certificate to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: rootca-internal
+  namespace: openstack
+  labels:
+    osp-rootca-issuer-internal: ""
+spec:
+  ca:
+    secretName: osp-rootca-secret
+---

--- a/tests/kuttl/tests/dataplane-deploy-tls-test/02-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-tls-test/02-assert.yaml
@@ -72,7 +72,7 @@ commands:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: openstack-edpm-tls-tls-dnsnames-certs
+  name: openstack-edpm-tls-default-service-tls-dnsnames-certs-0
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
     kind: OpenStackDataPlaneNodeSet
@@ -94,12 +94,14 @@ spec:
   backoffLimit: 6
   extraMounts:
   - mounts:
-    - mountPath: /var/lib/openstack/certs/tls-dnsnames
-      name: openstack-edpm-tls-tls-dnsnames-certs
+    - mountPath: /var/lib/openstack/certs/default-service-tls-dnsnames
+      name: openstack-edpm-tls-default-service-tls-dnsnames-certs-0
     volumes:
-    - name: openstack-edpm-tls-tls-dnsnames-certs
-      secret:
-        secretName: openstack-edpm-tls-tls-dnsnames-certs
+    - name: openstack-edpm-tls-default-service-tls-dnsnames-certs-0
+      projected:
+        sources:
+        - secret:
+            name: openstack-edpm-tls-default-service-tls-dnsnames-certs-0
   - mounts:
     - mountPath: /var/lib/openstack/cacerts/tls-dnsnames
       name: tls-dnsnames-combined-ca-bundle

--- a/tests/kuttl/tests/dataplane-deploy-tls-test/03-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-tls-test/03-assert.yaml
@@ -116,7 +116,7 @@ commands:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: openstack-edpm-tls-tls-dns-ips-certs
+  name: openstack-edpm-tls-custom-service-tls-dns-ips-certs-0
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
     kind: OpenStackDataPlaneNodeSet
@@ -126,7 +126,7 @@ type: Opaque
 apiVersion: v1
 kind: Secret
 metadata:
-  name: openstack-edpm-tls-custom-tls-dns-certs
+  name: openstack-edpm-tls-custom-service-tls-dns-certs-0
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
     kind: OpenStackDataPlaneNodeSet
@@ -148,12 +148,14 @@ spec:
   backoffLimit: 6
   extraMounts:
   - mounts:
-    - mountPath: /var/lib/openstack/certs/tls-dns-ips
-      name: openstack-edpm-tls-tls-dns-ips-certs
+    - mountPath: /var/lib/openstack/certs/custom-service-tls-dns-ips
+      name: openstack-edpm-tls-custom-service-tls-dns-ips-certs-0
     volumes:
-    - name: openstack-edpm-tls-tls-dns-ips-certs
-      secret:
-        secretName: openstack-edpm-tls-tls-dns-ips-certs
+    - name: openstack-edpm-tls-custom-service-tls-dns-ips-certs-0
+      projected:
+        sources:
+          - secret:
+              name: openstack-edpm-tls-custom-service-tls-dns-ips-certs-0
   - mounts:
     - mountPath: /var/lib/openstack/cacerts/tls-dns-ips
       name: tls-dns-ips-combined-ca-bundle
@@ -162,12 +164,14 @@ spec:
       secret:
         secretName: combined-ca-bundle
   - mounts:
-    - mountPath: /var/lib/openstack/certs/custom-tls-dns
-      name: openstack-edpm-tls-custom-tls-dns-certs
+    - mountPath: /var/lib/openstack/certs/custom-service-tls-dns
+      name: openstack-edpm-tls-custom-service-tls-dns-certs-0
     volumes:
-    - name: openstack-edpm-tls-custom-tls-dns-certs
-      secret:
-        secretName: openstack-edpm-tls-custom-tls-dns-certs
+    - name: openstack-edpm-tls-custom-service-tls-dns-certs-0
+      projected:
+        sources:
+        - secret:
+            name: openstack-edpm-tls-custom-service-tls-dns-certs-0
   - mounts:
     - mountPath: /var/lib/openstack/cacerts/custom-tls-dns
       name: custom-tls-dns-combined-ca-bundle

--- a/tests/kuttl/tests/dataplane-deploy-tls-test/03-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-tls-test/03-assert.yaml
@@ -116,7 +116,7 @@ commands:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: openstack-edpm-tls-custom-service-tls-dns-ips-certs-0
+  name: openstack-edpm-tls-tls-dns-ips-certs-0
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
     kind: OpenStackDataPlaneNodeSet
@@ -126,7 +126,7 @@ type: Opaque
 apiVersion: v1
 kind: Secret
 metadata:
-  name: openstack-edpm-tls-custom-service-tls-dns-certs-0
+  name: openstack-edpm-tls-custom-tls-dns-certs-0
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
     kind: OpenStackDataPlaneNodeSet
@@ -148,14 +148,14 @@ spec:
   backoffLimit: 6
   extraMounts:
   - mounts:
-    - mountPath: /var/lib/openstack/certs/custom-service-tls-dns-ips
-      name: openstack-edpm-tls-custom-service-tls-dns-ips-certs-0
+    - mountPath: /var/lib/openstack/certs/tls-dns-ips
+      name: openstack-edpm-tls-tls-dns-ips-certs-0
     volumes:
-    - name: openstack-edpm-tls-custom-service-tls-dns-ips-certs-0
+    - name: openstack-edpm-tls-tls-dns-ips-certs-0
       projected:
         sources:
-          - secret:
-              name: openstack-edpm-tls-custom-service-tls-dns-ips-certs-0
+        - secret:
+            name: openstack-edpm-tls-tls-dns-ips-certs-0
   - mounts:
     - mountPath: /var/lib/openstack/cacerts/tls-dns-ips
       name: tls-dns-ips-combined-ca-bundle
@@ -164,14 +164,14 @@ spec:
       secret:
         secretName: combined-ca-bundle
   - mounts:
-    - mountPath: /var/lib/openstack/certs/custom-service-tls-dns
-      name: openstack-edpm-tls-custom-service-tls-dns-certs-0
+    - mountPath: /var/lib/openstack/certs/custom-tls-dns
+      name: openstack-edpm-tls-custom-tls-dns-certs-0
     volumes:
-    - name: openstack-edpm-tls-custom-service-tls-dns-certs-0
+    - name: openstack-edpm-tls-custom-tls-dns-certs-0
       projected:
         sources:
         - secret:
-            name: openstack-edpm-tls-custom-service-tls-dns-certs-0
+            name: openstack-edpm-tls-custom-tls-dns-certs-0
   - mounts:
     - mountPath: /var/lib/openstack/cacerts/custom-tls-dns
       name: custom-tls-dns-combined-ca-bundle


### PR DESCRIPTION
This code allows the creation of multiple secrets when either the number of nodes or of services or both of them create more certificates than the maximum size a secret can accommodate.