### PR TITLE
Add validator for issuers and cacert secrets

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -15,7 +15,9 @@ require (
 require (
 	github.com/cert-manager/cert-manager v1.13.5
 	github.com/go-playground/validator/v10 v10.19.0
+	github.com/openstack-k8s-operators/lib-common/modules/certmanager v0.0.0-20240408095526-357d8fffa034
 	golang.org/x/exp v0.0.0-20240213143201-ec583247a57a
+	k8s.io/client-go v0.28.8
 )
 
 require (
@@ -72,7 +74,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.28.8 // indirect
-	k8s.io/client-go v0.28.8 // indirect
 	k8s.io/component-base v0.28.8 // indirect
 	k8s.io/klog/v2 v2.110.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20230905202853-d090da108d2f // indirect

--- a/api/go.sum
+++ b/api/go.sum
@@ -92,6 +92,8 @@ github.com/onsi/ginkgo/v2 v2.17.1 h1:V++EzdbhI4ZV4ev0UTIj0PzhzOcReJFyJaLjtSF55M8
 github.com/onsi/gomega v1.32.0 h1:JRYU78fJ1LPxlckP6Txi/EYqJvjtMrDC04/MM5XRHPk=
 github.com/openstack-k8s-operators/infra-operator/apis v0.3.1-0.20240408085033-bddcca32ce6e h1:6LYYB0FKVr1QUpPe25Zf7P/vowRifdDEnwQ492VT1XY=
 github.com/openstack-k8s-operators/infra-operator/apis v0.3.1-0.20240408085033-bddcca32ce6e/go.mod h1:ii0O3I9B+mkX6/D8qDQjg/q76sojufkYhM7bq7qo41E=
+github.com/openstack-k8s-operators/lib-common/modules/certmanager v0.0.0-20240408095526-357d8fffa034 h1:ncErNKpZkhwMFf2j3rl/dZWqCdVIX74u7ToiIKVWvoQ=
+github.com/openstack-k8s-operators/lib-common/modules/certmanager v0.0.0-20240408095526-357d8fffa034/go.mod h1:MkhvdDYL/CI7aQdKGHLVmUwnBGTnWhcUQMdCB9ZE4BI=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240408095526-357d8fffa034 h1:HLI/aUA7KnBK5oLPIWXMasz7zqjal4GhNn1P/fdLI20=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240408095526-357d8fffa034/go.mod h1:gqByVGUdKQB/NkhKV4eD+8NWYkHq961nC96rTCB3ywE=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240408095526-357d8fffa034 h1:LDWJWy545zW7KsZ2d2d+J5mJJK5eX/pL7mnSqn63PH4=

--- a/hack/clean_local_webhook.sh
+++ b/hack/clean_local_webhook.sh
@@ -3,3 +3,7 @@ set -ex
 
 oc delete validatingwebhookconfiguration/vopenstackdataplanenodeset.kb.io --ignore-not-found
 oc delete mutatingwebhookconfiguration/mopenstackdataplanenodeset.kb.io --ignore-not-found
+oc delete validatingwebhookconfiguration/vopenstackdataplanedeployment.kb.io --ignore-not-found
+oc delete mutatingwebhookconfiguration/mopenstackdataplanedeployment.kb.io --ignore-not-found
+oc delete validatingwebhookconfiguration/vopenstackdataplaneservice.kb.io --ignore-not-found
+oc delete mutatingwebhookconfiguration/mopenstackdataplaneservice.kb.io --ignore-not-found

--- a/hack/configure_local_webhook.sh
+++ b/hack/configure_local_webhook.sh
@@ -87,6 +87,118 @@ webhooks:
     scope: '*'
   sideEffects: None
   timeoutSeconds: 10
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: vopenstackdataplanedeployment.kb.io
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    caBundle: ${CA_BUNDLE}
+    url: https://${CRC_IP}:9443/validate-dataplane-openstack-org-v1beta1-openstackdataplanedeployment
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: vopenstackdataplanedeployment.kb.io
+  objectSelector: {}
+  rules:
+  - apiGroups:
+    - dataplane.openstack.org
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - openstackdataplanedeployments
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mopenstackdataplanedeployment.kb.io
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    caBundle: ${CA_BUNDLE}
+    url: https://${CRC_IP}:9443/mutate-dataplane-openstack-org-v1beta1-openstackdataplanedeployment
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: mopenstackdataplanedeployment.kb.io
+  objectSelector: {}
+  rules:
+  - apiGroups:
+    - dataplane.openstack.org
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - openstackdataplanedeployments
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: vopenstackdataplaneservice.kb.io
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    caBundle: ${CA_BUNDLE}
+    url: https://${CRC_IP}:9443/validate-dataplane-openstack-org-v1beta1-openstackdataplaneservice
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: vopenstackdataplaneservice.kb.io
+  objectSelector: {}
+  rules:
+  - apiGroups:
+    - dataplane.openstack.org
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - openstackdataplaneservices
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mopenstackdataplaneservice.kb.io
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    caBundle: ${CA_BUNDLE}
+    url: https://${CRC_IP}:9443/mutate-dataplane-openstack-org-v1beta1-openstackdataplaneservice
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: mopenstackdataplaneservice.kb.io
+  objectSelector: {}
+  rules:
+  - apiGroups:
+    - dataplane.openstack.org
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - openstackdataplaneservices
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
 EOF_CAT
 
 oc apply -n openstack -f ${TMPDIR}/patch_webhook_configurations.yaml


### PR DESCRIPTION
This adds validation code to confirm that any issuers or cacert secrets that are referenced in a dataplane service actually exist before the dataplane service is created.

This will be required even if tls-e is not enabled on the nodeset.

This is WIP for now as I need to add tests, but I'd like feedback on the approach.

See https://issues.redhat.com/browse/OSPRH-5893 for more discussion on the approach.  If we want to use the deployment webhook instead, it will be easy to move this over.
