### PR TITLE
Fix error scope when deploying

### DIFF
--- a/controllers/openstackdataplanedeployment_controller.go
+++ b/controllers/openstackdataplanedeployment_controller.go
@@ -300,12 +300,6 @@ func (r *OpenStackDataPlaneDeploymentReconciler) Reconcile(ctx context.Context, 
 			} else {
 				deploymentErrMsg = fmt.Sprintf("%s & %s", deploymentErrMsg, errMsg)
 			}
-			instance.Status.Conditions.MarkFalse(
-				dataplanev1.NodeSetDeploymentReadyCondition,
-				condition.ErrorReason,
-				condition.SeverityError,
-				dataplanev1.DataPlaneNodeSetErrorMessage,
-				errMsg)
 			nsConditions.MarkFalse(
 				dataplanev1.NodeSetDeploymentReadyCondition,
 				condition.ErrorReason,

--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -149,8 +149,9 @@ func (d *Deployer) ConditionalDeploy(
 	}
 
 	if nsConditions.IsFalse(readyCondition) {
+		var ansibleEE *ansibleeev1.OpenStackAnsibleEE
 		_, labelSelector := dataplaneutil.GetAnsibleExecutionNameAndLabel(&foundService, d.Deployment, d.NodeSet)
-		ansibleEE, err := dataplaneutil.GetAnsibleExecution(d.Ctx, d.Helper, d.Deployment, labelSelector)
+		ansibleEE, err = dataplaneutil.GetAnsibleExecution(d.Ctx, d.Helper, d.Deployment, labelSelector)
 		if err != nil {
 			// Return nil if we don't have AnsibleEE available yet
 			if k8s_errors.IsNotFound(err) {

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/05-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/05-assert.yaml
@@ -170,13 +170,6 @@ status:
     reason: Ready
     status: "True"
     type: InputReady
-  - message: 'DataPlaneNodeSet error occurred nodeSet: edpm-compute-no-nodes error:
-      OpenStackDataPlaneService.dataplane.openstack.org "this-service-does-not-exist"
-      not found'
-    reason: Error
-    severity: Error
-    status: "False"
-    type: NodeSetDeploymentReady
   nodeSetConditions:
     edpm-compute-no-nodes:
     - message: Deployment error occurred OpenStackDataPlaneService.dataplane.openstack.org


### PR DESCRIPTION
we were creating a new `err` inside the `if` scope 
ref: https://stackoverflow.com/a/34633601

From: https://logserver.rdoproject.org/12/1312/2245be092585a96b407116f4fc258dae5ce46f43/github-check/cifmw-data-plane-adoption-osp-17-to-extracted-crc/d8677a6/controller/ci-framework-data/logs/openstack-k8s-operators-openstack-must-gather/namespaces/openstack-operators/pods/dataplane-operator-controller-manager-8486fb84db-bfb74/logs/manager.log
we can see the `err` wasn't propagated
```
2024-03-21T12:29:55Z	INFO	Controllers.OpenStackDataPlaneDeployment	Condition ServiceNovaComputeExtraconfigDeploymentReady error	{"controller": "openstackdataplanedeployment", "controllerGroup": "dataplane.openstack.org", "controllerKind": "OpenStackDataPlaneDeployment", "OpenStackDataPlaneDeployment": {"name":"openstack","namespace":"openstack"}, "namespace": "openstack", "name": "openstack", "reconcileID": "21c2fa84-b46e-4ad8-80b9-204ccd9f42e4"}
2024-03-21T12:29:55Z	INFO	Controllers.OpenStackDataPlaneDeployment	Condition ServiceNovaComputeExtraconfigDeploymentReady not ready	{"controller": "openstackdataplanedeployment", "controllerGroup": "dataplane.openstack.org", "controllerKind": "OpenStackDataPlaneDeployment", "OpenStackDataPlaneDeployment": {"name":"openstack","namespace":"openstack"}, "namespace": "openstack", "name": "openstack", "reconcileID": "21c2fa84-b46e-4ad8-80b9-204ccd9f42e4"}
```