### PR TITLE
Add caCerts to neutron-sriov

### DIFF
--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_neutron_sriov.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_neutron_sriov.yaml
@@ -6,3 +6,4 @@ spec:
   playbook: osp.edpm.neutron_sriov
   secrets:
   - neutron-sriov-agent-neutron-config
+  caCerts: combined-ca-bundle


### PR DESCRIPTION
Required for tls enabled setup.

Related-Issue: [OSPRH-6430](https://issues.redhat.com//browse/OSPRH-6430)