### PR TITLE
Fix $RELATED_IMAGE* vars for consistency

### DIFF
--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -11,27 +11,27 @@ spec:
       containers:
       - name: manager
         env:
-        - name: RELATED_IMAGE_OPENSTACK_EDPM_FRR_DEFAULT_IMG
+        - name: RELATED_IMAGE_EDPM_FRR_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-frr:current-podified
-        - name: RELATED_IMAGE_OPENSTACK_EDPM_ISCSID_DEFAULT_IMG
+        - name: RELATED_IMAGE_EDPM_ISCSID_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-iscsid:current-podified
-        - name: RELATED_IMAGE_OPENSTACK_EDPM_LOGROTATE_CROND_DEFAULT_IMG
+        - name: RELATED_IMAGE_EDPM_LOGROTATE_CROND_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-cron:current-podified
-        - name: RELATED_IMAGE_OPENSTACK_EDPM_NOVA_COMPUTE_DEFAULT_IMG
+        - name: RELATED_IMAGE_EDPM_NOVA_COMPUTE_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-nova-compute:current-podified
-        - name: RELATED_IMAGE_OPENSTACK_EDPM_OVN_CONTROLLER_AGENT_DEFAULT_IMG
+        - name: RELATED_IMAGE_EDPM_OVN_CONTROLLER_AGENT_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-ovn-controller:current-podified
-        - name: RELATED_IMAGE_OPENSTACK_EDPM_NEUTRON_METADATA_AGENT_DEFAULT_IMG
+        - name: RELATED_IMAGE_EDPM_NEUTRON_METADATA_AGENT_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-neutron-metadata-agent-ovn:current-podified
-        - name: RELATED_IMAGE_OPENSTACK_EDPM_NEUTRON_SRIOV_AGENT_DEFAULT_IMG
+        - name: RELATED_IMAGE_EDPM_NEUTRON_SRIOV_AGENT_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-neutron-sriov-agent:current-podified
-        - name: RELATED_IMAGE_OPENSTACK_EDPM_OVN_BGP_AGENT_IMAGE
+        - name: RELATED_IMAGE_EDPM_OVN_BGP_AGENT_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-ovn-bgp-agent:current-podified
-        - name: RELATED_IMAGE_OPENSTACK_EDPM_CEILOMETER_COMPUTE_IMAGE
+        - name: RELATED_IMAGE_EDPM_CEILOMETER_COMPUTE_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-ceilometer-compute:current-podified
-        - name: RELATED_IMAGE_OPENSTACK_EDPM_CEILOMETER_IPMI_IMAGE
+        - name: RELATED_IMAGE_EDPM_CEILOMETER_IPMI_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-ceilometer-ipmi:current-podified
-        - name: RELATED_IMAGE_OPENSTACK_EDPM_NODE_EXPORTER_IMAGE
+        - name: RELATED_IMAGE_EDPM_NODE_EXPORTER_IMAGE_URL_DEFAULT
           value: quay.io/prometheus/node-exporter:v1.5.0
-        - name: RELATED_IMAGE_OPENSTACK_EDPM_MULTIPATHD_IMAGE
+        - name: RELATED_IMAGE_EDPM_MULTIPATHD_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-multipathd:current-podified

--- a/controllers/openstackdataplanenodeset_controller.go
+++ b/controllers/openstackdataplanenodeset_controller.go
@@ -86,18 +86,18 @@ const (
 // SetupAnsibleImageDefaults -
 func SetupAnsibleImageDefaults() {
 	dataplaneAnsibleImageDefaults = dataplanev1.DataplaneAnsibleImageDefaults{
-		Frr:                        util.GetEnvVar("RELATED_IMAGE_OPENSTACK_EDPM_FRR_DEFAULT_IMG", FrrDefaultImage),
-		IscsiD:                     util.GetEnvVar("RELATED_IMAGE_OPENSTACK_EDPM_ISCSID_DEFAULT_IMG", IscsiDDefaultImage),
-		Logrotate:                  util.GetEnvVar("RELATED_IMAGE_OPENSTACK_EDPM_LOGROTATE_CROND_DEFAULT_IMG", LogrotateDefaultImage),
-		Multipathd:                 util.GetEnvVar("RELATED_IMAGE_OPENSTACK_EDPM_MULTIPATHD_DEFAULT_IMG", MultipathdDefaultImage),
-		NeutronMetadataAgent:       util.GetEnvVar("RELATED_IMAGE_OPENSTACK_EDPM_NEUTRON_METADATA_AGENT_DEFAULT_IMG", NeutronMetadataAgentDefaultImage),
-		NeutronSRIOVAgent:          util.GetEnvVar("RELATED_IMAGE_OPENSTACK_EDPM_NEUTRON_SRIOV_AGENT_DEFAULT_IMG", NeutronSRIOVAgentDefaultImage),
-		NovaCompute:                util.GetEnvVar("RELATED_IMAGE_OPENSTACK_EDPM_NOVA_COMPUTE_DEFAULT_IMG", NovaComputeDefaultImage),
-		OvnControllerAgent:         util.GetEnvVar("RELATED_IMAGE_OPENSTACK_EDPM_OVN_CONTROLLER_AGENT_DEFAULT_IMG", OvnControllerAgentDefaultImage),
-		OvnBgpAgent:                util.GetEnvVar("RELATED_IMAGE_OPENSTACK_EDPM_OVN_BGP_AGENT_IMAGE", OvnBgpAgentDefaultImage),
-		TelemetryCeilometerCompute: util.GetEnvVar("RELATED_IMAGE_OPENSTACK_EDPM_CEILOMETER_COMPUTE_IMAGE", TelemetryCeilometerComputeDefaultImage),
-		TelemetryCeilometerIpmi:    util.GetEnvVar("RELATED_IMAGE_OPENSTACK_EDPM_CEILOMETER_IPMI_IMAGE", TelemetryCeilometerIpmiDefaultImage),
-		TelemetryNodeExporter:      util.GetEnvVar("RELATED_IMAGE_OPENSTACK_EDPM_NODE_EXPORTER_IMAGE", TelemetryNodeExporterDefaultImage),
+		Frr:                        util.GetEnvVar("RELATED_IMAGE_EDPM_FRR_IMAGE_URL_DEFAULT", FrrDefaultImage),
+		IscsiD:                     util.GetEnvVar("RELATED_IMAGE_EDPM_ISCSID_IMAGE_URL_DEFAULT", IscsiDDefaultImage),
+		Logrotate:                  util.GetEnvVar("RELATED_IMAGE_EDPM_LOGROTATE_CROND_IMAGE_URL_DEFAULT", LogrotateDefaultImage),
+		Multipathd:                 util.GetEnvVar("RELATED_IMAGE_EDPM_MULTIPATHD_IMAGE_URL_DEFAULT", MultipathdDefaultImage),
+		NeutronMetadataAgent:       util.GetEnvVar("RELATED_IMAGE_EDPM_NEUTRON_METADATA_AGENT_IMAGE_URL_DEFAULT", NeutronMetadataAgentDefaultImage),
+		NeutronSRIOVAgent:          util.GetEnvVar("RELATED_IMAGE_EDPM_NEUTRON_SRIOV_AGENT_IMAGE_URL_DEFAULT", NeutronSRIOVAgentDefaultImage),
+		NovaCompute:                util.GetEnvVar("RELATED_IMAGE_EDPM_NOVA_COMPUTE_IMAGE_URL_DEFAULT", NovaComputeDefaultImage),
+		OvnControllerAgent:         util.GetEnvVar("RELATED_IMAGE_EDPM_OVN_CONTROLLER_AGENT_IMAGE_URL_DEFAULT", OvnControllerAgentDefaultImage),
+		OvnBgpAgent:                util.GetEnvVar("RELATED_IMAGE_EDPM_OVN_BGP_AGENT_IMAGE_URL_DEFAULT", OvnBgpAgentDefaultImage),
+		TelemetryCeilometerCompute: util.GetEnvVar("RELATED_IMAGE_EDPM_CEILOMETER_COMPUTE_IMAGE_URL_DEFAULT", TelemetryCeilometerComputeDefaultImage),
+		TelemetryCeilometerIpmi:    util.GetEnvVar("RELATED_IMAGE_EDPM_CEILOMETER_IPMI_IMAGE_URL_DEFAULT", TelemetryCeilometerIpmiDefaultImage),
+		TelemetryNodeExporter:      util.GetEnvVar("RELATED_IMAGE_EDPM_NODE_EXPORTER_IMAGE_URL_DEFAULT", TelemetryNodeExporterDefaultImage),
 	}
 }
 


### PR DESCRIPTION
Fixes the environment variables to match the naming convention from the
other operators for consistency.

- Drops OPENSTACK from the names
- Each vars ends in IMAGE_URL_DEFAULT

Signed-off-by: James Slagle <jslagle@redhat.com>
