### PR TITLE
[DNM] tls disable tests

### DIFF
--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset.yaml
@@ -3,7 +3,7 @@ kind: OpenStackDataPlaneNodeSet
 metadata:
   name: openstack-edpm
 spec:
-  tlsEnabled: true
+  tlsEnabled: false
   env:
     - name: ANSIBLE_FORCE_COLOR
       value: "True"

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -2,7 +2,4 @@
 - project:
     name: openstack-k8s-operators/dataplane-operator
     github-check:
-      jobs:
-        - dataplane-operator-docs-preview
-    templates:
-      - podified-multinode-edpm-baremetal-pipeline
+      jobs: []


### PR DESCRIPTION
openstack-operator prs are not merged to enable tls and using samples from dataplane-operator without it fails, trying out disabling it.