### PR TITLE
Fix kuttl tests when running locally without webhooks

### DIFF
--- a/tests/kuttl/tests/dataplane-deploy-global-service-test/00-dataplane-create.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-global-service-test/00-dataplane-create.yaml
@@ -117,6 +117,22 @@ kind: OpenStackDataPlaneNodeSet
 metadata:
   name: edpm-compute-global
 spec:
+  baremetalSetTemplate:
+    automatedCleaningMode: metadata
+    bmhNamespace: openshift-machine-api
+    cloudUserName: ""
+    ctlplaneInterface: ""
+    ctlplaneNetmask: 255.255.255.0
+    deploymentSSHSecret: ""
+    hardwareReqs:
+      cpuReqs:
+        countReq: {}
+        mhzReq: {}
+      diskReqs:
+        gbReq: {}
+        ssdReq: {}
+      memReqs:
+        gbReq: {}
   preProvisioned: true
   tlsEnabled: false
   services:

--- a/tests/kuttl/tests/dataplane-deploy-global-service-test/02-add-nodeset.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-global-service-test/02-add-nodeset.yaml
@@ -3,6 +3,22 @@ kind: OpenStackDataPlaneNodeSet
 metadata:
   name: edpm-compute-beta-nodeset
 spec:
+  baremetalSetTemplate:
+    automatedCleaningMode: metadata
+    bmhNamespace: openshift-machine-api
+    cloudUserName: ""
+    ctlplaneInterface: ""
+    ctlplaneNetmask: 255.255.255.0
+    deploymentSSHSecret: ""
+    hardwareReqs:
+      cpuReqs:
+        countReq: {}
+        mhzReq: {}
+      diskReqs:
+        gbReq: {}
+        ssdReq: {}
+      memReqs:
+        gbReq: {}
   preProvisioned: true
   services:
   - download-cache
@@ -13,6 +29,8 @@ spec:
   nodes: {}
   nodeTemplate:
     ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
+    ansible:
+      ansibleUser: cloud-admin
 ---
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneDeployment

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/06-add-nodeset.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/06-add-nodeset.yaml
@@ -3,6 +3,22 @@ kind: OpenStackDataPlaneNodeSet
 metadata:
   name: edpm-compute-beta-nodeset
 spec:
+  baremetalSetTemplate:
+    automatedCleaningMode: metadata
+    bmhNamespace: openshift-machine-api
+    cloudUserName: ""
+    ctlplaneInterface: ""
+    ctlplaneNetmask: 255.255.255.0
+    deploymentSSHSecret: ""
+    hardwareReqs:
+      cpuReqs:
+        countReq: {}
+        mhzReq: {}
+      diskReqs:
+        gbReq: {}
+        ssdReq: {}
+      memReqs:
+        gbReq: {}
   preProvisioned: true
   services:
   - download-cache
@@ -13,6 +29,8 @@ spec:
   nodes: {}
   nodeTemplate:
     ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
+    ansible:
+      ansibleUser: cloud-admin
 ---
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneDeployment

--- a/tests/kuttl/tests/dataplane-deploy-nodehashes-test/00-dataplane-create.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-nodehashes-test/00-dataplane-create.yaml
@@ -4,12 +4,30 @@ kind: OpenStackDataPlaneNodeSet
 metadata:
   name: edpm-compute-no-nodes
 spec:
+  baremetalSetTemplate:
+    automatedCleaningMode: metadata
+    bmhNamespace: openshift-machine-api
+    cloudUserName: ""
+    ctlplaneInterface: ""
+    ctlplaneNetmask: 255.255.255.0
+    deploymentSSHSecret: ""
+    hardwareReqs:
+      cpuReqs:
+        countReq: {}
+        mhzReq: {}
+      diskReqs:
+        gbReq: {}
+        ssdReq: {}
+      memReqs:
+        gbReq: {}
   preProvisioned: true
   services:
   - download-cache
   nodes: {}
   nodeTemplate:
     ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
+    ansible:
+      ansibleUser: cloud-admin
 ---
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneDeployment


### PR DESCRIPTION
The tests that assert hashes rely on webhooks modifying the spec so that
the asserted hash value matches the calculated value. When running
locally without webhooks, these tests would fail. This commit adds the
relevant parts to the specs that the webhooks add so that the caluclated
hashes are equivalent when running locally.

Signed-off-by: James Slagle <jslagle@redhat.com>
