### PR TITLE
Add CertsFrom and EDPMServiceName to Service

### DIFF
--- a/api/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
@@ -36,6 +36,8 @@ spec:
                 type: boolean
               caCerts:
                 type: string
+              certsFrom:
+                type: string
               configMaps:
                 items:
                   type: string

--- a/api/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
@@ -48,6 +48,8 @@ spec:
                 type: array
               deployOnAllNodeSets:
                 type: boolean
+              edpmServiceName:
+                type: string
               openStackAnsibleEERunnerImage:
                 type: string
               play:

--- a/api/v1beta1/openstackdataplaneservice_types.go
+++ b/api/v1beta1/openstackdataplaneservice_types.go
@@ -96,6 +96,10 @@ type OpenStackDataPlaneServiceSpec struct {
 	// ContainerImages struct field names from
 	// github.com/openstack-k8s-operators/openstack-operator/apis/core/v1beta1
 	ContainerImageFields []string `json:"containerImageFields,omitempty" yaml:"containerImageFields,omitempty"`
+
+	// EDPMServiceName - name to use for edpm_service_name ansible variable
+	// +kubebuilder:validation:Optional
+	EDPMServiceName string `json:"edpmServiceName,omitempty" yaml:"edpmServiceName,omitempty"`
 }
 
 // OpenStackDataPlaneServiceStatus defines the observed state of OpenStackDataPlaneService

--- a/api/v1beta1/openstackdataplaneservice_types.go
+++ b/api/v1beta1/openstackdataplaneservice_types.go
@@ -74,6 +74,12 @@ type OpenStackDataPlaneServiceSpec struct {
 	// +kubebuilder:validation:Optional
 	OpenStackAnsibleEERunnerImage string `json:"openStackAnsibleEERunnerImage,omitempty" yaml:"openStackAnsibleEERunnerImage,omitempty"`
 
+	// CertsFrom - Service name used to obtain TLSCert and CACerts data. If both
+	// CertsFrom and either TLSCert or CACerts is set, then those fields take
+	// precedence.
+	// +kubebuilder:validation:Optional
+	CertsFrom string `json:"certsFrom,omitempty" yaml:"certsFrom,omitempty"`
+
 	// AddCertMounts - Whether to add cert mounts
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
@@ -36,6 +36,8 @@ spec:
                 type: boolean
               caCerts:
                 type: string
+              certsFrom:
+                type: string
               configMaps:
                 items:
                   type: string

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
@@ -48,6 +48,8 @@ spec:
                 type: array
               deployOnAllNodeSets:
                 type: boolean
+              edpmServiceName:
+                type: string
               openStackAnsibleEERunnerImage:
                 type: string
               play:

--- a/docs/assemblies/custom_resources.adoc
+++ b/docs/assemblies/custom_resources.adoc
@@ -353,6 +353,11 @@ OpenStackDataPlaneServiceSpec defines the desired state of OpenStackDataPlaneSer
 | ContainerImageFields - list of container image fields names that this service deploys. The field names should match the ContainerImages struct field names from github.com/openstack-k8s-operators/openstack-operator/apis/core/v1beta1
 | []string
 | false
+
+| edpmServiceName
+| EDPMServiceName - name to use for edpm_service_name ansible variable
+| string
+| false
 |===
 
 <<custom-resources,Back to Custom Resources>>

--- a/docs/assemblies/custom_resources.adoc
+++ b/docs/assemblies/custom_resources.adoc
@@ -334,6 +334,11 @@ OpenStackDataPlaneServiceSpec defines the desired state of OpenStackDataPlaneSer
 | string
 | false
 
+| certsFrom
+| CertsFrom - Service name used to obtain TLSCert and CACerts data. If both CertsFrom and either TLSCert or CACerts is set, then those fields take precedence.
+| string
+| false
+
 | addCertMounts
 | AddCertMounts - Whether to add cert mounts
 | bool

--- a/pkg/util/ansible_execution.go
+++ b/pkg/util/ansible_execution.go
@@ -122,7 +122,11 @@ func AnsibleExecution(
 			util.LogForObject(helper,
 				fmt.Sprintf("for service %s, substituting existing ansible play host with '%s'.", service.Name, nodeSet.GetName()), ansibleEE)
 		}
-		ansibleEE.Spec.ExtraVars["edpm_service_name"] = json.RawMessage([]byte(fmt.Sprintf("\"%s\"", service.Name)))
+		if service.Spec.EDPMServiceName != "" {
+			ansibleEE.Spec.ExtraVars["edpm_service_name"] = json.RawMessage([]byte(fmt.Sprintf("\"%s\"", service.Spec.EDPMServiceName)))
+		} else {
+			ansibleEE.Spec.ExtraVars["edpm_service_name"] = json.RawMessage([]byte(fmt.Sprintf("\"%s\"", service.Name)))
+		}
 
 		for sshKeyNodeName, sshKeySecret := range sshKeySecrets {
 			if service.Spec.DeployOnAllNodeSets {

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -51,6 +51,21 @@ func CreateDataplaneService(name types.NamespacedName, globalService bool) *unst
 	return th.CreateUnstructured(raw)
 }
 
+// Create an OpenStackDataPlaneService with a given NamespacedName, and a given unstructured spec
+func CreateDataPlaneServiceFromSpec(name types.NamespacedName, spec map[string]interface{}) *unstructured.Unstructured {
+	raw := map[string]interface{}{
+
+		"apiVersion": "dataplane.openstack.org/v1beta1",
+		"kind":       "OpenStackDataPlaneService",
+		"metadata": map[string]interface{}{
+			"name":      name.Name,
+			"namespace": name.Namespace,
+		},
+		"spec": spec,
+	}
+	return th.CreateUnstructured(raw)
+}
+
 // Build CustomServiceImageSpec struct with empty `Nodes` list
 func CustomServiceImageSpec() map[string]interface{} {
 
@@ -96,6 +111,7 @@ func DefaultDataPlaneNodeSetSpec(nodeSetName string) map[string]interface{} {
 	return map[string]interface{}{
 		"services": []string{
 			"foo-service",
+			"foo-update-service",
 			"global-service",
 		},
 		"nodeTemplate": map[string]interface{}{


### PR DESCRIPTION
Some services will have different names, but effectively be managing the same
EDPM service, using the same ansible content, and need the same cert data as
another service.

Jira: [OSPRH-6532](https://issues.redhat.com//browse/OSPRH-6532)
Signed-off-by: James Slagle <jslagle@redhat.com>
