### PR TITLE
Fix Deployment statuses

### DIFF
--- a/controllers/openstackdataplanedeployment_controller.go
+++ b/controllers/openstackdataplanedeployment_controller.go
@@ -230,10 +230,10 @@ func (r *OpenStackDataPlaneDeploymentReconciler) Reconcile(ctx context.Context, 
 		if err := deployment.CheckGlobalServiceExecutionConsistency(ctx, helper, nodeSets.Items); err != nil {
 			util.LogErrorForObject(helper, err, "OpenStackDeployment error for deployment", instance)
 			instance.Status.Conditions.MarkFalse(
-				condition.ReadyCondition,
+				condition.DeploymentReadyCondition,
 				condition.ErrorReason,
 				condition.SeverityError,
-				condition.DeploymentReadyErrorMessage,
+				dataplanev1.ServiceErrorMessage,
 				err.Error())
 			return ctrl.Result{}, err
 		}
@@ -291,10 +291,10 @@ func (r *OpenStackDataPlaneDeploymentReconciler) Reconcile(ctx context.Context, 
 			util.LogErrorForObject(helper, err, fmt.Sprintf("OpenStackDeployment error for NodeSet %s", nodeSet.Name), instance)
 			haveError = true
 			instance.Status.Conditions.MarkFalse(
-				condition.ReadyCondition,
+				condition.DeploymentReadyCondition,
 				condition.ErrorReason,
 				condition.SeverityError,
-				dataplanev1.DataPlaneNodeSetErrorMessage,
+				condition.DeploymentReadyErrorMessage,
 				err.Error())
 		}
 

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/05-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/05-assert.yaml
@@ -1,0 +1,91 @@
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneNodeSet
+metadata:
+  name: edpm-compute-no-nodes
+  namespace: openstack
+spec:
+  services:
+  - download-cache
+  - bootstrap
+  - configure-network
+  - validate-network
+  - install-os
+  - configure-os
+  - run-os
+  - install-certs
+  - ovn
+  - neutron-metadata
+  - neutron-ovn
+  - neutron-sriov
+  - neutron-dhcp
+  - libvirt
+  - nova
+  env:
+  - name: ANSIBLE_FORCE_COLOR
+    value: "True"
+  nodes: {}
+  nodeTemplate:
+    ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
+status:
+  conditions:
+  - message: Deployment in progress
+    reason: Requested
+    status: "False"
+    type: Ready
+  - message: Deployment in progress
+    reason: Requested
+    status: "False"
+    type: DeploymentReady
+  - message: Input data complete
+    reason: Ready
+    status: "True"
+    type: InputReady
+  - message: Setup complete
+    reason: Ready
+    status: "True"
+    type: SetupReady
+  configMapHashes:
+    ovncontroller-config: n56h54bh9bhcbh65ch9fhdh66dh95h5dch569h678h7fh599h7ch84h597h59h54dh58dhf6h66bh565h4hc4h587h645hd7hcch5d8h5f4h55cq
+  secretHashes:
+    neutron-dhcp-agent-neutron-config: n68h676h98h689hd4h575h5dbh694h6fh688h57h665h5c5h56dh5ddh65bh5d7h5cdh644hb8h8fh5d9h5b9h555h9ch56dh5fh6chd4h5c5h5c5h68q
+    neutron-ovn-agent-neutron-config: n5f4h89hb8h645h55bh657h9fh5d9h5c6h595h9dh667h5f4hfhffh7fh685h56ch57fh679h5ddh5ddh95h696hbch5c7h669h84h54dh685hfh85q
+    neutron-ovn-metadata-agent-neutron-config: n68dh585h666h5c4h568hf7h65fh695h649hb9h657h5f6h548h679h77h5b4h664h8h5b8h654h5hf5h674h664h545h74h58ch57ch8ch56h54fh5ddq
+    neutron-sriov-agent-neutron-config: n685h567h697h5bch8ch5cfh87h698h658h684h8h99h5dch5c5h699h79hb5h87h66dh664h546h586h7bh56fh5d6h5d4h566h56bh87h678h696h56cq
+    nova-cell1-compute-config: n89hd6h5h545h644h58h556hd9h5c5h598hd4h7bh5f9h5bdh649hb5h99h686h677h8ch575h665h574h587h5b6h5ddh8fh687h9bh657h675h97q
+    nova-metadata-neutron-config: n7fh696h674h5b9h68dh77h677h5c5hd9h5dbh89h646h696h65ch64bh86hd8h56h78h558h5h5c7h87h86h5bh5bch78h6ch5cbh54fh56fhfdq
+    nova-migration-ssh-key: n64dh97h54dhffh65fh577h59bh664hbch54dhcbh547hdbhdch655hd9h675h5d4h67dh5ch67bh64h5fdh5c8h5cdh66bh5f5h58dhcbh9bh66bhd4q
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneDeployment
+metadata:
+  name: edpm-compute-no-nodes-non-existent-service
+  namespace: openstack
+spec:
+  nodeSets:
+    - edpm-compute-no-nodes
+  servicesOverride:
+    - this-service-does-not-exist
+status:
+  conditions:
+  - message: Deployment error occurred OpenStackDataPlaneService.dataplane.openstack.org
+      "this-service-does-not-exist" not found
+    reason: Error
+    severity: Error
+    status: "False"
+    type: Ready
+  - message: Deployment error occurred OpenStackDataPlaneService.dataplane.openstack.org
+      "this-service-does-not-exist" not found
+    reason: Error
+    severity: Error
+    status: "False"
+    type: DeploymentReady
+  - message: Setup complete
+    reason: Ready
+    status: "True"
+    type: InputReady
+  nodeSetConditions:
+    edpm-compute-no-nodes:
+    - message: Init
+      reason: Init
+      status: Unknown
+      type: Deployment ready for NodeSet

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/05-dataplane-deploy-service-not-found.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/05-dataplane-deploy-service-not-found.yaml
@@ -1,0 +1,9 @@
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneDeployment
+metadata:
+  name: edpm-compute-no-nodes-non-existent-service
+spec:
+  nodeSets:
+    - edpm-compute-no-nodes
+  servicesOverride:
+    - this-service-does-not-exist


### PR DESCRIPTION
`condition.ReadyCondition` gets reset at: https://github.com/openstack-k8s-operators/dataplane-operator/blob/785c63db66eb0fab41cdeffd4af897f99b8859a8/controllers/openstackdataplanedeployment_controller.go#L99-L101

For properly update the status we should use `condition.DeploymentReadyCondition` for deployment statuses