### PR TITLE
Fix how we use labels and aee name for services

### DIFF
--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -149,7 +149,8 @@ func (d *Deployer) ConditionalDeploy(
 	}
 
 	if nsConditions.IsFalse(readyCondition) {
-		ansibleEE, err := dataplaneutil.GetAnsibleExecution(d.Ctx, d.Helper, d.Deployment, foundService.Name)
+		_, labelSelector := dataplaneutil.GetAnsibleExecutionNameAndLabel(&foundService, d.Deployment, d.NodeSet)
+		ansibleEE, err := dataplaneutil.GetAnsibleExecution(d.Ctx, d.Helper, d.Deployment, labelSelector)
 		if err != nil {
 			// Return nil if we don't have AnsibleEE available yet
 			if k8s_errors.IsNotFound(err) {

--- a/pkg/deployment/service.go
+++ b/pkg/deployment/service.go
@@ -51,7 +51,7 @@ func (d *Deployer) DeployService(foundService dataplanev1.OpenStackDataPlaneServ
 		d.AnsibleSSHPrivateKeySecrets,
 		d.InventorySecrets,
 		d.AeeSpec,
-		d.NodeSet.Name)
+		d.NodeSet)
 
 	if err != nil {
 		d.Helper.GetLogger().Error(err, fmt.Sprintf("Unable to execute Ansible for %s", foundService.Name))

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -19,4 +19,5 @@ package util
 const (
 	// AnsibleExecutionServiceNameLen max length for the ansibleEE service name prefix
 	AnsibleExecutionServiceNameLen = 53
+	AnsibleExcecutionNameLabelLen  = 63
 )

--- a/tests/functional/openstackdataplanedeployment_controller_test.go
+++ b/tests/functional/openstackdataplanedeployment_controller_test.go
@@ -168,12 +168,14 @@ var _ = Describe("Dataplane Deployment Test", func() {
 					Namespace: namespace,
 				}
 				service := GetService(dataplaneServiceName)
-				executionName := dataplaneutil.GetAnsibleExecutionNamePrefix(service)
+				deployment := GetDataplaneDeployment(dataplaneDeploymentName)
 				//Retrieve service AnsibleEE and set JobStatus to Successful
+				aeeName, _ := dataplaneutil.GetAnsibleExecutionNameAndLabel(
+					service, deployment, &nodeSet)
 				Eventually(func(g Gomega) {
 					// Make an AnsibleEE name for each service
 					ansibleeeName := types.NamespacedName{
-						Name:      fmt.Sprintf("%s-%s", executionName, dataplaneDeploymentName.Name),
+						Name:      aeeName,
 						Namespace: dataplaneDeploymentName.Namespace,
 					}
 					ansibleEE := &ansibleeev1.OpenStackAnsibleEE{
@@ -371,12 +373,14 @@ var _ = Describe("Dataplane Deployment Test", func() {
 					Namespace: namespace,
 				}
 				service := GetService(dataplaneServiceName)
-				executionName := dataplaneutil.GetAnsibleExecutionNamePrefix(service)
+				deployment := GetDataplaneDeployment(dataplaneMultiNodesetDeploymentName)
+				aeeName, _ := dataplaneutil.GetAnsibleExecutionNameAndLabel(
+					service, deployment, &nodeSetAlpha)
 				//Retrieve service AnsibleEE and set JobStatus to Successful
 				Eventually(func(g Gomega) {
 					// Make an AnsibleEE name for each service
 					ansibleeeName := types.NamespacedName{
-						Name:      fmt.Sprintf("%s-%s", executionName, dataplaneMultiNodesetDeploymentName.Name),
+						Name:      aeeName,
 						Namespace: dataplaneMultiNodesetDeploymentName.Namespace,
 					}
 					ansibleEE := GetAnsibleee(ansibleeeName)
@@ -401,12 +405,15 @@ var _ = Describe("Dataplane Deployment Test", func() {
 					Namespace: namespace,
 				}
 				service := GetService(dataplaneServiceName)
-				executionName := dataplaneutil.GetAnsibleExecutionNamePrefix(service)
+				deployment := GetDataplaneDeployment(dataplaneMultiNodesetDeploymentName)
+				aeeName, _ := dataplaneutil.GetAnsibleExecutionNameAndLabel(
+					service, deployment, &nodeSetBeta)
+
 				//Retrieve service AnsibleEE and set JobStatus to Successful
 				Eventually(func(g Gomega) {
 					// Make an AnsibleEE name for each service
 					ansibleeeName := types.NamespacedName{
-						Name:      fmt.Sprintf("%s-%s", executionName, dataplaneMultiNodesetDeploymentName.Name),
+						Name:      aeeName,
 						Namespace: dataplaneMultiNodesetDeploymentName.Namespace,
 					}
 					ansibleEE := GetAnsibleee(ansibleeeName)

--- a/tests/kuttl/tests/dataplane-deploy-global-service-test/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-global-service-test/00-assert.yaml
@@ -1,7 +1,7 @@
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneNodeSet
 metadata:
-  name: edpm-compute-global-service
+  name: edpm-compute-global
   namespace: openstack
 spec:
   preProvisioned: true

--- a/tests/kuttl/tests/dataplane-deploy-global-service-test/00-dataplane-create.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-global-service-test/00-dataplane-create.yaml
@@ -115,7 +115,7 @@ data:
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneNodeSet
 metadata:
-  name: edpm-compute-global-service
+  name: edpm-compute-global
 spec:
   preProvisioned: true
   services:

--- a/tests/kuttl/tests/dataplane-deploy-global-service-test/01-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-global-service-test/01-assert.yaml
@@ -1,7 +1,7 @@
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneNodeSet
 metadata:
-  name: edpm-compute-global-service
+  name: edpm-compute-global
   namespace: openstack
 spec:
   services:
@@ -50,14 +50,14 @@ apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
   generation: 1
-  name: custom-global-service-edpm-compute-global-service
+  name: custom-global-service-edpm-compute-global
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
     blockOwnerDeletion: true
     controller: true
     kind: OpenStackDataPlaneDeployment
-    name: edpm-compute-global-service
+    name: edpm-compute-global
 spec:
   backoffLimit: 6
   env:
@@ -66,25 +66,25 @@ spec:
   envConfigMapName: openstack-aee-default-env
   extraMounts:
   - mounts:
-    - mountPath: /runner/env/ssh_key/ssh_key_edpm-compute-global-service
-      name: ssh-key-edpm-compute-global-service
-      subPath: ssh_key_edpm-compute-global-service
+    - mountPath: /runner/env/ssh_key/ssh_key_edpm-compute-global
+      name: ssh-key-edpm-compute-global
+      subPath: ssh_key_edpm-compute-global
     - mountPath: /runner/inventory/inventory-0
       name: inventory-0
       subPath: inventory-0
     volumes:
-    - name: ssh-key-edpm-compute-global-service
+    - name: ssh-key-edpm-compute-global
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key_edpm-compute-global-service
+          path: ssh_key_edpm-compute-global
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory-0
       secret:
         items:
         - key: inventory
           path: inventory-0
-        secretName: dataplanenodeset-edpm-compute-global-service
+        secretName: dataplanenodeset-edpm-compute-global
   extraVars:
     edpm_override_hosts: all
   name: openstackansibleee
@@ -114,14 +114,14 @@ status:
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  name: download-cache-edpm-compute-global-service
+  name: download-cache-edpm-compute-global-edpm-compute-global
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
     blockOwnerDeletion: true
     controller: true
     kind: OpenStackDataPlaneDeployment
-    name: edpm-compute-global-service
+    name: edpm-compute-global
 spec:
   backoffLimit: 6
   extraMounts:
@@ -144,7 +144,7 @@ spec:
         items:
         - key: inventory
           path: inventory
-        secretName: dataplanenodeset-edpm-compute-global-service
+        secretName: dataplanenodeset-edpm-compute-global
   name: openstackansibleee
   restartPolicy: Never
   playbook: osp.edpm.download_cache
@@ -164,14 +164,14 @@ status:
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  name: bootstrap-edpm-compute-global-service
+  name: bootstrap-edpm-compute-global-edpm-compute-global
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
     blockOwnerDeletion: true
     controller: true
     kind: OpenStackDataPlaneDeployment
-    name: edpm-compute-global-service
+    name: edpm-compute-global
 spec:
   backoffLimit: 6
   extraMounts:
@@ -194,7 +194,7 @@ spec:
         items:
         - key: inventory
           path: inventory
-        secretName: dataplanenodeset-edpm-compute-global-service
+        secretName: dataplanenodeset-edpm-compute-global
   name: openstackansibleee
   restartPolicy: Never
   playbook: osp.edpm.bootstrap
@@ -215,14 +215,14 @@ status:
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  name: configure-network-edpm-compute-global-service
+  name: configure-network-edpm-compute-global-edpm-compute-global
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
     blockOwnerDeletion: true
     controller: true
     kind: OpenStackDataPlaneDeployment
-    name: edpm-compute-global-service
+    name: edpm-compute-global
 spec:
   backoffLimit: 6
   extraMounts:
@@ -245,7 +245,7 @@ spec:
         items:
         - key: inventory
           path: inventory
-        secretName: dataplanenodeset-edpm-compute-global-service
+        secretName: dataplanenodeset-edpm-compute-global
   name: openstackansibleee
   restartPolicy: Never
   playbook: osp.edpm.configure_network
@@ -265,14 +265,14 @@ status:
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  name: validate-network-edpm-compute-global-service
+  name: validate-network-edpm-compute-global-edpm-compute-global
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
     blockOwnerDeletion: true
     controller: true
     kind: OpenStackDataPlaneDeployment
-    name: edpm-compute-global-service
+    name: edpm-compute-global
 spec:
   backoffLimit: 6
   extraMounts:
@@ -295,7 +295,7 @@ spec:
         items:
         - key: inventory
           path: inventory
-        secretName: dataplanenodeset-edpm-compute-global-service
+        secretName: dataplanenodeset-edpm-compute-global
   name: openstackansibleee
   restartPolicy: Never
   playbook: osp.edpm.validate_network
@@ -315,14 +315,14 @@ status:
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  name: install-os-edpm-compute-global-service
+  name: install-os-edpm-compute-global-edpm-compute-global
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
     blockOwnerDeletion: true
     controller: true
     kind: OpenStackDataPlaneDeployment
-    name: edpm-compute-global-service
+    name: edpm-compute-global
 spec:
   backoffLimit: 6
   extraMounts:
@@ -345,7 +345,7 @@ spec:
         items:
         - key: inventory
           path: inventory
-        secretName: dataplanenodeset-edpm-compute-global-service
+        secretName: dataplanenodeset-edpm-compute-global
   name: openstackansibleee
   restartPolicy: Never
   playbook: osp.edpm.install_os
@@ -366,14 +366,14 @@ apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
   generation: 1
-  name: configure-os-edpm-compute-global-service
+  name: configure-os-edpm-compute-global-edpm-compute-global
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
     blockOwnerDeletion: true
     controller: true
     kind: OpenStackDataPlaneDeployment
-    name: edpm-compute-global-service
+    name: edpm-compute-global
 spec:
   backoffLimit: 6
   extraMounts:
@@ -396,7 +396,7 @@ spec:
         items:
         - key: inventory
           path: inventory
-        secretName: dataplanenodeset-edpm-compute-global-service
+        secretName: dataplanenodeset-edpm-compute-global
   name: openstackansibleee
   restartPolicy: Never
   playbook: osp.edpm.configure_os
@@ -416,14 +416,14 @@ status:
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  name: run-os-edpm-compute-global-service
+  name: run-os-edpm-compute-global-edpm-compute-global
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
     blockOwnerDeletion: true
     controller: true
     kind: OpenStackDataPlaneDeployment
-    name: edpm-compute-global-service
+    name: edpm-compute-global
 spec:
   backoffLimit: 6
   extraMounts:
@@ -446,7 +446,7 @@ spec:
         items:
         - key: inventory
           path: inventory
-        secretName: dataplanenodeset-edpm-compute-global-service
+        secretName: dataplanenodeset-edpm-compute-global
   name: openstackansibleee
   restartPolicy: Never
   playbook: osp.edpm.run_os
@@ -466,14 +466,14 @@ status:
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  name: install-certs-edpm-compute-global-service
+  name: install-certs-edpm-compute-global-edpm-compute-global
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
     blockOwnerDeletion: true
     controller: true
     kind: OpenStackDataPlaneDeployment
-    name: edpm-compute-global-service
+    name: edpm-compute-global
 spec:
   backoffLimit: 6
   extraMounts:
@@ -496,7 +496,7 @@ spec:
         items:
         - key: inventory
           path: inventory
-        secretName: dataplanenodeset-edpm-compute-global-service
+        secretName: dataplanenodeset-edpm-compute-global
   name: openstackansibleee
   restartPolicy: Never
   playbook: osp.edpm.install_certs
@@ -517,14 +517,14 @@ apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
   generation: 1
-  name: ovn-edpm-compute-global-service
+  name: ovn-edpm-compute-global-edpm-compute-global
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
     blockOwnerDeletion: true
     controller: true
     kind: OpenStackDataPlaneDeployment
-    name: edpm-compute-global-service
+    name: edpm-compute-global
 spec:
   backoffLimit: 6
   extraMounts:
@@ -558,7 +558,7 @@ spec:
         items:
         - key: inventory
           path: inventory
-        secretName: dataplanenodeset-edpm-compute-global-service
+        secretName: dataplanenodeset-edpm-compute-global
   name: openstackansibleee
   restartPolicy: Never
   playbook: osp.edpm.ovn
@@ -579,14 +579,14 @@ apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
   generation: 1
-  name: neutron-metadata-edpm-compute-global-service
+  name: neutron-metadata-edpm-compute-global-edpm-compute-global
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
     blockOwnerDeletion: true
     controller: true
     kind: OpenStackDataPlaneDeployment
-    name: edpm-compute-global-service
+    name: edpm-compute-global
 spec:
   backoffLimit: 6
   extraMounts:
@@ -649,7 +649,7 @@ spec:
         items:
         - key: inventory
           path: inventory
-        secretName: dataplanenodeset-edpm-compute-global-service
+        secretName: dataplanenodeset-edpm-compute-global
   name: openstackansibleee
   restartPolicy: Never
   playbook: osp.edpm.neutron_metadata
@@ -670,14 +670,14 @@ apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
   generation: 1
-  name: neutron-ovn-edpm-compute-global-service
+  name: neutron-ovn-edpm-compute-global-edpm-compute-global
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
     blockOwnerDeletion: true
     controller: true
     kind: OpenStackDataPlaneDeployment
-    name: edpm-compute-global-service
+    name: edpm-compute-global
 spec:
   backoffLimit: 6
   extraMounts:
@@ -711,7 +711,7 @@ spec:
         items:
         - key: inventory
           path: inventory
-        secretName: dataplanenodeset-edpm-compute-global-service
+        secretName: dataplanenodeset-edpm-compute-global
   name: openstackansibleee
   restartPolicy: Never
   playbook: osp.edpm.neutron_ovn
@@ -732,14 +732,14 @@ apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
   generation: 1
-  name: neutron-sriov-edpm-compute-global-service
+  name: neutron-sriov-edpm-compute-global-edpm-compute-global
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
     blockOwnerDeletion: true
     controller: true
     kind: OpenStackDataPlaneDeployment
-    name: edpm-compute-global-service
+    name: edpm-compute-global
 spec:
   backoffLimit: 6
   extraMounts:
@@ -773,7 +773,7 @@ spec:
         items:
         - key: inventory
           path: inventory
-        secretName: dataplanenodeset-edpm-compute-global-service
+        secretName: dataplanenodeset-edpm-compute-global
   name: openstackansibleee
   restartPolicy: Never
   playbook: osp.edpm.neutron_sriov
@@ -794,14 +794,14 @@ apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
   generation: 1
-  name: neutron-dhcp-edpm-compute-global-service
+  name: neutron-dhcp-edpm-compute-global-edpm-compute-global
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
     blockOwnerDeletion: true
     controller: true
     kind: OpenStackDataPlaneDeployment
-    name: edpm-compute-global-service
+    name: edpm-compute-global
 spec:
   backoffLimit: 6
   extraMounts:
@@ -835,7 +835,7 @@ spec:
         items:
         - key: inventory
           path: inventory
-        secretName: dataplanenodeset-edpm-compute-global-service
+        secretName: dataplanenodeset-edpm-compute-global
   name: openstackansibleee
   restartPolicy: Never
   playbook: osp.edpm.neutron_dhcp
@@ -855,14 +855,14 @@ status:
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  name: libvirt-edpm-compute-global-service
+  name: libvirt-edpm-compute-global-edpm-compute-global
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
     blockOwnerDeletion: true
     controller: true
     kind: OpenStackDataPlaneDeployment
-    name: edpm-compute-global-service
+    name: edpm-compute-global
 spec:
   backoffLimit: 6
   envConfigMapName: openstack-aee-default-env
@@ -886,7 +886,7 @@ spec:
         items:
         - key: inventory
           path: inventory
-        secretName: dataplanenodeset-edpm-compute-global-service
+        secretName: dataplanenodeset-edpm-compute-global
   name: openstackansibleee
   preserveJobs: true
   restartPolicy: Never
@@ -907,7 +907,7 @@ status:
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  name: nova-edpm-compute-global-service
+  name: nova-edpm-compute-global-edpm-compute-global
   namespace: openstack
 spec:
   backoffLimit: 6
@@ -972,7 +972,7 @@ spec:
         items:
         - key: inventory
           path: inventory
-        secretName: dataplanenodeset-edpm-compute-global-service
+        secretName: dataplanenodeset-edpm-compute-global
   name: openstackansibleee
   preserveJobs: true
   restartPolicy: Never

--- a/tests/kuttl/tests/dataplane-deploy-global-service-test/01-dataplane-deploy.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-global-service-test/01-dataplane-deploy.yaml
@@ -2,7 +2,7 @@
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneDeployment
 metadata:
-  name: edpm-compute-global-service
+  name: edpm-compute-global
 spec:
   nodeSets:
-    - edpm-compute-global-service
+    - edpm-compute-global

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/01-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/01-assert.yaml
@@ -44,21 +44,11 @@ status:
     reason: Ready
     status: "True"
     type: SetupReady
-  configMapHashes:
-    ovncontroller-config: n647h6fh674h55fh56ch5bh68bh5fdh8dh59ch58dhdch59ch646h568h675h99h66bh59bhcch5b4h589h674h568hbch84h554h95h6dhc4hbh699q
-  secretHashes:
-    neutron-dhcp-agent-neutron-config: n68h676h98h689hd4h575h5dbh694h6fh688h57h665h5c5h56dh5ddh65bh5d7h5cdh644hb8h8fh5d9h5b9h555h9ch56dh5fh6chd4h5c5h5c5h68q
-    neutron-ovn-agent-neutron-config: n5f4h89hb8h645h55bh657h9fh5d9h5c6h595h9dh667h5f4hfhffh7fh685h56ch57fh679h5ddh5ddh95h696hbch5c7h669h84h54dh685hfh85q
-    neutron-ovn-metadata-agent-neutron-config: n68dh585h666h5c4h568hf7h65fh695h649hb9h657h5f6h548h679h77h5b4h664h8h5b8h654h5hf5h674h664h545h74h58ch57ch8ch56h54fh5ddq
-    neutron-sriov-agent-neutron-config: n685h567h697h5bch8ch5cfh87h698h658h684h8h99h5dch5c5h699h79hb5h87h66dh664h546h586h7bh56fh5d6h5d4h566h56bh87h678h696h56cq
-    nova-cell1-compute-config: n89hd6h5h545h644h58h556hd9h5c5h598hd4h7bh5f9h5bdh649hb5h99h686h677h8ch575h665h574h587h5b6h5ddh8fh687h9bh657h675h97q
-    nova-metadata-neutron-config: n7fh696h674h5b9h68dh77h677h5c5hd9h5dbh89h646h696h65ch64bh86hd8h56h78h558h5h5c7h87h86h5bh5bch78h6ch5cbh54fh56fhfdq
-    nova-migration-ssh-key: n64dh97h54dhffh65fh577h59bh664hbch54dhcbh547hdbhdch655hd9h675h5d4h67dh5ch67bh64h5fdh5c8h5cdh66bh5f5h58dhcbh9bh66bhd4q
 ---
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  name: download-cache-edpm-compute-no-nodes
+  name: download-cache-edpm-compute-no-nodes-edpm-compute-no-nodes
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -108,7 +98,7 @@ status:
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  name: bootstrap-edpm-compute-no-nodes
+  name: bootstrap-edpm-compute-no-nodes-edpm-compute-no-nodes
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -161,7 +151,7 @@ status:
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  name: configure-network-edpm-compute-no-nodes
+  name: configure-network-edpm-compute-no-nodes-edpm-compute-no-nodes
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -211,7 +201,7 @@ status:
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  name: validate-network-edpm-compute-no-nodes
+  name: validate-network-edpm-compute-no-nodes-edpm-compute-no-nodes
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -261,7 +251,7 @@ status:
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  name: install-os-edpm-compute-no-nodes
+  name: install-os-edpm-compute-no-nodes-edpm-compute-no-nodes
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -312,7 +302,7 @@ apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
   generation: 1
-  name: configure-os-edpm-compute-no-nodes
+  name: configure-os-edpm-compute-no-nodes-edpm-compute-no-nodes
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -362,7 +352,7 @@ status:
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  name: run-os-edpm-compute-no-nodes
+  name: run-os-edpm-compute-no-nodes-edpm-compute-no-nodes
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -412,7 +402,7 @@ status:
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  name: install-certs-edpm-compute-no-nodes
+  name: install-certs-edpm-compute-no-nodes-edpm-compute-no-nodes
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -463,7 +453,7 @@ apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
   generation: 1
-  name: ovn-edpm-compute-no-nodes
+  name: ovn-edpm-compute-no-nodes-edpm-compute-no-nodes
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -525,7 +515,7 @@ apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
   generation: 1
-  name: neutron-metadata-edpm-compute-no-nodes
+  name: neutron-metadata-edpm-compute-no-nodes-edpm-compute-no-nodes
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -616,7 +606,7 @@ apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
   generation: 1
-  name: neutron-ovn-edpm-compute-no-nodes
+  name: neutron-ovn-edpm-compute-no-nodes-edpm-compute-no-nodes
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -678,7 +668,7 @@ apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
   generation: 1
-  name: neutron-sriov-edpm-compute-no-nodes
+  name: neutron-sriov-edpm-compute-no-nodes-edpm-compute-no-nodes
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -740,7 +730,7 @@ apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
   generation: 1
-  name: neutron-dhcp-edpm-compute-no-nodes
+  name: neutron-dhcp-edpm-compute-no-nodes-edpm-compute-no-nodes
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -801,7 +791,7 @@ status:
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  name: libvirt-edpm-compute-no-nodes
+  name: libvirt-edpm-compute-no-nodes-edpm-compute-no-nodes
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -853,7 +843,7 @@ status:
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  name: nova-edpm-compute-no-nodes
+  name: nova-edpm-compute-no-nodes-edpm-compute-no-nodes
   namespace: openstack
 spec:
   backoffLimit: 6

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/02-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/02-assert.yaml
@@ -2,14 +2,14 @@ apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
   generation: 1
-  name: custom-service-override-edpm-compute-no-nodes-services-override
+  name: custom-svc-edpm-compute-no-nodes-ovrd-edpm-compute-no-nodes
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
     blockOwnerDeletion: true
     controller: true
     kind: OpenStackDataPlaneDeployment
-    name: edpm-compute-no-nodes-services-override
+    name: edpm-compute-no-nodes-ovrd
 spec:
   backoffLimit: 6
   env:

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/02-dataplane-deploy-services-override.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/02-dataplane-deploy-services-override.yaml
@@ -2,9 +2,9 @@
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneService
 metadata:
-  name: custom-service-override
+  name: custom-svc
 spec:
-  label: custom-service-override
+  label: custom-svc
   play: |
     - hosts: localhost
       gather_facts: no
@@ -17,9 +17,9 @@ spec:
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneDeployment
 metadata:
-  name: edpm-compute-no-nodes-services-override
+  name: edpm-compute-no-nodes-ovrd
 spec:
   nodeSets:
     - edpm-compute-no-nodes
   servicesOverride:
-    - custom-service-override
+    - custom-svc

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/03-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/03-assert.yaml
@@ -44,13 +44,3 @@ status:
     reason: Ready
     status: "True"
     type: SetupReady
-  configMapHashes:
-    ovncontroller-config: n647h6fh674h55fh56ch5bh68bh5fdh8dh59ch58dhdch59ch646h568h675h99h66bh59bhcch5b4h589h674h568hbch84h554h95h6dhc4hbh699q
-  secretHashes:
-    neutron-dhcp-agent-neutron-config: n68h676h98h689hd4h575h5dbh694h6fh688h57h665h5c5h56dh5ddh65bh5d7h5cdh644hb8h8fh5d9h5b9h555h9ch56dh5fh6chd4h5c5h5c5h68q
-    neutron-ovn-agent-neutron-config: n5f4h89hb8h645h55bh657h9fh5d9h5c6h595h9dh667h5f4hfhffh7fh685h56ch57fh679h5ddh5ddh95h696hbch5c7h669h84h54dh685hfh85q
-    neutron-ovn-metadata-agent-neutron-config: n68dh585h666h5c4h568hf7h65fh695h649hb9h657h5f6h548h679h77h5b4h664h8h5b8h654h5hf5h674h664h545h74h58ch57ch8ch56h54fh5ddq
-    neutron-sriov-agent-neutron-config: n685h567h697h5bch8ch5cfh87h698h658h684h8h99h5dch5c5h699h79hb5h87h66dh664h546h586h7bh56fh5d6h5d4h566h56bh87h678h696h56cq
-    nova-cell1-compute-config: n89hd6h5h545h644h58h556hd9h5c5h598hd4h7bh5f9h5bdh649hb5h99h686h677h8ch575h665h574h587h5b6h5ddh8fh687h9bh657h675h97q
-    nova-metadata-neutron-config: n7fh696h674h5b9h68dh77h677h5c5hd9h5dbh89h646h696h65ch64bh86hd8h56h78h558h5h5c7h87h86h5bh5bch78h6ch5cbh54fh56fhfdq
-    nova-migration-ssh-key: n64dh97h54dhffh65fh577h59bh664hbch54dhcbh547hdbhdch655hd9h675h5d4h67dh5ch67bh64h5fdh5c8h5cdh66bh5f5h58dhcbh9bh66bhd4q

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/04-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/04-assert.yaml
@@ -44,29 +44,19 @@ status:
     reason: Ready
     status: "True"
     type: SetupReady
-  configMapHashes:
-    ovncontroller-config: n56h54bh9bhcbh65ch9fhdh66dh95h5dch569h678h7fh599h7ch84h597h59h54dh58dhf6h66bh565h4hc4h587h645hd7hcch5d8h5f4h55cq
-  secretHashes:
-    neutron-dhcp-agent-neutron-config: n68h676h98h689hd4h575h5dbh694h6fh688h57h665h5c5h56dh5ddh65bh5d7h5cdh644hb8h8fh5d9h5b9h555h9ch56dh5fh6chd4h5c5h5c5h68q
-    neutron-ovn-agent-neutron-config: n5f4h89hb8h645h55bh657h9fh5d9h5c6h595h9dh667h5f4hfhffh7fh685h56ch57fh679h5ddh5ddh95h696hbch5c7h669h84h54dh685hfh85q
-    neutron-ovn-metadata-agent-neutron-config: n68dh585h666h5c4h568hf7h65fh695h649hb9h657h5f6h548h679h77h5b4h664h8h5b8h654h5hf5h674h664h545h74h58ch57ch8ch56h54fh5ddq
-    neutron-sriov-agent-neutron-config: n685h567h697h5bch8ch5cfh87h698h658h684h8h99h5dch5c5h699h79hb5h87h66dh664h546h586h7bh56fh5d6h5d4h566h56bh87h678h696h56cq
-    nova-cell1-compute-config: n89hd6h5h545h644h58h556hd9h5c5h598hd4h7bh5f9h5bdh649hb5h99h686h677h8ch575h665h574h587h5b6h5ddh8fh687h9bh657h675h97q
-    nova-metadata-neutron-config: n7fh696h674h5b9h68dh77h677h5c5hd9h5dbh89h646h696h65ch64bh86hd8h56h78h558h5h5c7h87h86h5bh5bch78h6ch5cbh54fh56fhfdq
-    nova-migration-ssh-key: n64dh97h54dhffh65fh577h59bh664hbch54dhcbh547hdbhdch655hd9h675h5d4h67dh5ch67bh64h5fdh5c8h5cdh66bh5f5h58dhcbh9bh66bhd4q
 ---
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
   generation: 1
-  name: ovn-edpm-compute-no-nodes
+  name: ovn-edpm-compute-no-nodes-updated-ovn-cm-edpm-compute-no-nodes
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
     blockOwnerDeletion: true
     controller: true
     kind: OpenStackDataPlaneDeployment
-    name: edpm-compute-no-nodes
+    name: edpm-compute-no-nodes-updated-ovn-cm
 spec:
   backoffLimit: 6
   extraMounts:

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/05-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/05-assert.yaml
@@ -46,8 +46,6 @@ status:
     reason: Ready
     status: "True"
     type: SetupReady
-  configMapHashes:
-    ovncontroller-config: n56h54bh9bhcbh65ch9fhdh66dh95h5dch569h678h7fh599h7ch84h597h59h54dh58dhf6h66bh565h4hc4h587h645hd7hcch5d8h5f4h55cq
   deploymentStatuses:
     edpm-compute-no-nodes:
     - message: Deployment completed
@@ -121,15 +119,15 @@ status:
       severity: Error
       status: "False"
       type: NodeSetDeploymentReady
-    edpm-compute-no-nodes-services-override:
+    edpm-compute-no-nodes-ovrd:
     - message: Deployment completed
       reason: Ready
       status: "True"
       type: NodeSetDeploymentReady
-    - message: custom-service-override Deployment ready
+    - message: custom-svc Deployment ready
       reason: Ready
       status: "True"
-      type: ServiceCustomServiceOverrideDeploymentReady
+      type: ServiceCustomSvcDeploymentReady
     edpm-compute-no-nodes-updated-ovn-cm:
     - message: Deployment completed
       reason: Ready
@@ -139,14 +137,6 @@ status:
       reason: Ready
       status: "True"
       type: ServiceOvnDeploymentReady
-  secretHashes:
-    neutron-dhcp-agent-neutron-config: n68h676h98h689hd4h575h5dbh694h6fh688h57h665h5c5h56dh5ddh65bh5d7h5cdh644hb8h8fh5d9h5b9h555h9ch56dh5fh6chd4h5c5h5c5h68q
-    neutron-ovn-agent-neutron-config: n5f4h89hb8h645h55bh657h9fh5d9h5c6h595h9dh667h5f4hfhffh7fh685h56ch57fh679h5ddh5ddh95h696hbch5c7h669h84h54dh685hfh85q
-    neutron-ovn-metadata-agent-neutron-config: n68dh585h666h5c4h568hf7h65fh695h649hb9h657h5f6h548h679h77h5b4h664h8h5b8h654h5hf5h674h664h545h74h58ch57ch8ch56h54fh5ddq
-    neutron-sriov-agent-neutron-config: n685h567h697h5bch8ch5cfh87h698h658h684h8h99h5dch5c5h699h79hb5h87h66dh664h546h586h7bh56fh5d6h5d4h566h56bh87h678h696h56cq
-    nova-cell1-compute-config: n89hd6h5h545h644h58h556hd9h5c5h598hd4h7bh5f9h5bdh649hb5h99h686h677h8ch575h665h574h587h5b6h5ddh8fh687h9bh657h675h97q
-    nova-metadata-neutron-config: n7fh696h674h5b9h68dh77h677h5c5hd9h5dbh89h646h696h65ch64bh86hd8h56h78h558h5h5c7h87h86h5bh5bch78h6ch5cbh54fh56fhfdq
-    nova-migration-ssh-key: n64dh97h54dhffh65fh577h59bh664hbch54dhcbh547hdbhdch655hd9h675h5d4h67dh5ch67bh64h5fdh5c8h5cdh66bh5f5h58dhcbh9bh66bhd4q
 ---
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneDeployment

--- a/tests/kuttl/tests/dataplane-deploy-tls-test/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-tls-test/00-assert.yaml
@@ -1,7 +1,7 @@
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneService
 metadata:
-  name: default-service-tls-dnsnames
+  name: tls-dnsnames
 spec:
   caCerts: combined-ca-bundle
   tlsCert:
@@ -19,7 +19,7 @@ spec:
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneService
 metadata:
-  name: default-install-certs-override
+  name: install-certs-ovrd
 spec:
   addCertMounts: True
   play: |
@@ -77,8 +77,8 @@ spec:
   preProvisioned: true
   tlsEnabled: true
   services:
-  - default-install-certs-override
-  - default-service-tls-dnsnames
+  - install-certs-ovrd
+  - tls-dnsnames
 status:
   conditions:
   - message: Deployment not started

--- a/tests/kuttl/tests/dataplane-deploy-tls-test/00-dataplane-create.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-tls-test/00-dataplane-create.yaml
@@ -14,7 +14,7 @@ spec:
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneService
 metadata:
-  name: default-service-tls-dnsnames
+  name: tls-dnsnames
 spec:
   caCerts: combined-ca-bundle
   tlsCert:
@@ -32,7 +32,7 @@ spec:
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneService
 metadata:
-  name: default-install-certs-override
+  name: install-certs-ovrd
 spec:
   addCertMounts: True
   play: |
@@ -91,8 +91,8 @@ spec:
     - name: ANSIBLE_FORCE_COLOR
       value: "True"
   services:
-    - default-install-certs-override
-    - default-service-tls-dnsnames
+    - install-certs-ovrd
+    - tls-dnsnames
   preProvisioned: true
   tlsEnabled: true
   nodes:

--- a/tests/kuttl/tests/dataplane-deploy-tls-test/02-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-tls-test/02-assert.yaml
@@ -1,15 +1,15 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cert-default-service-tls-dnsnames-edpm-compute-0
+  name: cert-tls-dnsnames-edpm-compute-0
   annotations:
-    cert-manager.io/certificate-name: default-service-tls-dnsnames-edpm-compute-0
+    cert-manager.io/certificate-name: tls-dnsnames-edpm-compute-0
     cert-manager.io/issuer-group: cert-manager.io
     cert-manager.io/issuer-kind: Issuer
     cert-manager.io/issuer-name: rootca-internal
   labels:
     hostname: edpm-compute-0
-    osdp-service: default-service-tls-dnsnames
+    osdp-service: tls-dnsnames
     osdpns: openstack-edpm-tls
 type: kubernetes.io/tls
 ---
@@ -18,24 +18,24 @@ kind: Certificate
 metadata:
   labels:
     hostname: edpm-compute-0
-    osdp-service: default-service-tls-dnsnames
+    osdp-service: tls-dnsnames
     osdpns: openstack-edpm-tls
-  name: default-service-tls-dnsnames-edpm-compute-0
+  name: tls-dnsnames-edpm-compute-0
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
     kind: OpenStackDataPlaneDeployment
-    name: openstack-edpm-tls-deployment
+    name: openstack-edpm-tls
 spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
     name: rootca-internal
-  secretName: cert-default-service-tls-dnsnames-edpm-compute-0
+  secretName: cert-tls-dnsnames-edpm-compute-0
   secretTemplate:
     labels:
       hostname: edpm-compute-0
-      osdp-service: default-service-tls-dnsnames
+      osdp-service: tls-dnsnames
       osdpns: openstack-edpm-tls
 ---
 # validate the alt-names and usages - which is a list with elements that can be in any order
@@ -44,7 +44,7 @@ kind: TestAssert
 commands:
   - script: |
       template='{{index .spec.dnsNames }}'
-      names=$(oc get certificate default-service-tls-dnsnames-edpm-compute-0 -n openstack -o go-template="$template")
+      names=$(oc get certificate tls-dnsnames-edpm-compute-0 -n openstack -o go-template="$template")
       echo $names > test123.data
       regex="(?=.*(edpm-compute-0\.internalapi\.example\.com))(?=.*(edpm-compute-0\.storage\.example\.com))(?=.*(edpm-compute-0\.tenant\.example\.com))(?=.*(edpm-compute-0\.ctlplane\.example\.com))"
       matches=$(grep -P "$regex" test123.data)
@@ -57,7 +57,7 @@ commands:
       fi
   - script: |
       template='{{index .spec.usages }}'
-      usages=$(oc get certificate default-service-tls-dnsnames-edpm-compute-0 -n openstack -o go-template="$template")
+      usages=$(oc get certificate tls-dnsnames-edpm-compute-0 -n openstack -o go-template="$template")
       echo $usages > test123.data
       regex="(?=.*(key encipherment))(?=.*(digital signature))(?=.*(server auth))"
       matches=$(grep -P "$regex" test123.data)
@@ -72,7 +72,7 @@ commands:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: openstack-edpm-tls-default-service-tls-dnsnames-certs
+  name: openstack-edpm-tls-tls-dnsnames-certs
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
     kind: OpenStackDataPlaneNodeSet
@@ -82,31 +82,29 @@ type: Opaque
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  labels:
-    osdpd: openstack-edpm-tls-deployment
-  name: default-install-certs-override-openstack-edpm-tls-deployment
+  name: install-certs-ovrd-openstack-edpm-tls-openstack-edpm-tls
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
     blockOwnerDeletion: true
     controller: true
     kind: OpenStackDataPlaneDeployment
-    name: openstack-edpm-tls-deployment
+    name: openstack-edpm-tls
 spec:
   backoffLimit: 6
   extraMounts:
   - mounts:
-    - mountPath: /var/lib/openstack/certs/default-service-tls-dnsnames
-      name: openstack-edpm-tls-default-service-tls-dnsnames-certs
+    - mountPath: /var/lib/openstack/certs/tls-dnsnames
+      name: openstack-edpm-tls-tls-dnsnames-certs
     volumes:
-    - name: openstack-edpm-tls-default-service-tls-dnsnames-certs
+    - name: openstack-edpm-tls-tls-dnsnames-certs
       secret:
-        secretName: openstack-edpm-tls-default-service-tls-dnsnames-certs
+        secretName: openstack-edpm-tls-tls-dnsnames-certs
   - mounts:
-    - mountPath: /var/lib/openstack/cacerts/default-service-tls-dnsnames
-      name: default-service-tls-dnsnames-combined-ca-bundle
+    - mountPath: /var/lib/openstack/cacerts/tls-dnsnames
+      name: tls-dnsnames-combined-ca-bundle
     volumes:
-    - name: default-service-tls-dnsnames-combined-ca-bundle
+    - name: tls-dnsnames-combined-ca-bundle
       secret:
         secretName: combined-ca-bundle
   - mounts:
@@ -147,14 +145,12 @@ status:
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  labels:
-    osdpd: openstack-edpm-tls-deployment
-  name: default-service-tls-dnsnames-openstack-edpm-tls-deployment
+  name: tls-dnsnames-openstack-edpm-tls-openstack-edpm-tls
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
     kind: OpenStackDataPlaneDeployment
-    name: openstack-edpm-tls-deployment
+    name: openstack-edpm-tls
 spec:
   backoffLimit: 6
   extraMounts:

--- a/tests/kuttl/tests/dataplane-deploy-tls-test/02-dataplane-deploy.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-tls-test/02-dataplane-deploy.yaml
@@ -2,7 +2,7 @@
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneDeployment
 metadata:
-  name: openstack-edpm-tls-deployment
+  name: openstack-edpm-tls
 spec:
   nodeSets:
     - openstack-edpm-tls

--- a/tests/kuttl/tests/dataplane-deploy-tls-test/03-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-tls-test/03-assert.yaml
@@ -1,17 +1,17 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cert-custom-service-tls-dns-ips-edpm-compute-0
+  name: cert-tls-dns-ips-edpm-compute-0
   annotations:
     cert-manager.io/alt-names: edpm-compute-0.ctlplane.example.com
-    cert-manager.io/certificate-name: custom-service-tls-dns-ips-edpm-compute-0
+    cert-manager.io/certificate-name: tls-dns-ips-edpm-compute-0
     cert-manager.io/ip-sans: 192.168.122.100
     cert-manager.io/issuer-group: cert-manager.io
     cert-manager.io/issuer-kind: Issuer
     cert-manager.io/issuer-name: rootca-internal
   labels:
     hostname: edpm-compute-0
-    osdp-service: custom-service-tls-dns-ips
+    osdp-service: tls-dns-ips
     osdpns: openstack-edpm-tls
 type: kubernetes.io/tls
 ---
@@ -20,14 +20,14 @@ kind: Certificate
 metadata:
   labels:
     hostname: edpm-compute-0
-    osdp-service: custom-service-tls-dns-ips
+    osdp-service: tls-dns-ips
     osdpns: openstack-edpm-tls
-  name: custom-service-tls-dns-ips-edpm-compute-0
+  name: tls-dns-ips-edpm-compute-0
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
     kind: OpenStackDataPlaneDeployment
-    name: openstack-edpm-tls-services-override
+    name: openstack-edpm-tls-ovrd
 spec:
   dnsNames:
   - edpm-compute-0.ctlplane.example.com
@@ -35,25 +35,25 @@ spec:
     group: cert-manager.io
     kind: Issuer
     name: rootca-internal
-  secretName: cert-custom-service-tls-dns-ips-edpm-compute-0
+  secretName: cert-tls-dns-ips-edpm-compute-0
   secretTemplate:
     labels:
       hostname: edpm-compute-0
-      osdp-service: custom-service-tls-dns-ips
+      osdp-service: tls-dns-ips
       osdpns: openstack-edpm-tls
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cert-custom-service-tls-dns-edpm-compute-0
+  name: cert-custom-tls-dns-edpm-compute-0
   annotations:
-    cert-manager.io/certificate-name: custom-service-tls-dns-edpm-compute-0
+    cert-manager.io/certificate-name: custom-tls-dns-edpm-compute-0
     cert-manager.io/issuer-group: cert-manager.io
     cert-manager.io/issuer-kind: Issuer
     cert-manager.io/issuer-name: rootca-internal
   labels:
     hostname: edpm-compute-0
-    osdp-service: custom-service-tls-dns
+    osdp-service: custom-tls-dns
     osdpns: openstack-edpm-tls
 type: kubernetes.io/tls
 ---
@@ -62,24 +62,24 @@ kind: Certificate
 metadata:
   labels:
     hostname: edpm-compute-0
-    osdp-service: custom-service-tls-dns
+    osdp-service: custom-tls-dns
     osdpns: openstack-edpm-tls
-  name: custom-service-tls-dns-edpm-compute-0
+  name: custom-tls-dns-edpm-compute-0
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
     kind: OpenStackDataPlaneDeployment
-    name: openstack-edpm-tls-services-override
+    name: openstack-edpm-tls-ovrd
 spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
     name: rootca-internal
-  secretName: cert-custom-service-tls-dns-edpm-compute-0
+  secretName: cert-custom-tls-dns-edpm-compute-0
   secretTemplate:
     labels:
       hostname: edpm-compute-0
-      osdp-service: custom-service-tls-dns
+      osdp-service: custom-tls-dns
       osdpns: openstack-edpm-tls
 ---
 # validate the alt-names and usages - which is a list with elements that can be in any order
@@ -88,7 +88,7 @@ kind: TestAssert
 commands:
   - script: |
       template='{{index .spec.dnsNames }}'
-      names=$(oc get certificate custom-service-tls-dns-edpm-compute-0 -n openstack -o go-template="$template")
+      names=$(oc get certificate custom-tls-dns-edpm-compute-0 -n openstack -o go-template="$template")
       echo $names > test123.data
       regex="(?=.*(edpm-compute-0\.internalapi\.example\.com))(?=.*(edpm-compute-0\.storage\.example\.com))(?=.*(edpm-compute-0\.tenant\.example\.com))(?=.*(edpm-compute-0\.ctlplane\.example\.com))"
       matches=$(grep -P "$regex" test123.data)
@@ -101,7 +101,7 @@ commands:
       fi
   - script: |
       template='{{index .spec.usages }}'
-      usages=$(oc get certificate custom-service-tls-dns-edpm-compute-0 -n openstack -o go-template="$template")
+      usages=$(oc get certificate custom-tls-dns-edpm-compute-0 -n openstack -o go-template="$template")
       echo $usages > test123.data
       regex="(?=.*(key encipherment))(?=.*(digital signature))(?=.*(server auth))(?=.*(client auth))"
       matches=$(grep -P "$regex" test123.data)
@@ -116,7 +116,7 @@ commands:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: openstack-edpm-tls-custom-service-tls-dns-ips-certs
+  name: openstack-edpm-tls-tls-dns-ips-certs
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
     kind: OpenStackDataPlaneNodeSet
@@ -126,7 +126,7 @@ type: Opaque
 apiVersion: v1
 kind: Secret
 metadata:
-  name: openstack-edpm-tls-custom-service-tls-dns-certs
+  name: openstack-edpm-tls-custom-tls-dns-certs
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
     kind: OpenStackDataPlaneNodeSet
@@ -136,45 +136,43 @@ type: Opaque
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  labels:
-    osdpd: openstack-edpm-tls-services-override
-  name: install-certs-override-openstack-edpm-tls-services-override
+  name: install-certs-ovrd-openstack-edpm-tls-ovrd-openstack-edpm-tls
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
     blockOwnerDeletion: true
     controller: true
     kind: OpenStackDataPlaneDeployment
-    name: openstack-edpm-tls-services-override
+    name: openstack-edpm-tls-ovrd
 spec:
   backoffLimit: 6
   extraMounts:
   - mounts:
-    - mountPath: /var/lib/openstack/certs/custom-service-tls-dns-ips
-      name: openstack-edpm-tls-custom-service-tls-dns-ips-certs
+    - mountPath: /var/lib/openstack/certs/tls-dns-ips
+      name: openstack-edpm-tls-tls-dns-ips-certs
     volumes:
-    - name: openstack-edpm-tls-custom-service-tls-dns-ips-certs
+    - name: openstack-edpm-tls-tls-dns-ips-certs
       secret:
-        secretName: openstack-edpm-tls-custom-service-tls-dns-ips-certs
+        secretName: openstack-edpm-tls-tls-dns-ips-certs
   - mounts:
-    - mountPath: /var/lib/openstack/cacerts/custom-service-tls-dns-ips
-      name: custom-service-tls-dns-ips-combined-ca-bundle
+    - mountPath: /var/lib/openstack/cacerts/tls-dns-ips
+      name: tls-dns-ips-combined-ca-bundle
     volumes:
-    - name: custom-service-tls-dns-ips-combined-ca-bundle
+    - name: tls-dns-ips-combined-ca-bundle
       secret:
         secretName: combined-ca-bundle
   - mounts:
-    - mountPath: /var/lib/openstack/certs/custom-service-tls-dns
-      name: openstack-edpm-tls-custom-service-tls-dns-certs
+    - mountPath: /var/lib/openstack/certs/custom-tls-dns
+      name: openstack-edpm-tls-custom-tls-dns-certs
     volumes:
-    - name: openstack-edpm-tls-custom-service-tls-dns-certs
+    - name: openstack-edpm-tls-custom-tls-dns-certs
       secret:
-        secretName: openstack-edpm-tls-custom-service-tls-dns-certs
+        secretName: openstack-edpm-tls-custom-tls-dns-certs
   - mounts:
-    - mountPath: /var/lib/openstack/cacerts/custom-service-tls-dns
-      name: custom-service-tls-dns-combined-ca-bundle
+    - mountPath: /var/lib/openstack/cacerts/custom-tls-dns
+      name: custom-tls-dns-combined-ca-bundle
     volumes:
-    - name: custom-service-tls-dns-combined-ca-bundle
+    - name: custom-tls-dns-combined-ca-bundle
       secret:
         secretName: combined-ca-bundle
   - mounts:
@@ -215,14 +213,12 @@ status:
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  labels:
-    osdpd: openstack-edpm-tls-services-override
-  name: custom-service-tls-dns-ips-openstack-edpm-tls-services-override
+  name: tls-dns-ips-openstack-edpm-tls-ovrd-openstack-edpm-tls
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
     kind: OpenStackDataPlaneDeployment
-    name: openstack-edpm-tls-services-override
+    name: openstack-edpm-tls-ovrd
 spec:
   backoffLimit: 6
   extraMounts:
@@ -264,14 +260,12 @@ status:
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  labels:
-    osdpd: openstack-edpm-tls-services-override
-  name: custom-service-tls-dns-openstack-edpm-tls-services-override
+  name: custom-tls-dns-openstack-edpm-tls-ovrd-openstack-edpm-tls
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
     kind: OpenStackDataPlaneDeployment
-    name: openstack-edpm-tls-services-override
+    name: openstack-edpm-tls-ovrd
 spec:
   backoffLimit: 6
   extraMounts:

--- a/tests/kuttl/tests/dataplane-deploy-tls-test/03-dataplane-deploy-services-override.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-tls-test/03-dataplane-deploy-services-override.yaml
@@ -2,7 +2,7 @@
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneService
 metadata:
-  name: custom-service-tls-dns-ips
+  name: tls-dns-ips
 spec:
   caCerts: combined-ca-bundle
   tlsCert:
@@ -24,7 +24,7 @@ spec:
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneService
 metadata:
-  name: custom-service-tls-dns
+  name: custom-tls-dns
 spec:
   caCerts: combined-ca-bundle
   tlsCert:
@@ -47,7 +47,7 @@ spec:
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneService
 metadata:
-  name: install-certs-override
+  name: install-certs-ovrd
 spec:
   addCertMounts: True
   play: |
@@ -62,11 +62,11 @@ spec:
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneDeployment
 metadata:
-  name: openstack-edpm-tls-services-override
+  name: openstack-edpm-tls-ovrd
 spec:
   nodeSets:
     - openstack-edpm-tls
   servicesOverride:
-    - install-certs-override
-    - custom-service-tls-dns-ips
-    - custom-service-tls-dns
+    - install-certs-ovrd
+    - tls-dns-ips
+    - custom-tls-dns

--- a/tests/kuttl/tests/dataplane-extramounts/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-extramounts/00-assert.yaml
@@ -23,7 +23,7 @@ spec:
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  name: test-service-edpm-extramounts
+  name: test-service-edpm-extramounts-edpm-extramounts
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1

--- a/tests/kuttl/tests/dataplane-service-config/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-service-config/00-assert.yaml
@@ -2,7 +2,7 @@
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  name: kuttl-service-edpm-compute-no-nodes
+  name: kuttl-service-edpm-compute-no-nodes-edpm-compute-no-nodes
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1

--- a/tests/kuttl/tests/dataplane-service-custom-image/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-service-custom-image/00-assert.yaml
@@ -2,11 +2,11 @@
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneNodeSet
 metadata:
-  name: edpm-no-nodes-custom-service
+  name: edpm-no-nodes-custom-svc
 spec:
   preProvisioned: true
   services:
-    - custom-image-service
+    - custom-img-svc
   nodes: {}
   nodeTemplate:
     ansible:
@@ -37,7 +37,7 @@ status:
 apiVersion: ansibleee.openstack.org/v1beta1
 kind: OpenStackAnsibleEE
 metadata:
-  name: custom-image-service-edpm-compute-no-nodes
+  name: custom-img-svc-edpm-compute-no-nodes-edpm-no-nodes-custom-svc
   namespace: openstack
   ownerReferences:
   - apiVersion: dataplane.openstack.org/v1beta1
@@ -67,7 +67,7 @@ spec:
         items:
         - key: inventory
           path: inventory
-        secretName: dataplanenodeset-edpm-no-nodes-custom-service
+        secretName: dataplanenodeset-edpm-no-nodes-custom-svc
   image: example.com/repo/runner-image:latest
   name: openstackansibleee
   restartPolicy: Never

--- a/tests/kuttl/tests/dataplane-service-custom-image/00-dataplane-create.yaml
+++ b/tests/kuttl/tests/dataplane-service-custom-image/00-dataplane-create.yaml
@@ -1,7 +1,7 @@
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneService
 metadata:
-  name: custom-image-service
+  name: custom-img-svc
 spec:
   openStackAnsibleEERunnerImage: example.com/repo/runner-image:latest
   role:
@@ -16,11 +16,11 @@ spec:
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneNodeSet
 metadata:
-  name: edpm-no-nodes-custom-service
+  name: edpm-no-nodes-custom-svc
 spec:
   preProvisioned: true
   services:
-    - custom-image-service
+    - custom-img-svc
   nodes: {}
   nodeTemplate:
     ansible:
@@ -34,4 +34,4 @@ metadata:
   name: edpm-compute-no-nodes
 spec:
   nodeSets:
-    - edpm-no-nodes-custom-service
+    - edpm-no-nodes-custom-svc


### PR DESCRIPTION
Use deployment and nodeset name/uuid in AEE name/label for normal services. 

Use deployment name/uuid in AEE name/label for global services.

This would fix the intermittent failures in functional and kuttl tests due to name collision of AEEs.