### PR TITLE
Added `update` OpenStackDataPlaneService

### DIFF
--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_update.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_update.yaml
@@ -1,0 +1,6 @@
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneService
+metadata:
+  name: update
+spec:
+  playbook: osp.edpm.update


### PR DESCRIPTION
This service has been added to allow the update the EDPM nodes using `edpm_update` ansible role.

Jira: https://issues.redhat.com/browse/OSPRH-6219
Depends-On: https://github.com/openstack-k8s-operators/edpm-ansible/pull/623