### PR TITLE
Add owner to cert request

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/openstack-k8s-operators/dataplane-operator/api v0.0.0-00010101000000-000000000000
 	github.com/openstack-k8s-operators/infra-operator/apis v0.3.1-0.20240310120756-8b35d05cd24e
 	github.com/openstack-k8s-operators/lib-common/modules/ansible v0.3.1-0.20240306153230-dc65ab49ebc0
-	github.com/openstack-k8s-operators/lib-common/modules/certmanager v0.0.0-20240306153230-dc65ab49ebc0
+	github.com/openstack-k8s-operators/lib-common/modules/certmanager v0.0.0-20240314165949-fec16b14c33b
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240306153230-dc65ab49ebc0
 	github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240306153230-dc65ab49ebc0
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240306153230-dc65ab49ebc0

--- a/go.sum
+++ b/go.sum
@@ -96,8 +96,8 @@ github.com/openstack-k8s-operators/infra-operator/apis v0.3.1-0.20240310120756-8
 github.com/openstack-k8s-operators/infra-operator/apis v0.3.1-0.20240310120756-8b35d05cd24e/go.mod h1:qKuzDDDMlAmJn4JWPoUeBEzpAia7J17++hhzR0oPv88=
 github.com/openstack-k8s-operators/lib-common/modules/ansible v0.3.1-0.20240306153230-dc65ab49ebc0 h1:3A1nj/nDRHDzfSPM7d5YXkAXQrn5c+FepzjAzQ679Q0=
 github.com/openstack-k8s-operators/lib-common/modules/ansible v0.3.1-0.20240306153230-dc65ab49ebc0/go.mod h1:tP+nxk95PisCKJaXE/an2igG9lluxuOVhdmV9WtkR2s=
-github.com/openstack-k8s-operators/lib-common/modules/certmanager v0.0.0-20240306153230-dc65ab49ebc0 h1:5uv4LtcThS4hcfuecTJj+rXifbsPGcKRiyTvFXyDgNU=
-github.com/openstack-k8s-operators/lib-common/modules/certmanager v0.0.0-20240306153230-dc65ab49ebc0/go.mod h1:GGbtUK5VQ/BHIT3n0ia31bzNJaQIAANhzT/nC6pygbQ=
+github.com/openstack-k8s-operators/lib-common/modules/certmanager v0.0.0-20240314165949-fec16b14c33b h1:Umvz8j2ySAAo7CbDIigCU9QcU1jywkkofNpjF4i3uKk=
+github.com/openstack-k8s-operators/lib-common/modules/certmanager v0.0.0-20240314165949-fec16b14c33b/go.mod h1:RV+rktKvegjYBQLuBKt8ax29UMqsU/D/sfSjQPr6XIs=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240306153230-dc65ab49ebc0 h1:1Q/9F3SAKvLN9vX+YxwaEB0WvBekj9eakQPoQbI1K6w=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240306153230-dc65ab49ebc0/go.mod h1:R2plZL2JdwDMJwv9+pkPmCB1Mww81J75G0MxRzi2Kug=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240306153230-dc65ab49ebc0 h1:9o0nbX808wq5ksmDCPG9tiuv9tYukCDpxXAAVsT55Nc=

--- a/pkg/deployment/cert.go
+++ b/pkg/deployment/cert.go
@@ -185,7 +185,7 @@ func GetTLSNodeCert(ctx context.Context, helper *helper.Helper,
 			Usages:      usages,
 		}
 
-		certSecret, result, err = certmanager.EnsureCert(ctx, helper, request)
+		certSecret, result, err = certmanager.EnsureCert(ctx, helper, request, instance)
 		if err != nil {
 			return nil, ctrl.Result{}, err
 		} else if (result != ctrl.Result{}) {

--- a/tests/kuttl/tests/dataplane-deploy-tls-test/02-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-tls-test/02-assert.yaml
@@ -24,7 +24,7 @@ metadata:
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
-    kind: OpenStackDataPlaneDeployment
+    kind: OpenStackDataPlaneNodeSet
     name: openstack-edpm-tls
 spec:
   issuerRef:

--- a/tests/kuttl/tests/dataplane-deploy-tls-test/03-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-tls-test/03-assert.yaml
@@ -26,8 +26,8 @@ metadata:
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
-    kind: OpenStackDataPlaneDeployment
-    name: openstack-edpm-tls-ovrd
+    kind: OpenStackDataPlaneNodeSet
+    name: openstack-edpm-tls
 spec:
   dnsNames:
   - edpm-compute-0.ctlplane.example.com
@@ -68,8 +68,8 @@ metadata:
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
-    kind: OpenStackDataPlaneDeployment
-    name: openstack-edpm-tls-ovrd
+    kind: OpenStackDataPlaneNodeSet
+    name: openstack-edpm-tls
 spec:
   issuerRef:
     group: cert-manager.io


### PR DESCRIPTION
Right now, the owner of the certificate object defaults to whatever object created it - which in this case is the deployment.  This of course means that the Certificate is deleted when the deployment is deleted.

The owner of the certificate should instead be set to the nodeset.

Depends-On: https://github.com/openstack-k8s-operators/lib-common/pull/476