### PR TITLE
Ensure golangci-lint runs on all files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,5 +63,5 @@ repos:
 - repo: https://github.com/golangci/golangci-lint
   rev: v1.55.2
   hooks:
-    - id: golangci-lint
+    - id: golangci-lint-full
       args: ["-v"]

--- a/controllers/openstackdataplanenodeset_controller.go
+++ b/controllers/openstackdataplanenodeset_controller.go
@@ -416,7 +416,7 @@ func checkDeployment(helper *helper.Helper,
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *OpenStackDataPlaneNodeSetReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
+func (r *OpenStackDataPlaneNodeSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	dnsMasqWatcher := handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
 		Log := r.GetLogger(ctx)
 		result := []reconcile.Request{}
@@ -429,7 +429,7 @@ func (r *OpenStackDataPlaneNodeSetReconciler) SetupWithManager(ctx context.Conte
 		listOpts := []client.ListOption{
 			client.InNamespace(obj.GetNamespace()),
 		}
-		if err := r.Client.List(context.Background(), nodeSets, listOpts...); err != nil {
+		if err := r.Client.List(ctx, nodeSets, listOpts...); err != nil {
 			Log.Error(err, "Unable to retrieve OpenStackDataPlaneNodeSetList %w")
 			return nil
 		}

--- a/main.go
+++ b/main.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"context"
 	"crypto/tls"
 	"flag"
 	"os"
@@ -135,7 +134,7 @@ func main() {
 		Client:  mgr.GetClient(),
 		Scheme:  mgr.GetScheme(),
 		Kclient: kclient,
-	}).SetupWithManager(context.Background(), mgr); err != nil {
+	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OpenStackDataPlaneNodeSet")
 		os.Exit(1)
 	}

--- a/pkg/deployment/cert.go
+++ b/pkg/deployment/cert.go
@@ -59,7 +59,7 @@ func EnsureTLSCerts(ctx context.Context, helper *helper.Helper,
 		var issuer *certmgrv1.Issuer
 		var issuerLabelSelector map[string]string
 		var certName string
-		var certSecret *corev1.Secret = nil
+		var certSecret *corev1.Secret
 		var err error
 		var result ctrl.Result
 

--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -89,7 +89,7 @@ func (d *Deployer) Deploy(services []string) (*ctrl.Result, error) {
 		// Add certMounts if TLS is enabled
 		if d.NodeSet.Spec.TLSEnabled {
 			if foundService.Spec.AddCertMounts {
-				d.AeeSpec, err = d.addCertMounts(foundService, services)
+				d.AeeSpec, err = d.addCertMounts(services)
 			}
 			if err != nil {
 				return &ctrl.Result{}, err
@@ -198,7 +198,6 @@ func (d *Deployer) ConditionalDeploy(
 
 // addCertMounts adds the cert mounts to the aeeSpec for the install-certs service
 func (d *Deployer) addCertMounts(
-	certService dataplanev1.OpenStackDataPlaneService,
 	services []string,
 ) (*dataplanev1.AnsibleEESpec, error) {
 	log := d.Helper.GetLogger()

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -3,7 +3,7 @@ package functional
 import (
 	"fmt"
 
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega" //revive:disable:dot-imports
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,7 +26,7 @@ var DefaultEdpmServiceAnsibleVarList = []string{
 	"edpm_ovn_bgp_agent_image",
 }
 
-var CustomEdpmServiceDomainTag string = "test-image:latest"
+var CustomEdpmServiceDomainTag = "test-image:latest"
 
 // Create OpenstackDataPlaneNodeSet in k8s and test that no errors occur
 func CreateDataplaneNodeSet(name types.NamespacedName, spec map[string]interface{}) *unstructured.Unstructured {

--- a/tests/functional/openstackdataplanedeployment_controller_test.go
+++ b/tests/functional/openstackdataplanedeployment_controller_test.go
@@ -4,11 +4,13 @@ import (
 	"fmt"
 	"os"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
 	dataplanev1 "github.com/openstack-k8s-operators/dataplane-operator/api/v1beta1"
 	dataplaneutil "github.com/openstack-k8s-operators/dataplane-operator/pkg/util"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
+
+	//revive:disable-next-line:dot-imports
 	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
 	ansibleeev1 "github.com/openstack-k8s-operators/openstack-ansibleee-operator/api/v1beta1"
 	baremetalv1 "github.com/openstack-k8s-operators/openstack-baremetal-operator/api/v1beta1"
@@ -317,7 +319,6 @@ var _ = Describe("Dataplane Deployment Test", func() {
 				Namespace: namespace,
 			}
 
-			nodeSetAlpha := dataplanev1.OpenStackDataPlaneNodeSet{}
 			baremetalAlpha := baremetalv1.OpenStackBaremetalSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      alphaNodeSetName.Name,
@@ -325,7 +326,6 @@ var _ = Describe("Dataplane Deployment Test", func() {
 				},
 			}
 
-			nodeSetBeta := dataplanev1.OpenStackDataPlaneNodeSet{}
 			baremetalBeta := baremetalv1.OpenStackBaremetalSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      betaNodeSetName.Name,
@@ -343,8 +343,8 @@ var _ = Describe("Dataplane Deployment Test", func() {
 			}
 			th.CreateConfigMap(ovnConfigMapName, mapData)
 
-			nodeSetAlpha = *GetDataplaneNodeSet(alphaNodeSetName)
-			nodeSetBeta = *GetDataplaneNodeSet(betaNodeSetName)
+			nodeSetAlpha := *GetDataplaneNodeSet(alphaNodeSetName)
+			nodeSetBeta := *GetDataplaneNodeSet(betaNodeSetName)
 
 			// Set baremetal provisioning conditions to True
 			Eventually(func(g Gomega) {

--- a/tests/functional/openstackdataplanenodeset_controller_test.go
+++ b/tests/functional/openstackdataplanenodeset_controller_test.go
@@ -20,10 +20,12 @@ import (
 	"fmt"
 	"os"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
 	dataplanev1 "github.com/openstack-k8s-operators/dataplane-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
+
+	//revive:disable-next-line:dot-imports
 	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
 	baremetalv1 "github.com/openstack-k8s-operators/openstack-baremetal-operator/api/v1beta1"
 	"gopkg.in/yaml.v3"

--- a/tests/functional/openstackdataplanenodeset_webhook_test.go
+++ b/tests/functional/openstackdataplanenodeset_webhook_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 

--- a/tests/functional/service_test.go
+++ b/tests/functional/service_test.go
@@ -18,8 +18,8 @@ package functional
 import (
 	"os"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
 	"k8s.io/apimachinery/pkg/types"
 )
 

--- a/tests/functional/suite_test.go
+++ b/tests/functional/suite_test.go
@@ -24,8 +24,8 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -47,6 +47,7 @@ import (
 	aee "github.com/openstack-k8s-operators/openstack-ansibleee-operator/api/v1beta1"
 	baremetalv1 "github.com/openstack-k8s-operators/openstack-baremetal-operator/api/v1beta1"
 
+	//revive:disable-next-line:dot-imports
 	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
 	test "github.com/openstack-k8s-operators/lib-common/modules/test"
 	//+kubebuilder:scaffold:imports
@@ -174,7 +175,7 @@ var _ = BeforeSuite(func() {
 		Client:  k8sManager.GetClient(),
 		Scheme:  k8sManager.GetScheme(),
 		Kclient: kclient,
-	}).SetupWithManager(context.Background(), k8sManager)
+	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&controllers.OpenStackDataPlaneDeploymentReconciler{


### PR DESCRIPTION
This needed the following adjustments:
* ignore revive dot-imports rule as ginkgo and gomega import cannot be
  ignored
* various small lint fixes
