### PR TITLE
Use correct check for DNSData readiness

### DIFF
--- a/controllers/openstackdataplanenodeset_controller.go
+++ b/controllers/openstackdataplanenodeset_controller.go
@@ -240,7 +240,7 @@ func (r *OpenStackDataPlaneNodeSetReconciler) Reconcile(ctx context.Context, req
 	err = dnsData.EnsureDNSData(
 		ctx, helper,
 		instance, allIPSets)
-	if err != nil || !isReady {
+	if err != nil || !dnsData.Ready {
 		return ctrl.Result{}, err
 	}
 


### PR DESCRIPTION
We're using the wrong variable and dnsData is not reconciled if not ready.