### PR TITLE
Moving kustomize-to-docs invocation to make target

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,6 @@
 repos:
 - repo: local
   hooks:
-    - id: kustomize-docs
-      name: kustomize-docs
-      language: system
-      require_serial: true
-      entry: docs/kustomize_to_docs.sh
     - id: gotidy
       name: gotidy
       language: system

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ docs-dependencies: .bundle
 	bundle config set --local path 'local/bundle'; bundle install
 
 .PHONY: docs
-docs: manifests docs-dependencies crd-to-markdown ## Build docs
+docs: manifests docs-dependencies crd-to-markdown  docs-kustomize-examples ## Build docs
 	$(CRD_MARKDOWN) -f api/v1beta1/common.go -f api/v1beta1/openstackdataplaneservice_types.go -f api/v1beta1/openstackdataplanenodeset_types.go -f api/v1beta1/openstackdataplanedeployment_types.go -n OpenStackDataPlaneService -n OpenStackDataPlaneNodeSet -n OpenStackDataPlaneDeployment > docs/assemblies/custom_resources.md
 	bundle exec kramdoc --auto-ids docs/assemblies/custom_resources.md && rm docs/assemblies/custom_resources.md
 	sed -i "s/=== Custom/== Custom/g" docs/assemblies/custom_resources.adoc
@@ -112,6 +112,10 @@ docs-watch: docs-preview
 .PHONY: docs-clean
 docs-clean:
 	rm -r docs_build
+
+.PHONY: docs-examples
+docs-kustomize-examples: yq kustomize ## Generate updated docs from examples using kustomize
+	KUSTOMIZE=$(KUSTOMIZE) LOCALBIN=$(LOCALBIN) ./docs/kustomize_to_docs.sh
 
 ##@ General
 
@@ -337,6 +341,12 @@ else
 OPM = $(shell which opm)
 endif
 endif
+
+.PHONY: yq
+yq: ## Download and install yq in local env
+	python -m venv $(LOCALBIN)/.virtualenv && \
+	source $(LOCALBIN)/.virtualenv/bin/activate && \
+	pip install yq
 
 # A comma-separated list of bundle images (e.g. make catalog-build BUNDLE_IMGS=example.com/operator-bundle:v0.1.0,example.com/operator-bundle:v0.2.0).
 # These images MUST exist in a registry and be pull-able.

--- a/docs/kustomize_to_docs.sh
+++ b/docs/kustomize_to_docs.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 set -ex pipefail
 
+source $LOCALBIN/.virtualenv/bin/activate
+
 BAREMETAL=docs/assemblies/ref_example-OpenStackDataPlaneNodeSet-CR-for-bare-metal-nodes.adoc
 FOOTER=$(sed '0,/----/d' $BAREMETAL | sed -e '0,/----/d')
 sed -i '/----/q' $BAREMETAL
 sed -i 's/preprovisioned/baremetal/' examples/no_vars_from/kustomization.yaml
-oc kustomize --load-restrictor LoadRestrictionsNone examples/no_vars_from | yq ' select(.kind == "OpenStackDataPlaneNodeSet")' >> $BAREMETAL
+$KUSTOMIZE --load-restrictor LoadRestrictionsNone build examples/no_vars_from | yq ' select(.kind == "OpenStackDataPlaneNodeSet")' -Y >> $BAREMETAL
 sed -i 's/\/baremetal/\/preprovisioned/' examples/no_vars_from/kustomization.yaml
 echo -e "----\n$FOOTER" >> $BAREMETAL
 
@@ -33,7 +35,7 @@ done
 PREPROVISIONED=docs/assemblies/ref_example-OpenStackDataPlaneNodeSet-CR-for-preprovisioned-nodes.adoc
 FOOTER=$(sed '0,/----/d' $PREPROVISIONED | sed -e '0,/----/d')
 sed -i '/----/q' $PREPROVISIONED
-oc kustomize --load-restrictor LoadRestrictionsNone examples/no_vars_from | yq ' select(.kind == "OpenStackDataPlaneNodeSet")' >> $PREPROVISIONED
+$KUSTOMIZE --load-restrictor LoadRestrictionsNone build examples/no_vars_from | yq ' select(.kind == "OpenStackDataPlaneNodeSet")' -Y >> $PREPROVISIONED
 echo -e "----\n$FOOTER" >> $PREPROVISIONED
 
 COUNT=1
@@ -54,3 +56,4 @@ do
   sed -i "/$callout:/ s/$/ #<$COUNT>/" $PREPROVISIONED
   COUNT=$((COUNT + 1))
 done
+deactivate


### PR DESCRIPTION
#764 introduced dependencies on `yq` and `oc` for pre-commit. These were not documented, nor were they installed automatically during pre-commit run and cached. Potentially breaking workflow for developers or forcing them to skip checks.

Since we don't need to build examples for every commit, this script should instead be invoked by make. 