### PR TITLE
Remove tls request from nova

### DIFF
--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_nova.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_nova.yaml
@@ -10,11 +10,4 @@ spec:
     # and ssh-publickey
     - nova-migration-ssh-key
   playbook: osp.edpm.nova
-  tlsCert:
-    contents:
-    - dnsnames
-    - ips
-    networks:
-    - ctlplane
-    issuer: osp-rootca-issuer-internal
   caCerts: combined-ca-bundle


### PR DESCRIPTION
Nova does not use the tls cert.  It still needs the cacert though.