### PR TITLE
Add cert rotation kuttl tests

### DIFF
--- a/tests/kuttl/tests/dataplane-deploy-tls-test/04-rotate-certs.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-tls-test/04-rotate-certs.yaml
@@ -1,0 +1,4 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: oc delete -n openstack secrets cert-custom-tls-dns-edpm-compute-0 cert-tls-dns-ips-edpm-compute-0

--- a/tests/kuttl/tests/dataplane-deploy-tls-test/05-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-tls-test/05-assert.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+  - script: |
+      PNAME=`oc get pod -l job-name=install-certs-ovrd-certs-refresh-openstack-edpm-tls --field-selector status.phase=Succeeded  -n openstack -o name`
+      echo $PNAME
+      if [ -z "$PNAME" ]; then
+          echo "Waiting for successful ansibleee pod"
+          exit 1
+      fi
+
+      serial1=`oc get secret cert-custom-tls-dns-edpm-compute-0 -n openstack -o json|jq -r '.data."tls.crt"'|base64 -d |openssl x509 -noout -serial`
+      echo "serial1:" $serial1
+      serial2=`oc debug $PNAME -n openstack  -- cat /var/lib/openstack/certs/custom-tls-dns/edpm-compute-0.ctlplane.example.com-tls.crt |openssl x509 -noout -serial`
+      echo "serial2:" $serial2
+      if [ $serial1 != $serial2 ]; then
+          echo "serials for cert-custom-tls-dns-edpm-compute-0 not equal"
+          exit 1
+      fi
+
+      serial1=`oc get secret cert-tls-dns-ips-edpm-compute-0 -n openstack -o json|jq -r '.data."tls.crt"'|base64 -d |openssl x509 -noout -serial`
+      echo "serial1:" $serial1
+      serial2=`oc debug $PNAME -n openstack -- cat /var/lib/openstack/certs/tls-dns-ips/edpm-compute-0.ctlplane.example.com-tls.crt |openssl x509 -noout -serial`
+      echo "serial2:" $serial2
+      if [ $serial1 != $serial2 ]; then
+          echo "serials for cert-tls-dns-ips-edpm-compute-0 not equal"
+          exit 1
+      fi
+
+      exit 0

--- a/tests/kuttl/tests/dataplane-deploy-tls-test/05-dataplane-redeploy.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-tls-test/05-dataplane-redeploy.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneDeployment
+metadata:
+  name: certs-refresh
+spec:
+  nodeSets:
+    - openstack-edpm-tls
+  servicesOverride:
+    - install-certs-ovrd
+    - tls-dns-ips
+    - custom-tls-dns


### PR DESCRIPTION
This will add kuttl tests to confirm that certs are rotated when a new deployment is done.