### PR TITLE
Fix default image name for Apache

### DIFF
--- a/api/v1beta1/openstackdataplanenodeset_types.go
+++ b/api/v1beta1/openstackdataplanenodeset_types.go
@@ -206,7 +206,7 @@ func (instance OpenStackDataPlaneNodeSet) GetAnsibleEESpec() AnsibleEESpec {
 var ContainerImageDefaults = openstackv1.ContainerImages{
 	ContainerTemplate: openstackv1.ContainerTemplate{
 		AgentImage:                    getStrPtr("quay.io/openstack-k8s-operators/openstack-baremetal-operator-agent:current-podified"),
-		ApacheImage:                   getStrPtr("registry.redhat.io/ubi9/httpd-24:current-podified"),
+		ApacheImage:                   getStrPtr("registry.redhat.io/ubi9/httpd-24:latest"),
 		EdpmFrrImage:                  getStrPtr("quay.io/podified-antelope-centos9/openstack-frr:current-podified"),
 		EdpmIscsidImage:               getStrPtr("quay.io/podified-antelope-centos9/openstack-iscsid:current-podified"),
 		EdpmLogrotateCrondImage:       getStrPtr("quay.io/podified-antelope-centos9/openstack-cron:current-podified"),


### PR DESCRIPTION
`current-podified` tag does not exist in `registry.redhat.io/ubi9/httpd-24`.  I don't know if `latest` is the proper alternative, but I am proposing it here since it is available in the registry.