### PR TITLE
Make OpenStackDataPlaneDeployment Spec immutable

### DIFF
--- a/api/bases/dataplane.openstack.org_openstackdataplanedeployments.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplanedeployments.yaml
@@ -68,6 +68,9 @@ spec:
             - deploymentRequeueTime
             - nodeSets
             type: object
+            x-kubernetes-validations:
+            - message: OpenStackDataPlaneDeployment Spec is immutable
+              rule: self == oldSelf
           status:
             properties:
               conditions:

--- a/api/v1beta1/openstackdataplanedeployment_types.go
+++ b/api/v1beta1/openstackdataplanedeployment_types.go
@@ -91,6 +91,7 @@ type OpenStackDataPlaneDeployment struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="OpenStackDataPlaneDeployment Spec is immutable"
 	Spec   OpenStackDataPlaneDeploymentSpec   `json:"spec,omitempty"`
 	Status OpenStackDataPlaneDeploymentStatus `json:"status,omitempty"`
 }

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanedeployments.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanedeployments.yaml
@@ -68,6 +68,9 @@ spec:
             - deploymentRequeueTime
             - nodeSets
             type: object
+            x-kubernetes-validations:
+            - message: OpenStackDataPlaneDeployment Spec is immutable
+              rule: self == oldSelf
           status:
             properties:
               conditions:


### PR DESCRIPTION
This way one can't change the deployment to add new nodesets when deployment is in progress or update
an already deployed deployment. Though we can use the rbac roles to not allow update/patch, this kind of ensures that without the need for an webhook.