### PR TITLE
add addtional logging to dataplane-deploy-global-service-test

### DIFF
--- a/tests/kuttl/tests/dataplane-deploy-global-service-test/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-global-service-test/00-assert.yaml
@@ -1,3 +1,14 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 600
+collectors:
+- type: command
+  command: oc get OpenStackDataPlaneDeployment -n openstack edpm-compute-global -o yaml
+  name: edpm-compute-global-deployment
+- type: command
+  command: oc logs -n openstack-operators -l openstack.org/operator-name=dataplane
+  name: dataplane-operator-logs
+---
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneNodeSet
 metadata:

--- a/tests/kuttl/tests/dataplane-deploy-global-service-test/01-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-global-service-test/01-assert.yaml
@@ -1,3 +1,14 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 600
+collectors:
+- type: command
+  command: oc get OpenStackDataPlaneDeployment -n openstack edpm-compute-global -o yaml
+  name: edpm-compute-global-deployment
+- type: command
+  command: oc logs -n openstack-operators -l openstack.org/operator-name=dataplane
+  name: dataplane-operator-logs
+---
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneNodeSet
 metadata:


### PR DESCRIPTION
this patch add collectors to the 00-assert.yaml file to collect
the deployment cr and dataplane operator logs on assert failure.
