### PR TITLE
Add multipathd image

### DIFF
--- a/api/v1beta1/openstackdataplanenodeset_types.go
+++ b/api/v1beta1/openstackdataplanenodeset_types.go
@@ -203,6 +203,7 @@ type DataplaneAnsibleImageDefaults struct {
 	Frr                        string
 	IscsiD                     string
 	Logrotate                  string
+	Multipathd                 string
 	NeutronMetadataAgent       string
 	NeutronSRIOVAgent          string
 	NovaCompute                string

--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -33,3 +33,5 @@ spec:
           value: quay.io/podified-antelope-centos9/openstack-ceilometer-ipmi:current-podified
         - name: RELATED_IMAGE_OPENSTACK_EDPM_NODE_EXPORTER_IMAGE
           value: quay.io/prometheus/node-exporter:v1.5.0
+        - name: RELATED_IMAGE_OPENSTACK_EDPM_MULTIPATHD_IMAGE
+          value: quay.io/podified-antelope-centos9/openstack-multipathd:current-podified

--- a/controllers/openstackdataplanenodeset_controller.go
+++ b/controllers/openstackdataplanenodeset_controller.go
@@ -63,6 +63,8 @@ const (
 	IscsiDDefaultImage = "quay.io/podified-antelope-centos9/openstack-iscsid:current-podified"
 	// LogrotateDefaultImage -
 	LogrotateDefaultImage = "quay.io/podified-antelope-centos9/openstack-cron:current-podified"
+	// MultipathdDefaultImage -
+	MultipathdDefaultImage = "quay.io/podified-antelope-centos9/openstack-multipathd:current-podified"
 	// NeutronMetadataAgentDefaultImage -
 	NeutronMetadataAgentDefaultImage = "quay.io/podified-antelope-centos9/openstack-neutron-metadata-agent-ovn:current-podified"
 	// NeutronSRIOVAgentDefaultImage -
@@ -87,6 +89,7 @@ func SetupAnsibleImageDefaults() {
 		Frr:                        util.GetEnvVar("RELATED_IMAGE_OPENSTACK_EDPM_FRR_DEFAULT_IMG", FrrDefaultImage),
 		IscsiD:                     util.GetEnvVar("RELATED_IMAGE_OPENSTACK_EDPM_ISCSID_DEFAULT_IMG", IscsiDDefaultImage),
 		Logrotate:                  util.GetEnvVar("RELATED_IMAGE_OPENSTACK_EDPM_LOGROTATE_CROND_DEFAULT_IMG", LogrotateDefaultImage),
+		Multipathd:                 util.GetEnvVar("RELATED_IMAGE_OPENSTACK_EDPM_MULTIPATHD_DEFAULT_IMG", MultipathdDefaultImage),
 		NeutronMetadataAgent:       util.GetEnvVar("RELATED_IMAGE_OPENSTACK_EDPM_NEUTRON_METADATA_AGENT_DEFAULT_IMG", NeutronMetadataAgentDefaultImage),
 		NeutronSRIOVAgent:          util.GetEnvVar("RELATED_IMAGE_OPENSTACK_EDPM_NEUTRON_SRIOV_AGENT_DEFAULT_IMG", NeutronSRIOVAgentDefaultImage),
 		NovaCompute:                util.GetEnvVar("RELATED_IMAGE_OPENSTACK_EDPM_NOVA_COMPUTE_DEFAULT_IMG", NovaComputeDefaultImage),

--- a/docs/assemblies/custom_resources.adoc
+++ b/docs/assemblies/custom_resources.adoc
@@ -418,6 +418,11 @@ DataplaneAnsibleImageDefaults default images for dataplane services
 | string
 | false
 
+| Multipathd
+|
+| string
+| false
+
 | NeutronMetadataAgent
 |
 | string

--- a/pkg/deployment/inventory.go
+++ b/pkg/deployment/inventory.go
@@ -241,6 +241,9 @@ func resolveGroupAnsibleVars(template *dataplanev1.NodeTemplate, group *ansible.
 	if template.Ansible.AnsibleVars["edpm_logrotate_crond_image"] == nil {
 		group.Vars["edpm_logrotate_crond_image"] = defaultImages.Logrotate
 	}
+	if template.Ansible.AnsibleVars["edpm_multipathd_image"] == nil {
+		group.Vars["edpm_multipathd_image"] = defaultImages.Multipathd
+	}
 	if template.Ansible.AnsibleVars["edpm_neutron_metadata_agent_image"] == nil {
 		group.Vars["edpm_neutron_metadata_agent_image"] = defaultImages.NeutronMetadataAgent
 	}


### PR DESCRIPTION
Adds a default environment var for the multipathd image and sets the
corresponding ansible variable, edpm_multipathd_image, in the
generated inventory.

Signed-off-by: James Slagle <jslagle@redhat.com>
