### PR TITLE
Fix how we build cert names

### DIFF
--- a/pkg/deployment/ipam.go
+++ b/pkg/deployment/ipam.go
@@ -114,7 +114,7 @@ func (dns *DataplaneDNSData) createOrPatchDNSData(ctx context.Context, helper *h
 					fqdnName := strings.Join([]string{shortName, res.DNSDomain}, ".")
 					if fqdnName != hostName {
 						fqdnNames = append(fqdnNames, fqdnName)
-						dns.Hostnames[hostName][res.Network] = fqdnName
+						dns.Hostnames[hostName][infranetworkv1.NetNameStr(netLower)] = fqdnName
 					}
 					if dataplanev1.NodeHostNameIsFQDN(hostName) && netLower == CtlPlaneNetwork {
 						fqdnNames = append(fqdnNames, hostName)


### PR DESCRIPTION
We should be using `hostName` instead of `nodeName`. Also fixes a bug where `allHostnames` did not have networks in small case.

jira: https://issues.redhat.com/browse/OSPRH-6266