### PR TITLE
Fix issuer for ovn

### DIFF
--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_ovn.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_ovn.yaml
@@ -12,7 +12,7 @@ spec:
     - ips
     networks:
     - ctlplane
-    issuer: osp-rootca-issuer-ovndb
+    issuer: osp-rootca-issuer-ovn
     keyUsages:
       - digital signature
       - key encipherment

--- a/pkg/deployment/cert.go
+++ b/pkg/deployment/cert.go
@@ -116,8 +116,9 @@ func EnsureTLSCerts(ctx context.Context, helper *helper.Helper,
 			issuerLabelSelector = map[string]string{service.Spec.TLSCert.Issuer: ""}
 		}
 
-		issuer, err = certmanager.GetIssuerByLabels(ctx, helper, "", issuerLabelSelector)
+		issuer, err = certmanager.GetIssuerByLabels(ctx, helper, instance.Namespace, issuerLabelSelector)
 		if err != nil {
+			helper.GetLogger().Info("Error retrieving issuer by label", "issuerLabelSelector", issuerLabelSelector)
 			return &result, err
 		}
 


### PR DESCRIPTION
The issuer label for ovn is set incorrectly in the service definition. In lib-common, the label is set to OvnDbCaName = tls.DefaultCAPrefix + "ovn", but we have ovndb instead.

Also, added an error message to help troubleshoot these in future.