### PR TITLE
Reset the state of conditions to Unknown for each reconcile

### DIFF
--- a/controllers/openstackdataplanedeployment_controller.go
+++ b/controllers/openstackdataplanedeployment_controller.go
@@ -131,6 +131,10 @@ func (r *OpenStackDataPlaneDeploymentReconciler) Reconcile(ctx context.Context, 
 		// in the cli
 		return ctrl.Result{}, nil
 	}
+	// Reset all conditions to Unknown as the state is not yet known for
+	// this reconcile loop.
+	instance.InitConditions()
+
 	if instance.Status.ConfigMapHashes == nil {
 		instance.Status.ConfigMapHashes = make(map[string]string)
 	}

--- a/controllers/openstackdataplanenodeset_controller.go
+++ b/controllers/openstackdataplanenodeset_controller.go
@@ -226,6 +226,10 @@ func (r *OpenStackDataPlaneNodeSetReconciler) Reconcile(ctx context.Context, req
 		// in the cli
 		return ctrl.Result{}, nil
 	}
+	// Reset all conditions to Unknown as the state is not yet known for
+	// this reconcile loop.
+	instance.InitConditions()
+
 	if instance.Status.ConfigMapHashes == nil {
 		instance.Status.ConfigMapHashes = make(map[string]string)
 	}


### PR DESCRIPTION
All conditions are set to Unknown at the beginning of the reconcile, as
their state is not yet known for that particular reconcile.

Otherwise, stale and incorrect condition state could be persisted on the
resources indefinitely if they were never reset.

Jira: [OSPRH-5698](https://issues.redhat.com//browse/OSPRH-5698)
Signed-off-by: James Slagle <jslagle@redhat.com>
