### PR TITLE
Create a ServiceAccount for use by edpm nodes

### DIFF
--- a/api/v1beta1/common.go
+++ b/api/v1beta1/common.go
@@ -152,4 +152,8 @@ type AnsibleEESpec struct {
 	Env []corev1.EnvVar `json:"env,omitempty"`
 	// DNSConfig for setting dnsservers
 	DNSConfig *corev1.PodDNSConfig `json:"dnsConfig,omitempty"`
+	// ServiceAccountName allows to specify what ServiceAccountName do we want
+	// the ansible execution run with. Without specifying, it will run with
+	// default serviceaccount
+	ServiceAccountName string
 }

--- a/api/v1beta1/openstackdataplanenodeset_types.go
+++ b/api/v1beta1/openstackdataplanenodeset_types.go
@@ -160,6 +160,7 @@ func (instance *OpenStackDataPlaneNodeSet) InitConditions() {
 		condition.UnknownCondition(SetupReadyCondition, condition.InitReason, condition.InitReason),
 		condition.UnknownCondition(NodeSetIPReservationReadyCondition, condition.InitReason, condition.InitReason),
 		condition.UnknownCondition(NodeSetDNSDataReadyCondition, condition.InitReason, condition.InitReason),
+		condition.UnknownCondition(condition.ServiceAccountReadyCondition, condition.InitReason, condition.InitReason),
 	)
 
 	// Only set Baremetal related conditions if we have baremetal hosts included in the
@@ -178,6 +179,7 @@ func (instance OpenStackDataPlaneNodeSet) GetAnsibleEESpec() AnsibleEESpec {
 		NetworkAttachments: instance.Spec.NetworkAttachments,
 		ExtraMounts:        instance.Spec.NodeTemplate.ExtraMounts,
 		Env:                instance.Spec.Env,
+		ServiceAccountName: instance.Name,
 	}
 }
 

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -6,6 +6,82 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - imagestreamimages
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - imagestreammappings
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - imagestreams
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - imagestreams/layers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - imagestreamtags
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - imagetags
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - projects
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - ansibleee.openstack.org
   resources:
   - openstackansibleees
@@ -84,14 +160,6 @@ rules:
   - list
   - patch
   - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get
-  - list
   - watch
 - apiGroups:
   - ""
@@ -197,6 +265,52 @@ rules:
   - update
   - watch
 - apiGroups:
+  - image.openshift.io
+  resources:
+  - imagestreamimages
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - image.openshift.io
+  resources:
+  - imagestreammappings
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - image.openshift.io
+  resources:
+  - imagestreams
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - image.openshift.io
+  resources:
+  - imagestreams/layers
+  verbs:
+  - get
+- apiGroups:
+  - image.openshift.io
+  resources:
+  - imagestreamtags
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - image.openshift.io
+  resources:
+  - imagetags
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - k8s.cni.cncf.io
   resources:
   - network-attachment-definitions
@@ -274,3 +388,38 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - project.openshift.io
+  resources:
+  - projects
+  verbs:
+  - get
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - anyuid
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use

--- a/docs/assemblies/custom_resources.adoc
+++ b/docs/assemblies/custom_resources.adoc
@@ -77,6 +77,11 @@ AnsibleEESpec is a specification of the ansible EE attributes
 | DNSConfig for setting dnsservers
 | *corev1.PodDNSConfig
 | false
+
+| ServiceAccountName
+| ServiceAccountName allows to specify what ServiceAccountName do we want the ansible execution run with. Without specifying, it will run with default serviceaccount
+| string
+| false
 |===
 
 <<custom-resources,Back to Custom Resources>>

--- a/pkg/deployment/inventory.go
+++ b/pkg/deployment/inventory.go
@@ -116,6 +116,9 @@ func GenerateNodeSetInventory(ctx context.Context, helper *helper.Helper,
 		return "", err
 	}
 
+	// add the NodeSet name variable
+	nodeSetGroup.Vars["edpm_nodeset_name"] = instance.Name
+
 	// add TLS ansible variable
 	nodeSetGroup.Vars["edpm_tls_certs_enabled"] = instance.Spec.TLSEnabled
 	if instance.Spec.Tags != nil {

--- a/pkg/util/ansible_execution.go
+++ b/pkg/util/ansible_execution.go
@@ -98,6 +98,9 @@ func AnsibleExecution(
 		if len(aeeSpec.AnsibleSkipTags) > 0 {
 			fmt.Fprintf(&cmdLineArguments, "--skip-tags %s ", aeeSpec.AnsibleSkipTags)
 		}
+		if len(aeeSpec.ServiceAccountName) > 0 {
+			ansibleEE.Spec.ServiceAccountName = aeeSpec.ServiceAccountName
+		}
 		if cmdLineArguments.Len() > 0 {
 			ansibleEE.Spec.CmdLine = strings.TrimSpace(cmdLineArguments.String())
 		}

--- a/tests/kuttl/tests/dataplane-create-test/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-create-test/00-assert.yaml
@@ -103,7 +103,16 @@ status:
     reason: Ready
     status: "True"
     type: InputReady
+  - message: ServiceAccount created
+    reason: Ready
+    status: "True"
+    type: ServiceAccountReady
   - message: Setup complete
     reason: Ready
     status: "True"
     type: SetupReady
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openstack-edpm

--- a/tests/kuttl/tests/dataplane-deploy-global-service-test/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-global-service-test/00-assert.yaml
@@ -111,6 +111,10 @@ status:
     reason: Ready
     status: "True"
     type: InputReady
+  - message: ServiceAccount created
+    reason: Ready
+    status: "True"
+    type: ServiceAccountReady
   - message: Setup complete
     reason: Ready
     status: "True"

--- a/tests/kuttl/tests/dataplane-deploy-global-service-test/01-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-global-service-test/01-assert.yaml
@@ -41,6 +41,10 @@ status:
     reason: Ready
     status: "True"
     type: InputReady
+  - message: ServiceAccount created
+    reason: Ready
+    status: "True"
+    type: ServiceAccountReady
   - message: Setup complete
     reason: Ready
     status: "True"

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/00-assert.yaml
@@ -41,6 +41,10 @@ status:
     reason: Ready
     status: "True"
     type: InputReady
+  - message: ServiceAccount created
+    reason: Ready
+    status: "True"
+    type: ServiceAccountReady
   - message: Setup complete
     reason: Ready
     status: "True"

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/01-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/01-assert.yaml
@@ -40,6 +40,10 @@ status:
     reason: Ready
     status: "True"
     type: InputReady
+  - message: ServiceAccount created
+    reason: Ready
+    status: "True"
+    type: ServiceAccountReady
   - message: Setup complete
     reason: Ready
     status: "True"

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/03-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/03-assert.yaml
@@ -40,6 +40,10 @@ status:
     reason: Ready
     status: "True"
     type: InputReady
+  - message: ServiceAccount created
+    reason: Ready
+    status: "True"
+    type: ServiceAccountReady
   - message: Setup complete
     reason: Ready
     status: "True"

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/04-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/04-assert.yaml
@@ -40,6 +40,10 @@ status:
     reason: Ready
     status: "True"
     type: InputReady
+  - message: ServiceAccount created
+    reason: Ready
+    status: "True"
+    type: ServiceAccountReady
   - message: Setup complete
     reason: Ready
     status: "True"

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/05-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/05-assert.yaml
@@ -42,6 +42,10 @@ status:
     reason: Ready
     status: "True"
     type: InputReady
+  - message: ServiceAccount created
+    reason: Ready
+    status: "True"
+    type: ServiceAccountReady
   - message: Setup complete
     reason: Ready
     status: "True"

--- a/tests/kuttl/tests/dataplane-deploy-tls-test/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-tls-test/00-assert.yaml
@@ -101,6 +101,10 @@ status:
     reason: Ready
     status: "True"
     type: NodeSetIPReservationReady
+  - message: ServiceAccount created
+    reason: Ready
+    status: "True"
+    type: ServiceAccountReady
   - message: Setup complete
     reason: Ready
     status: "True"

--- a/tests/kuttl/tests/dataplane-service-custom-image/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-service-custom-image/00-assert.yaml
@@ -29,6 +29,10 @@ status:
     reason: Ready
     status: "True"
     type: InputReady
+  - message: ServiceAccount created
+    reason: Ready
+    status: "True"
+    type: ServiceAccountReady
   - message: Setup complete
     reason: Ready
     status: "True"

--- a/tests/kuttl/tests/dataplane-with-ipam-create-test/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-with-ipam-create-test/00-assert.yaml
@@ -90,6 +90,10 @@ status:
     reason: Ready
     status: "True"
     type: NodeSetIPReservationReady
+  - message: ServiceAccount created
+    reason: Ready
+    status: "True"
+    type: ServiceAccountReady
   - message: Setup complete
     reason: Ready
     status: "True"


### PR DESCRIPTION
Adds creating a ServiceAccount to the NodeSet reconciliation, with a
name equal to the NodeSet. The ClusterRole registry-viewer is set in a
RoleBinding (also named the same as the NodeSet) for the ServiceAccount.

The ServiceAccount will be used by EDPM nodes to podman login to the OCP
default internal registry to allow for pulling images. This allows for
mirroring images from their source (quay.io, etc) to the OCP internal
registry.

Since the ServiceAccount is named the same as the NodeSet, an additional
ansible variable is added to the inventory as edpm_nodeset_name. The
login tasks will use the value of this variable as the username.

The OpenStackAnsibleEE.Spec.ServiceAccountName field is set on all
OpenStackAnsibleEE's for the NodeSet so that the ServiceAccount
credentials are injected into the ansible pods. Ansible content will
then take over running the podman login command with the ServiceAccount
credentials on the EDPM nodes.

Signed-off-by: James Slagle <jslagle@redhat.com>

Related to https://github.com/openstack-k8s-operators/edpm-ansible/pull/579
