### PR TITLE
Pin setup-envtest at working commit to unblock content provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -271,7 +271,7 @@ $(CRD_MARKDOWN): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@c7e1dc9b
 
 .PHONY: ginkgo
 ginkgo: $(GINKGO) ## Download ginkgo locally if necessary.


### PR DESCRIPTION
See https://github.com/openstack-k8s-operators/openstack-operator/pull/723#issue-2202688542