### PR TITLE
Adding subscription-manager InitContainer

### DIFF
--- a/api/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
@@ -1054,6 +1054,8 @@ spec:
                       - subnetName
                       type: object
                     type: array
+                  subscriptionManagerSecret:
+                    type: string
                   userData:
                     properties:
                       name:

--- a/api/v1beta1/common.go
+++ b/api/v1beta1/common.go
@@ -87,6 +87,13 @@ type NodeTemplate struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:io.kubernetes:Secret"}
 	AnsibleSSHPrivateKeySecret string `json:"ansibleSSHPrivateKeySecret"`
 
+	// SubscriptionManagerSecret Name of a subscription-manager secret containing
+	// username and password for registering to node.
+	// <https://kubernetes.io/docs/concepts/configuration/secret/#basic-authentication-secret>
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:io.kubernetes:Secret"}
+	SubscriptionManagerSecret string `json:"subscriptionManagerSecret,omitempty"`
+
 	// Networks - Instance networks
 	// +kubebuilder:validation:Optional
 	Networks []infranetworkv1.IPSetNetwork `json:"networks,omitempty"`
@@ -127,11 +134,13 @@ type AnsibleEESpec struct {
 	// AnsibleSkipTags for ansible execution
 	AnsibleSkipTags string `json:"ansibleSkipTags,omitempty"`
 	// ExtraVars for ansible execution
-	ExtraVars map[string]json.RawMessage  `json:"extraVars,omitempty"`
+	ExtraVars map[string]json.RawMessage `json:"extraVars,omitempty"`
 	// ExtraMounts containing files which can be mounted into an Ansible Execution Pod
 	ExtraMounts []storage.VolMounts `json:"extraMounts,omitempty"`
 	// Env is a list containing the environment variables to pass to the pod
 	Env []corev1.EnvVar `json:"env,omitempty"`
 	// DNSConfig for setting dnsservers
 	DNSConfig *corev1.PodDNSConfig `json:"dnsConfig,omitempty"`
+	// SubscriptionManagerSecret for ansible execution
+	SubscriptionManagerSecret string `json:"subscriptionManagerSecret,omitempty"`
 }

--- a/api/v1beta1/openstackdataplanenodeset_types.go
+++ b/api/v1beta1/openstackdataplanenodeset_types.go
@@ -175,9 +175,10 @@ func (instance *OpenStackDataPlaneNodeSet) InitConditions() {
 // GetAnsibleEESpec - get the fields that will be passed to AEE
 func (instance OpenStackDataPlaneNodeSet) GetAnsibleEESpec() AnsibleEESpec {
 	return AnsibleEESpec{
-		NetworkAttachments: instance.Spec.NetworkAttachments,
-		ExtraMounts:        instance.Spec.NodeTemplate.ExtraMounts,
-		Env:                instance.Spec.Env,
+		NetworkAttachments:        instance.Spec.NetworkAttachments,
+		ExtraMounts:               instance.Spec.NodeTemplate.ExtraMounts,
+		Env:                       instance.Spec.Env,
+		SubscriptionManagerSecret: instance.Spec.NodeTemplate.SubscriptionManagerSecret,
 	}
 }
 

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
@@ -1054,6 +1054,8 @@ spec:
                       - subnetName
                       type: object
                     type: array
+                  subscriptionManagerSecret:
+                    type: string
                   userData:
                     properties:
                       name:

--- a/config/manifests/bases/dataplane-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/dataplane-operator.clusterserviceversion.yaml
@@ -49,13 +49,18 @@ spec:
         path: nodeTemplate.ansibleSSHPrivateKeySecret
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes:Secret
+      - description: SubscriptionManagerSecret Name of a subscription-manager secret
+          containing username and password for registering to node. <https://kubernetes.io/docs/concepts/configuration/secret/#basic-authentication-secret>
+        displayName: Subscription Manager Secret
+        path: nodeTemplate.subscriptionManagerSecret
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:Secret
       - description: AnsiblePort SSH port for Ansible connection
         displayName: Ansible Port
         path: nodes.ansible.ansiblePort
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
-      - description: PreProvisioned - Whether the nodes are actually pre-provisioned
-          (True) or should be preprovisioned (False)
+      - description: PreProvisioned - Set to true if the nodes have been Pre Provisioned.
         displayName: Pre Provisioned
         path: preProvisioned
         x-descriptors:

--- a/docs/assemblies/custom_resources.adoc
+++ b/docs/assemblies/custom_resources.adoc
@@ -76,6 +76,11 @@ AnsibleEESpec is a specification of the ansible EE attributes
 | DNSConfig for setting dnsservers
 | *corev1.PodDNSConfig
 | false
+
+| subscriptionManagerSecret
+| SubscriptionManagerSecret for ansible execution
+| string
+| false
 |===
 
 <<custom-resources,Back to Custom Resources>>
@@ -169,6 +174,11 @@ NodeTemplate is a specification of the node attributes that override top level a
 | AnsibleSSHPrivateKeySecret Name of a private SSH key secret containing private SSH key for connecting to node. The named secret must be of the form: Secret.data.ssh-privatekey: +++<base64 encoded="" private="" key="" contents="">+++<https://kubernetes.io/docs/concepts/configuration/secret/#ssh-authentication-secrets>+++</base64>+++
 | string
 | true
+
+| subscriptionManagerSecret
+| SubscriptionManagerSecret Name of a subscription-manager secret containing username and password for registering to node. https://kubernetes.io/docs/concepts/configuration/secret/#basic-authentication-secret
+| string
+| false
 
 | networks
 | Networks - Instance networks

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -19,4 +19,16 @@ package util
 const (
 	// AnsibleExecutionServiceNameLen max length for the ansibleEE service name prefix
 	AnsibleExecutionServiceNameLen = 53
+	SubscriptionPlay               = `
+- hosts: all
+  strategy: linear
+  tasks:
+    - name: subscription-manager register
+      become: true
+      no_log: true
+      when: ansible_facts.distribution == 'RedHat'
+      ansible.builtin.shell: |
+        set -euxo pipefail
+        subscription-manager register --username {{ lookup('ansible.builtin.env', 'SECRET_USERNAME') }} --password {{ lookup('ansible.builtin.env', 'SECRET_PASSWORD') }}
+`
 )


### PR DESCRIPTION
Provide a way to execute `subscription-manager register` without exposing the password at `edpm_bootstrap_command`