### PR TITLE
[pre-commit] Updated `golangci-lint` hook to `v1.57.2`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
       exclude: ^vendor|^docs
 
 - repo: https://github.com/golangci/golangci-lint
-  rev: v1.55.2
+  rev: v1.57.2
   hooks:
     - id: golangci-lint-full
       args: ["-v"]


### PR DESCRIPTION
The version of `golangci-lint` hook configured in the pre-commit config file, `v1.55.2`, contains a dependency to a deprecated url of the library `musttag`, and installing pre-commit hooks from scratch caused this error:

```bash
    pkg/golinters/musttag.go:4:2: unrecognized import path "go.tmz.dev/musttag": parse https://go.tmz.dev/musttag?go-get=1: no go-import meta tags ()
```

This problem has been fixed with this [1] commit, so we have updated the hook to the last available version.

[1] https://github.com/golangci/golangci-lint/pull/4201