### PR TITLE
Don't try to mount all nodeset keys/inventories in AEE

### DIFF
--- a/controllers/openstackdataplanedeployment_controller.go
+++ b/controllers/openstackdataplanedeployment_controller.go
@@ -216,13 +216,13 @@ func (r *OpenStackDataPlaneDeploymentReconciler) Reconcile(ctx context.Context, 
 	shouldRequeue := false
 	haveError := false
 
-	globalInventorySecrets := []string{}
+	globalInventorySecrets := map[string]string{}
 	globalSSHKeySecrets := map[string]string{}
 
 	// Gathering individual inventory and ssh secrets for later use
 	for _, nodeSet := range nodeSets.Items {
 		// Add inventory secret to list of inventories for global services
-		globalInventorySecrets = append(globalInventorySecrets, fmt.Sprintf("dataplanenodeset-%s", nodeSet.Name))
+		globalInventorySecrets[nodeSet.Name] = fmt.Sprintf("dataplanenodeset-%s", nodeSet.Name)
 		globalSSHKeySecrets[nodeSet.Name] = nodeSet.Spec.NodeTemplate.AnsibleSSHPrivateKeySecret
 	}
 

--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -45,7 +45,7 @@ type Deployer struct {
 	Deployment                  *dataplanev1.OpenStackDataPlaneDeployment
 	Status                      *dataplanev1.OpenStackDataPlaneDeploymentStatus
 	AeeSpec                     *dataplanev1.AnsibleEESpec
-	InventorySecrets            []string
+	InventorySecrets            map[string]string
 	AnsibleSSHPrivateKeySecrets map[string]string
 }
 

--- a/tests/functional/openstackdataplanedeployment_controller_test.go
+++ b/tests/functional/openstackdataplanedeployment_controller_test.go
@@ -371,7 +371,6 @@ var _ = Describe("Dataplane Deployment Test", func() {
 				}
 				service := GetService(dataplaneServiceName)
 				executionName := dataplaneutil.GetAnsibleExecutionNamePrefix(service)
-
 				//Retrieve service AnsibleEE and set JobStatus to Successful
 				Eventually(func(g Gomega) {
 					// Make an AnsibleEE name for each service
@@ -379,12 +378,12 @@ var _ = Describe("Dataplane Deployment Test", func() {
 						Name:      fmt.Sprintf("%s-%s", executionName, dataplaneMultiNodesetDeploymentName.Name),
 						Namespace: dataplaneMultiNodesetDeploymentName.Namespace,
 					}
-					ansibleEE := &ansibleeev1.OpenStackAnsibleEE{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      ansibleeeName.Name,
-							Namespace: ansibleeeName.Namespace,
-						}}
-					g.Expect(th.K8sClient.Get(th.Ctx, ansibleeeName, ansibleEE)).To(Succeed())
+					ansibleEE := GetAnsibleee(ansibleeeName)
+					if service.Spec.DeployOnAllNodeSets {
+						g.Expect(ansibleEE.Spec.ExtraMounts[0].Volumes).Should(HaveLen(4))
+					} else {
+						g.Expect(ansibleEE.Spec.ExtraMounts[0].Volumes).Should(HaveLen(2))
+					}
 					ansibleEE.Status.JobStatus = ansibleeev1.JobStatusSucceeded
 					g.Expect(th.K8sClient.Status().Update(th.Ctx, ansibleEE)).To(Succeed())
 					if service.Spec.DeployOnAllNodeSets {
@@ -408,12 +407,12 @@ var _ = Describe("Dataplane Deployment Test", func() {
 						Name:      fmt.Sprintf("%s-%s", executionName, dataplaneMultiNodesetDeploymentName.Name),
 						Namespace: dataplaneMultiNodesetDeploymentName.Namespace,
 					}
-					ansibleEE := &ansibleeev1.OpenStackAnsibleEE{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      ansibleeeName.Name,
-							Namespace: ansibleeeName.Namespace,
-						}}
-					g.Expect(th.K8sClient.Get(th.Ctx, ansibleeeName, ansibleEE)).To(Succeed())
+					ansibleEE := GetAnsibleee(ansibleeeName)
+					if service.Spec.DeployOnAllNodeSets {
+						g.Expect(ansibleEE.Spec.ExtraMounts[0].Volumes).Should(HaveLen(4))
+					} else {
+						g.Expect(ansibleEE.Spec.ExtraMounts[0].Volumes).Should(HaveLen(2))
+					}
 					ansibleEE.Status.JobStatus = ansibleeev1.JobStatusSucceeded
 					g.Expect(th.K8sClient.Status().Update(th.Ctx, ansibleEE)).To(Succeed())
 				}, th.Timeout, th.Interval).Should(Succeed())


### PR DESCRIPTION
It tries to mount keys and inventories for all nodesets with the same mount path and fails when there are multiple nodesets in a deployment.

Jira: https://issues.redhat.com/browse/OSPRH-5371