### PR TITLE
Remove DNSData hosts slice assertion

### DIFF
--- a/tests/kuttl/tests/dataplane-deploy-multiple-secrets/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-multiple-secrets/00-assert.yaml
@@ -337,43 +337,6 @@ metadata:
   name: openstack-edpm-tls
 spec:
   dnsDataLabelSelectorValue: dnsdata
-  hosts:
-  - hostnames:
-      - edpm-compute-0.ctlplane.example.com
-    ip: 192.168.122.100
-  - hostnames:
-      - edpm-compute-0.internalapi.example.com
-    ip: 172.17.0.100
-  - hostnames:
-      - edpm-compute-0.storage.example.com
-    ip: 172.18.0.100
-  - hostnames:
-      - edpm-compute-0.tenant.example.com
-    ip: 172.19.0.100
-  - hostnames:
-      - edpm-compute-1.ctlplane.example.com
-    ip: 192.168.122.101
-  - hostnames:
-      - edpm-compute-1.internalapi.example.com
-    ip: 172.17.0.101
-  - hostnames:
-      - edpm-compute-1.storage.example.com
-    ip: 172.18.0.101
-  - hostnames:
-      - edpm-compute-1.tenant.example.com
-    ip: 172.19.0.101
-  - hostnames:
-      - edpm-compute-2.ctlplane.example.com
-    ip: 192.168.122.102
-  - hostnames:
-      - edpm-compute-2.internalapi.example.com
-    ip: 172.17.0.102
-  - hostnames:
-      - edpm-compute-2.storage.example.com
-    ip: 172.18.0.102
-  - hostnames:
-      - edpm-compute-2.tenant.example.com
-    ip: 172.19.0.102
 status:
   conditions:
   - message: Setup complete


### PR DESCRIPTION
DNSData `hosts` slice won't be ordered and the current assertion would fail most of the times.

kuttl jobs are failing as in https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openstack-k8s-operators_dataplane-operator/790/pull-ci-openstack-k8s-operators-dataplane-operator-main-dataplane-operator-build-deploy-kuttl/1774652247741829120

[1] https://github.com/kudobuilder/kuttl/issues/76#issuecomment-632118211