### PR TITLE
Selecting service by nodeset

### DIFF
--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -148,7 +148,7 @@ func (d *Deployer) ConditionalDeploy(
 	}
 
 	if nsConditions.IsFalse(readyCondition) {
-		ansibleEE, err := dataplaneutil.GetAnsibleExecution(d.Ctx, d.Helper, d.Deployment, foundService.Name)
+		ansibleEE, err := dataplaneutil.GetAnsibleExecution(d.Ctx, d.Helper, d.Deployment, foundService.Name, d.NodeSet.Name)
 		if err != nil {
 			// Return nil if we don't have AnsibleEE available yet
 			if k8s_errors.IsNotFound(err) {

--- a/tests/functional/openstackdataplanedeployment_controller_test.go
+++ b/tests/functional/openstackdataplanedeployment_controller_test.go
@@ -7,7 +7,6 @@ import (
 	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
 	. "github.com/onsi/gomega"    //revive:disable:dot-imports
 	dataplanev1 "github.com/openstack-k8s-operators/dataplane-operator/api/v1beta1"
-	dataplaneutil "github.com/openstack-k8s-operators/dataplane-operator/pkg/util"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 
 	//revive:disable-next-line:dot-imports
@@ -168,20 +167,9 @@ var _ = Describe("Dataplane Deployment Test", func() {
 					Namespace: namespace,
 				}
 				service := GetService(dataplaneServiceName)
-				executionName := dataplaneutil.GetAnsibleExecutionNamePrefix(service)
 				//Retrieve service AnsibleEE and set JobStatus to Successful
 				Eventually(func(g Gomega) {
-					// Make an AnsibleEE name for each service
-					ansibleeeName := types.NamespacedName{
-						Name:      fmt.Sprintf("%s-%s", executionName, dataplaneDeploymentName.Name),
-						Namespace: dataplaneDeploymentName.Namespace,
-					}
-					ansibleEE := &ansibleeev1.OpenStackAnsibleEE{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      ansibleeeName.Name,
-							Namespace: ansibleeeName.Namespace,
-						}}
-					g.Expect(th.K8sClient.Get(th.Ctx, ansibleeeName, ansibleEE)).To(Succeed())
+					ansibleEE := GetAnsibleeeByLabel(dataplaneNodeSetName.Name, dataplaneDeploymentName, dataplaneServiceName.Name)
 					ansibleEE.Status.JobStatus = ansibleeev1.JobStatusSucceeded
 
 					g.Expect(th.K8sClient.Status().Update(th.Ctx, ansibleEE)).To(Succeed())
@@ -370,15 +358,10 @@ var _ = Describe("Dataplane Deployment Test", func() {
 					Namespace: namespace,
 				}
 				service := GetService(dataplaneServiceName)
-				executionName := dataplaneutil.GetAnsibleExecutionNamePrefix(service)
 				//Retrieve service AnsibleEE and set JobStatus to Successful
 				Eventually(func(g Gomega) {
-					// Make an AnsibleEE name for each service
-					ansibleeeName := types.NamespacedName{
-						Name:      fmt.Sprintf("%s-%s", executionName, dataplaneMultiNodesetDeploymentName.Name),
-						Namespace: dataplaneMultiNodesetDeploymentName.Namespace,
-					}
-					ansibleEE := GetAnsibleee(ansibleeeName)
+					ansibleEE := GetAnsibleeeByLabel(
+						alphaNodeSetName.Name, dataplaneMultiNodesetDeploymentName, dataplaneServiceName.Name)
 					if service.Spec.DeployOnAllNodeSets {
 						g.Expect(ansibleEE.Spec.ExtraMounts[0].Volumes).Should(HaveLen(4))
 					} else {
@@ -399,15 +382,10 @@ var _ = Describe("Dataplane Deployment Test", func() {
 					Namespace: namespace,
 				}
 				service := GetService(dataplaneServiceName)
-				executionName := dataplaneutil.GetAnsibleExecutionNamePrefix(service)
 				//Retrieve service AnsibleEE and set JobStatus to Successful
 				Eventually(func(g Gomega) {
-					// Make an AnsibleEE name for each service
-					ansibleeeName := types.NamespacedName{
-						Name:      fmt.Sprintf("%s-%s", executionName, dataplaneMultiNodesetDeploymentName.Name),
-						Namespace: dataplaneMultiNodesetDeploymentName.Namespace,
-					}
-					ansibleEE := GetAnsibleee(ansibleeeName)
+					ansibleEE := GetAnsibleeeByLabel(
+						betaNodeSetName.Name, dataplaneMultiNodesetDeploymentName, dataplaneServiceName.Name)
 					if service.Spec.DeployOnAllNodeSets {
 						g.Expect(ansibleEE.Spec.ExtraMounts[0].Volumes).Should(HaveLen(4))
 					} else {

--- a/tests/kuttl/tests/dataplane-deploy-global-service-test/01-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-global-service-test/01-assert.yaml
@@ -50,7 +50,7 @@ apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
   generation: 1
-  name: custom-global-service-edpm-compute-global-service
+  generateName: custom-global-service-edpm-deploy-global-service-edpm-compute-global-service-
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -114,7 +114,7 @@ status:
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  name: download-cache-edpm-compute-global-service
+  generateName: download-cache-edpm-deploy-global-service-edpm-compute-global-service-
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -164,7 +164,7 @@ status:
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  name: bootstrap-edpm-compute-global-service
+  generateName: bootstrap-edpm-deploy-global-service-edpm-compute-global-service-
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -215,7 +215,7 @@ status:
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  name: configure-network-edpm-compute-global-service
+  generateName: configure-network-edpm-deploy-global-service-edpm-compute-global-service-
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -265,7 +265,7 @@ status:
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  name: validate-network-edpm-compute-global-service
+  generateName: validate-network-edpm-deploy-global-service-edpm-compute-global-service-
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -315,7 +315,7 @@ status:
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  name: install-os-edpm-compute-global-service
+  generateName: install-os-edpm-deploy-global-service-edpm-compute-global-service-
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -366,7 +366,7 @@ apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
   generation: 1
-  name: configure-os-edpm-compute-global-service
+  generateName: configure-os-edpm-deploy-global-service-edpm-compute-global-service-
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -416,7 +416,7 @@ status:
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  name: run-os-edpm-compute-global-service
+  generateName: run-os-edpm-deploy-global-service-edpm-compute-global-service-
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -466,7 +466,7 @@ status:
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  name: install-certs-edpm-compute-global-service
+  generateName: install-certs-edpm-deploy-global-service-edpm-compute-global-service-
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -517,7 +517,7 @@ apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
   generation: 1
-  name: ovn-edpm-compute-global-service
+  generateName: ovn-edpm-deploy-global-service-edpm-compute-global-service-
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -579,7 +579,7 @@ apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
   generation: 1
-  name: neutron-metadata-edpm-compute-global-service
+  generateName: neutron-metadata-edpm-deploy-global-service-edpm-compute-global-service-
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -670,7 +670,7 @@ apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
   generation: 1
-  name: neutron-ovn-edpm-compute-global-service
+  generateName: neutron-ovn-edpm-deploy-global-service-edpm-compute-global-service-
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -732,7 +732,7 @@ apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
   generation: 1
-  name: neutron-sriov-edpm-compute-global-service
+  generateName: neutron-sriov-edpm-deploy-global-service-edpm-compute-global-service-
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -794,7 +794,7 @@ apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
   generation: 1
-  name: neutron-dhcp-edpm-compute-global-service
+  generateName: neutron-dhcp-edpm-deploy-global-service-edpm-compute-global-service-
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -855,7 +855,7 @@ status:
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  name: libvirt-edpm-compute-global-service
+  generateName: libvirt-edpm-deploy-global-service-edpm-compute-global-service-
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -907,8 +907,14 @@ status:
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  name: nova-edpm-compute-global-service
+  generateName: nova-edpm-deploy-global-service-edpm-compute-global-service-
   namespace: openstack
+  ownerReferences:
+  - apiVersion: dataplane.openstack.org/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: OpenStackDataPlaneDeployment
+    name: edpm-compute-global-service
 spec:
   backoffLimit: 6
   envConfigMapName: openstack-aee-default-env

--- a/tests/kuttl/tests/dataplane-deploy-global-service-test/01-dataplane-deploy.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-global-service-test/01-dataplane-deploy.yaml
@@ -2,7 +2,7 @@
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneDeployment
 metadata:
-  name: edpm-compute-global-service
+  name: edpm-deploy-global-service
 spec:
   nodeSets:
     - edpm-compute-global-service

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/01-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/01-assert.yaml
@@ -58,7 +58,7 @@ status:
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  name: download-cache-edpm-compute-no-nodes
+  generateName: download-cache-edpm-compute-no-nodes-edpm-compute-no-nodes-
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -108,7 +108,7 @@ status:
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  name: bootstrap-edpm-compute-no-nodes
+  generateName: bootstrap-edpm-compute-no-nodes-edpm-compute-no-nodes-
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -161,7 +161,7 @@ status:
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  name: configure-network-edpm-compute-no-nodes
+  generateName: configure-network-edpm-compute-no-nodes-edpm-compute-no-nodes-
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -211,7 +211,7 @@ status:
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  name: validate-network-edpm-compute-no-nodes
+  generateName: validate-network-edpm-compute-no-nodes-edpm-compute-no-nodes-
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -261,7 +261,7 @@ status:
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  name: install-os-edpm-compute-no-nodes
+  generateName: install-os-edpm-compute-no-nodes-edpm-compute-no-nodes-
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -312,7 +312,7 @@ apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
   generation: 1
-  name: configure-os-edpm-compute-no-nodes
+  generateName: configure-os-edpm-compute-no-nodes-edpm-compute-no-nodes-
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -362,7 +362,7 @@ status:
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  name: run-os-edpm-compute-no-nodes
+  generateName: run-os-edpm-compute-no-nodes-edpm-compute-no-nodes-
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -412,7 +412,7 @@ status:
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  name: install-certs-edpm-compute-no-nodes
+  generateName: install-certs-edpm-compute-no-nodes-edpm-compute-no-nodes-
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -463,7 +463,7 @@ apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
   generation: 1
-  name: ovn-edpm-compute-no-nodes
+  generateName: ovn-edpm-compute-no-nodes-edpm-compute-no-nodes-
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -525,7 +525,7 @@ apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
   generation: 1
-  name: neutron-metadata-edpm-compute-no-nodes
+  generateName: neutron-metadata-edpm-compute-no-nodes-edpm-compute-no-nodes-
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -616,7 +616,7 @@ apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
   generation: 1
-  name: neutron-ovn-edpm-compute-no-nodes
+  generateName: neutron-ovn-edpm-compute-no-nodes-edpm-compute-no-nodes-
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -678,7 +678,7 @@ apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
   generation: 1
-  name: neutron-sriov-edpm-compute-no-nodes
+  generateName: neutron-sriov-edpm-compute-no-nodes-edpm-compute-no-nodes-
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -740,7 +740,7 @@ apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
   generation: 1
-  name: neutron-dhcp-edpm-compute-no-nodes
+  generateName: neutron-dhcp-edpm-compute-no-nodes-edpm-compute-no-nodes-
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -801,7 +801,7 @@ status:
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  name: libvirt-edpm-compute-no-nodes
+  generateName: libvirt-edpm-compute-no-nodes-edpm-compute-no-nodes-
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -853,7 +853,7 @@ status:
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  name: nova-edpm-compute-no-nodes
+  generateName: nova-edpm-compute-no-nodes-edpm-compute-no-nodes-
   namespace: openstack
 spec:
   backoffLimit: 6

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/02-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/02-assert.yaml
@@ -2,7 +2,7 @@ apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
   generation: 1
-  name: custom-service-override-edpm-compute-no-nodes-services-override
+  generateName: custom-service-override-edpm-compute-no-nodes-services-override-edpm-compute-no-nodes-
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/04-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/04-assert.yaml
@@ -45,7 +45,7 @@ status:
     status: "True"
     type: SetupReady
   configMapHashes:
-    ovncontroller-config: n56h54bh9bhcbh65ch9fhdh66dh95h5dch569h678h7fh599h7ch84h597h59h54dh58dhf6h66bh565h4hc4h587h645hd7hcch5d8h5f4h55cq
+    ovncontroller-config: n647h6fh674h55fh56ch5bh68bh5fdh8dh59ch58dhdch59ch646h568h675h99h66bh59bhcch5b4h589h674h568hbch84h554h95h6dhc4hbh699q
   secretHashes:
     neutron-dhcp-agent-neutron-config: n68h676h98h689hd4h575h5dbh694h6fh688h57h665h5c5h56dh5ddh65bh5d7h5cdh644hb8h8fh5d9h5b9h555h9ch56dh5fh6chd4h5c5h5c5h68q
     neutron-ovn-agent-neutron-config: n5f4h89hb8h645h55bh657h9fh5d9h5c6h595h9dh667h5f4hfhffh7fh685h56ch57fh679h5ddh5ddh95h696hbch5c7h669h84h54dh685hfh85q
@@ -59,7 +59,7 @@ apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
   generation: 1
-  name: ovn-edpm-compute-no-nodes
+  generateName: ovn-edpm-compute-no-nodes-edpm-compute-no-nodes-
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1

--- a/tests/kuttl/tests/dataplane-deploy-tls-test/02-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-tls-test/02-assert.yaml
@@ -83,8 +83,10 @@ apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
   labels:
-    osdpd: openstack-edpm-tls-deployment
-  name: default-install-certs-override-openstack-edpm-tls-deployment
+    openstackdataplanedeployment: openstack-edpm-tls-deployment
+    openstackdataplanenodeset: openstack-edpm-tls
+    openstackdataplaneservice: default-service-tls-dnsnames
+  generateName: default-service-tls-dnsnames-openstack-edpm-tls-deployment-openstack-edpm-tls-
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -148,8 +150,10 @@ apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
   labels:
-    osdpd: openstack-edpm-tls-deployment
-  name: default-service-tls-dnsnames-openstack-edpm-tls-deployment
+    openstackdataplanedeployment: openstack-edpm-tls-deployment
+    openstackdataplanenodeset: openstack-edpm-tls
+    openstackdataplaneservice: default-install-certs-override
+  generateName: default-install-certs-override-openstack-edpm-tls-deployment-openstack-edpm-tls-
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1

--- a/tests/kuttl/tests/dataplane-deploy-tls-test/03-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-tls-test/03-assert.yaml
@@ -137,8 +137,8 @@ apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
   labels:
-    osdpd: openstack-edpm-tls-services-override
-  name: install-certs-override-openstack-edpm-tls-services-override
+    openstackdataplanedeployment: openstack-edpm-tls-services-override
+  generateName: install-certs-override-openstack-edpm-tls-services-override-openstack-edpm-tls-
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -216,8 +216,8 @@ apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
   labels:
-    osdpd: openstack-edpm-tls-services-override
-  name: custom-service-tls-dns-ips-openstack-edpm-tls-services-override
+    openstackdataplanedeployment: openstack-edpm-tls-services-override
+  generateName: custom-service-tls-dns-ips-openstack-edpm-tls-services-override-openstack-edpm-tls-
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -265,8 +265,8 @@ apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
   labels:
-    osdpd: openstack-edpm-tls-services-override
-  name: custom-service-tls-dns-openstack-edpm-tls-services-override
+    openstackdataplanedeployment: openstack-edpm-tls-services-override
+  generateName: custom-service-tls-dns-openstack-edpm-tls-services-override-openstack-edpm-tls-
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1

--- a/tests/kuttl/tests/dataplane-extramounts/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-extramounts/00-assert.yaml
@@ -23,7 +23,7 @@ spec:
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  name: test-service-edpm-extramounts
+  generateName: test-service-edpm-extramounts-edpm-extramounts-
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1

--- a/tests/kuttl/tests/dataplane-service-config/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-service-config/00-assert.yaml
@@ -2,7 +2,7 @@
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  name: kuttl-service-edpm-compute-no-nodes
+  generateName: kuttl-service-edpm-compute-no-nodes-edpm-compute-no-nodes-
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1

--- a/tests/kuttl/tests/dataplane-service-custom-image/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-service-custom-image/00-assert.yaml
@@ -37,7 +37,7 @@ status:
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  name: custom-image-service-edpm-compute-no-nodes
+  generateName: custom-image-service-edpm-compute-no-nodes-edpm-no-nodes-custom-service-
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1


### PR DESCRIPTION
Rather than identifying service ansibleee resources by combination of deployment and nodeset, this PR sets prefix of service and nodeset names, appended with randomly generated string. While this approach does not guarantee true unique identification of Ansibleee resources, it makes namespace collisions substantially less likely. 
Furthermore, it will allow us to retrieve information about previously used ansibleee resources, provided they were not deleted, for purposes of diagnostics.

The service resources will now also be labeled with identification of nodeset they were applied to.