### PR TITLE
Remove storage management netwok in OVS DPDK CR

### DIFF
--- a/examples/ovs_dpdk/values.yaml
+++ b/examples/ovs_dpdk/values.yaml
@@ -105,8 +105,6 @@ data:
         subnetName: subnet1
       - name: tenant
         subnetName: subnet1
-      - name: storagemgmt
-        subnetName: subnet1
     nodes:
       edpm-compute-0:
         hostName: edpm-compute-0


### PR DESCRIPTION
This change is to remove storage management network changes in OVS DPDK NodeSet CR.