### PR TITLE
Drop kuttl check for dnsmasq

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -284,7 +284,6 @@ $(GINKGO): $(LOCALBIN)
 
 .PHONY: kuttl-test
 kuttl-test: ## Run kuttl tests
-	if oc get dnsmasq dns; then echo "dnsmasq/dns CR can not exist during kuttl tests"; exit 1; fi
 	$(LOCALBIN)/kubectl-kuttl test --config kuttl-test.yaml tests/kuttl/tests $(KUTTL_ARGS)
 
 .PHONY: kuttl


### PR DESCRIPTION
The dnsmasq resource is now created in tests that need it, and the tests
are updated to pass when it exists.

The Depends-On is not strictly required, but that change needs to be tested with dataplane kuttl tests, so I'm triggering those with this PR.

Depends-On: https://github.com/openstack-k8s-operators/install_yamls/pull/808
Signed-off-by: James Slagle <jslagle@redhat.com>
