### PR TITLE
[renovate]Do not track openstack-operator/api

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,8 +8,12 @@
      {
        "matchPackageNames": ["github.com/openstack-k8s-operators/dataplane-operator/api"],
        "enabled": false
-     }
-   ],
+     },
+     {
+      "matchPackageNames": ["github.com/openstack-k8s-operators/openstack-operator/api"],
+      "enabled": false
+    }
+  ],
   "postUpgradeTasks": {
     "commands": ["make gowork", "make tidy", "make manifests generate"],
     "fileFilters": ["**/go.mod", "**/go.sum", "**/*.go", "**/*.yaml"],


### PR DESCRIPTION
There is a dependency cycle due to using git hash based pseudoversions
and keeping the main and api module in the same repository and because
both openstack-operator depends on dataplane-operator/api and
dataplane-operator depends on openstack-operator/api. This creates a
constant need in renovate to generate version bumps to both
repositories. To avoid the unnecessary churn renovate is disabled on the
openstack-operator/api dependency of the dataplane-operator. In longer
term we intend to merge the two repository and therefore remove the
cycle.
