### PR TITLE
Allow client auth in cert usage

### DIFF
--- a/pkg/deployment/cert.go
+++ b/pkg/deployment/cert.go
@@ -121,8 +121,14 @@ func EnsureTLSCerts(ctx context.Context, helper *helper.Helper,
 			return &result, err
 		}
 
+		// TODO: paramaterize usage
 		certSecret, result, err = GetTLSNodeCert(ctx, helper, instance, certName,
-			issuer.Name, labels, hosts, ips, nil)
+			issuer.Name, labels, hosts, ips, []certmgrv1.KeyUsage{
+				certmgrv1.UsageDigitalSignature,
+				certmgrv1.UsageKeyEncipherment,
+				certmgrv1.UsageServerAuth,
+				certmgrv1.UsageClientAuth,
+			})
 
 		// handle cert request errors
 		if (err != nil) || (result != ctrl.Result{}) {


### PR DESCRIPTION
Should be a param but for now continue hardcoding since both ovn and libvirt need client auth.