### PR TITLE
Add ObservedGeneration to NodeSet and Deployment Status

### DIFF
--- a/api/bases/dataplane.openstack.org_openstackdataplanedeployments.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplanedeployments.yaml
@@ -129,6 +129,9 @@ spec:
                 additionalProperties:
                   type: string
                 type: object
+              observedGeneration:
+                format: int64
+                type: integer
               secretHashes:
                 additionalProperties:
                   type: string

--- a/api/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
@@ -2026,6 +2026,9 @@ spec:
                 items:
                   type: string
                 type: array
+              observedGeneration:
+                format: int64
+                type: integer
               secretHashes:
                 additionalProperties:
                   type: string

--- a/api/v1beta1/openstackdataplanedeployment_types.go
+++ b/api/v1beta1/openstackdataplanedeployment_types.go
@@ -79,6 +79,9 @@ type OpenStackDataPlaneDeploymentStatus struct {
 
 	// NodeSetHashes
 	NodeSetHashes map[string]string `json:"nodeSetHashes,omitempty" optional:"true"`
+
+	//ObservedGeneration - the most recent generation observed for this Deployment. If the observed generation is less than the spec generation, then the controller has not processed the latest changes.
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1beta1/openstackdataplanenodeset_types.go
+++ b/api/v1beta1/openstackdataplanenodeset_types.go
@@ -136,6 +136,9 @@ type OpenStackDataPlaneNodeSetStatus struct {
 	// This hash is used to determine when new Ansible executions are required to roll
 	// out config changes.
 	DeployedConfigHash string `json:"deployedConfigHash,omitempty"`
+
+	//ObservedGeneration - the most recent generation observed for this NodeSet. If the observed generation is less than the spec generation, then the controller has not processed the latest changes.
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanedeployments.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanedeployments.yaml
@@ -129,6 +129,9 @@ spec:
                 additionalProperties:
                   type: string
                 type: object
+              observedGeneration:
+                format: int64
+                type: integer
               secretHashes:
                 additionalProperties:
                   type: string

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
@@ -2026,6 +2026,9 @@ spec:
                 items:
                   type: string
                 type: array
+              observedGeneration:
+                format: int64
+                type: integer
               secretHashes:
                 additionalProperties:
                   type: string

--- a/controllers/openstackdataplanenodeset_controller.go
+++ b/controllers/openstackdataplanenodeset_controller.go
@@ -198,19 +198,36 @@ func (r *OpenStackDataPlaneNodeSetReconciler) Reconcile(ctx context.Context, req
 		Log,
 	)
 
+	// initialize status if Conditions is nil, but do not reset if it already
+	// exists
+	isNewInstance := instance.Status.Conditions == nil
+	if isNewInstance {
+		instance.Status.Conditions = condition.Conditions{}
+	}
+
+	// Save a copy of the conditions so that we can restore the LastTransitionTime
+	// when a condition's state doesn't change.
+	savedConditions := instance.Status.Conditions.DeepCopy()
+
+	// Reset all conditions to Unknown as the state is not yet known for
+	// this reconcile loop.
+	instance.InitConditions()
+	// Set ObservedGeneration since we've reset conditions
+	instance.Status.ObservedGeneration = instance.Generation
+
 	// Always patch the instance status when exiting this function so we can persist any changes.
 	defer func() { // update the Ready condition based on the sub conditions
+		condition.RestoreLastTransitionTimes(
+			&instance.Status.Conditions, savedConditions)
 		if instance.Status.Conditions.AllSubConditionIsTrue() {
 			instance.Status.Conditions.MarkTrue(
 				condition.ReadyCondition, dataplanev1.NodeSetReadyMessage)
-		} else {
-			// something is not ready so reset the Ready condition
-			instance.Status.Conditions.MarkUnknown(
-				condition.ReadyCondition, condition.InitReason, condition.ReadyInitMessage)
-			// and recalculate it based on the state of the rest of the conditions
+		} else if instance.Status.Conditions.IsUnknown(condition.ReadyCondition) {
+			// Recalculate ReadyCondition based on the state of the rest of the conditions
 			instance.Status.Conditions.Set(
 				instance.Status.Conditions.Mirror(condition.ReadyCondition))
 		}
+
 		err := helper.PatchInstance(ctx, instance)
 		if err != nil {
 			Log.Error(err, "Error updating instance status conditions")
@@ -218,17 +235,6 @@ func (r *OpenStackDataPlaneNodeSetReconciler) Reconcile(ctx context.Context, req
 			return
 		}
 	}()
-
-	// Initialize Status
-	if instance.Status.Conditions == nil {
-		instance.InitConditions()
-		// Register overall status immediately to have an early feedback e.g.
-		// in the cli
-		return ctrl.Result{}, nil
-	}
-	// Reset all conditions to Unknown as the state is not yet known for
-	// this reconcile loop.
-	instance.InitConditions()
 
 	if instance.Status.ConfigMapHashes == nil {
 		instance.Status.ConfigMapHashes = make(map[string]string)

--- a/docs/assemblies/custom_resources.adoc
+++ b/docs/assemblies/custom_resources.adoc
@@ -631,6 +631,11 @@ OpenStackDataPlaneNodeSetStatus defines the observed state of OpenStackDataPlane
 | DeployedConfigHash - holds the hash of the NodeTemplate and Node sections of the struct that was last deployed. This hash is used to determine when new Ansible executions are required to roll out config changes.
 | string
 | false
+
+| observedGeneration
+| ObservedGeneration - the most recent generation observed for this NodeSet. If the observed generation is less than the spec generation, then the controller has not processed the latest changes.
+| int64
+| false
 |===
 
 <<custom-resources,Back to Custom Resources>>
@@ -764,6 +769,11 @@ OpenStackDataPlaneDeploymentStatus defines the observed state of OpenStackDataPl
 | nodeSetHashes
 | NodeSetHashes
 | map[string]string
+| false
+
+| observedGeneration
+| ObservedGeneration - the most recent generation observed for this Deployment. If the observed generation is less than the spec generation, then the controller has not processed the latest changes.
+| int64
 | false
 |===
 

--- a/tests/kuttl/tests/dataplane-create-test/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-create-test/00-assert.yaml
@@ -91,6 +91,7 @@ spec:
   - libvirt
   - nova
 status:
+  observedGeneration: 1
   conditions:
   - message: Deployment not started
     reason: Requested

--- a/tests/kuttl/tests/dataplane-deploy-global-service-test/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-global-service-test/00-assert.yaml
@@ -107,6 +107,7 @@ spec:
          # SELinux module
          edpm_selinux_mode: enforcing
 status:
+  observedGeneration: 1
   conditions:
   - message: Deployment not started
     reason: Requested

--- a/tests/kuttl/tests/dataplane-deploy-global-service-test/01-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-global-service-test/01-assert.yaml
@@ -39,6 +39,7 @@ spec:
   nodeTemplate:
     ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
 status:
+  observedGeneration: 1
   conditions:
   - message: NodeSet Ready
     reason: Ready

--- a/tests/kuttl/tests/dataplane-deploy-multiple-secrets/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-multiple-secrets/00-assert.yaml
@@ -112,6 +112,7 @@ spec:
   - install-certs-ovr
   - generic-service1
 status:
+  observedGeneration: 1
   conditions:
   - message: Deployment not started
     reason: Requested

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/00-assert.yaml
@@ -28,6 +28,7 @@ spec:
   nodeTemplate:
     ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
 status:
+  observedGeneration: 1
   conditions:
   - message: Deployment not started
     reason: Requested

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/01-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/01-assert.yaml
@@ -27,6 +27,7 @@ spec:
   nodeTemplate:
     ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
 status:
+  observedGeneration: 1
   conditions:
   - message: NodeSet Ready
     reason: Ready

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/03-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/03-assert.yaml
@@ -27,6 +27,7 @@ spec:
   nodeTemplate:
     ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
 status:
+  observedGeneration: 1
   conditions:
   - message: NodeSet Ready
     reason: Ready

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/04-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/04-assert.yaml
@@ -27,6 +27,7 @@ spec:
   nodeTemplate:
     ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
 status:
+  observedGeneration: 1
   conditions:
   - message: NodeSet Ready
     reason: Ready

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/05-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/05-assert.yaml
@@ -27,6 +27,7 @@ spec:
   nodeTemplate:
     ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
 status:
+  observedGeneration: 1
   conditions:
   - message: Deployment error occurred check deploymentStatuses for more details
     reason: Error
@@ -153,6 +154,7 @@ spec:
   servicesOverride:
     - this-service-does-not-exist
 status:
+  observedGeneration: 1
   conditions:
   - message: 'Deployment error occurred nodeSet: edpm-compute-no-nodes error: OpenStackDataPlaneService.dataplane.openstack.org
          "this-service-does-not-exist" not found'

--- a/tests/kuttl/tests/dataplane-deploy-tls-test/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-tls-test/00-assert.yaml
@@ -80,6 +80,7 @@ spec:
   - install-certs-ovrd
   - tls-dnsnames
 status:
+  observedGeneration: 1
   conditions:
   - message: Deployment not started
     reason: Requested

--- a/tests/kuttl/tests/dataplane-service-custom-image/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-service-custom-image/00-assert.yaml
@@ -14,6 +14,7 @@ spec:
       ansiblePort: 22
     ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
 status:
+  observedGeneration: 1
   conditions:
   - message: Deployment in progress
     reason: Requested

--- a/tests/kuttl/tests/dataplane-with-ipam-create-test/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-with-ipam-create-test/00-assert.yaml
@@ -56,6 +56,7 @@ spec:
   - libvirt
   - nova
 status:
+  observedGeneration: 1
   allHostnames:
     edpm-compute-0:
       ctlplane: edpm-compute-0.ctlplane.example.com


### PR DESCRIPTION
This also updates the initCondition logic that was added in commit
https://github.com/openstack-k8s-operators/dataplane-operator/commit/c95f54021688e115ebbd4b4c0c44f37214c23ba9 to match the pattern being
applied to all of openstack-k8s-operators.

Signed-off-by: James Slagle <jslagle@redhat.com>
