### PR TITLE
Remove `deployed` from nodeset status

### DIFF
--- a/api/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
@@ -1998,8 +1998,6 @@ spec:
                 type: object
               ctlplaneSearchDomain:
                 type: string
-              deployed:
-                type: boolean
               deployedConfigHash:
                 type: string
               deployedVersion:

--- a/api/v1beta1/openstackdataplanenodeset_types.go
+++ b/api/v1beta1/openstackdataplanenodeset_types.go
@@ -148,10 +148,6 @@ type OpenStackDataPlaneNodeSetStatus struct {
 
 	// DeployedVersion
 	DeployedVersion string `json:"deployedVersion,omitempty"`
-
-	// +operator-sdk:csv:customresourcedefinitions:type=status,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
-	// Deployed
-	Deployed bool `json:"deployed,omitempty" optional:"true"`
 }
 
 //+kubebuilder:object:root=true
@@ -193,7 +189,6 @@ func (instance *OpenStackDataPlaneNodeSet) InitConditions() {
 	}
 
 	instance.Status.Conditions.Init(&cl)
-	instance.Status.Deployed = false
 }
 
 // GetAnsibleEESpec - get the fields that will be passed to AEE

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
@@ -1998,8 +1998,6 @@ spec:
                 type: object
               ctlplaneSearchDomain:
                 type: string
-              deployed:
-                type: boolean
               deployedConfigHash:
                 type: string
               deployedVersion:

--- a/controllers/openstackdataplanenodeset_controller.go
+++ b/controllers/openstackdataplanenodeset_controller.go
@@ -369,13 +369,6 @@ func (r *OpenStackDataPlaneNodeSetReconciler) Reconcile(ctx context.Context, req
 		}
 	}
 
-	if instance.Status.Deployed && instance.DeletionTimestamp.IsZero() {
-		// The NodeSet is already deployed and not being deleted, so reconciliation
-		// is already complete.
-		Log.Info("NodeSet already deployed", "instance", instance)
-		return ctrl.Result{}, nil
-	}
-
 	// Generate NodeSet Inventory
 	version, err := dataplaneutil.GetVersion(ctx, helper, instance.Namespace)
 	if err != nil {

--- a/docs/assemblies/custom_resources.adoc
+++ b/docs/assemblies/custom_resources.adoc
@@ -589,11 +589,6 @@ OpenStackDataPlaneNodeSetStatus defines the observed state of OpenStackDataPlane
 | DeployedVersion
 | string
 | false
-
-| deployed
-| Deployed
-| bool
-| false
 |===
 
 <<custom-resources,Back to Custom Resources>>

--- a/tests/functional/openstackdataplanenodeset_controller_test.go
+++ b/tests/functional/openstackdataplanenodeset_controller_test.go
@@ -187,11 +187,6 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 				Expect(dataplaneNodeSetInstance.Spec).Should(Equal(emptyNodeSpec))
 			})
 
-			It("should have the Status fields initialized", func() {
-				dataplaneNodeSetInstance := GetDataplaneNodeSet(dataplaneNodeSetName)
-				Expect(dataplaneNodeSetInstance.Status.Deployed).Should(BeFalse())
-			})
-
 			It("should have input not ready and unknown Conditions initialized", func() {
 				th.ExpectCondition(
 					dataplaneNodeSetName,
@@ -317,11 +312,6 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 				Expect(dataplaneNodeSetInstance.Spec).Should(Equal(emptyNodeSpec))
 			})
 
-			It("should have the Status fields initialized", func() {
-				dataplaneNodeSetInstance := GetDataplaneNodeSet(dataplaneNodeSetName)
-				Expect(dataplaneNodeSetInstance.Status.Deployed).Should(BeFalse())
-			})
-
 			It("should have input not ready and unknown Conditions initialized", func() {
 				th.ExpectCondition(
 					dataplaneNodeSetName,
@@ -365,11 +355,6 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 				Expect(dataplaneNodeSetInstance.Spec.PreProvisioned).Should(BeFalse())
 			})
 
-			It("should have the Status fields initialized", func() {
-				dataplaneNodeSetInstance := GetDataplaneNodeSet(dataplaneNodeSetName)
-				Expect(dataplaneNodeSetInstance.Status.Deployed).Should(BeFalse())
-			})
-
 			It("should have ReadyCondition, InputReadyCondition and SetupReadyCondition set to false, and DeploymentReadyCondition set to Unknown", func() {
 				th.ExpectCondition(
 					dataplaneNodeSetName,
@@ -411,11 +396,6 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 			It("should have the Spec fields initialized", func() {
 				dataplaneNodeSetInstance := GetDataplaneNodeSet(dataplaneNodeSetName)
 				Expect(dataplaneNodeSetInstance.Spec.PreProvisioned).Should(BeTrue())
-			})
-
-			It("should have the Status fields initialized", func() {
-				dataplaneNodeSetInstance := GetDataplaneNodeSet(dataplaneNodeSetName)
-				Expect(dataplaneNodeSetInstance.Status.Deployed).Should(BeFalse())
 			})
 
 			It("should have ReadyCondition, InputReadCondition and SetupReadyCondition set to false, and DeploymentReadyCondition set to unknown", func() {
@@ -716,11 +696,6 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 				Expect(dataplaneNodeSetInstance.Spec).Should(Equal(emptyNodeSpec))
 			})
 
-			It("should have the Status fields initialized", func() {
-				dataplaneNodeSetInstance := GetDataplaneNodeSet(dataplaneNodeSetName)
-				Expect(dataplaneNodeSetInstance.Status.Deployed).Should(BeFalse())
-			})
-
 			It("should have input not ready and unknown Conditions initialized", func() {
 				th.ExpectCondition(
 					dataplaneNodeSetName,
@@ -757,11 +732,6 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 			It("should have the Spec fields initialized", func() {
 				dataplaneNodeSetInstance := GetDataplaneNodeSet(dataplaneNodeSetName)
 				Expect(dataplaneNodeSetInstance.Spec.PreProvisioned).Should(BeFalse())
-			})
-
-			It("should have the Status fields initialized", func() {
-				dataplaneNodeSetInstance := GetDataplaneNodeSet(dataplaneNodeSetName)
-				Expect(dataplaneNodeSetInstance.Status.Deployed).Should(BeFalse())
 			})
 
 			It("should have ReadyCondition, InputReadyCondition and SetupReadyCondition set to false, and DeploymentReadyCondition set to Unknown", func() {
@@ -805,11 +775,6 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 			It("should have the Spec fields initialized", func() {
 				dataplaneNodeSetInstance := GetDataplaneNodeSet(dataplaneNodeSetName)
 				Expect(dataplaneNodeSetInstance.Spec.PreProvisioned).Should(BeTrue())
-			})
-
-			It("should have the Status fields initialized", func() {
-				dataplaneNodeSetInstance := GetDataplaneNodeSet(dataplaneNodeSetName)
-				Expect(dataplaneNodeSetInstance.Status.Deployed).Should(BeFalse())
 			})
 
 			It("should have ReadyCondition, InputReadCondition and SetupReadyCondition set to false, and DeploymentReadyCondition set to unknown", func() {


### PR DESCRIPTION
We don't set it after reconciliation. We check Ready condition to understand that nodeset has been deployed. Also this field is set as optional which now omits it from the status.