### PR TITLE
Adding derive_pci_devicespec dataplane service

### DIFF
--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_derive_pci_devicespec.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_derive_pci_devicespec.yaml
@@ -1,0 +1,12 @@
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneService
+metadata:
+  labels:
+    app.kubernetes.io/name: openstackdataplaneservice
+    app.kubernetes.io/instance: openstackdataplaneservice-derive-pci-devicespec
+    app.kubernetes.io/part-of: dataplane-operator
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: dataplane-operator
+  name: derive-pci-devicespec
+spec:
+  playbook: osp.edpm.sriov_derive_device_spec


### PR DESCRIPTION
This serivce can be used to derive the pci device_spec for SR-IOV nic partitioned deployment