### PR TITLE
[pre-commit][kuttl]Check for multiple TestAsserts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,3 +65,11 @@ repos:
   hooks:
     - id: golangci-lint-full
       args: ["-v"]
+
+- repo: https://github.com/openstack-k8s-operators/openstack-k8s-operators-ci
+  # NOTE(gibi): we cannot automatically track main here
+  # see https://pre-commit.com/#using-the-latest-version-for-a-repository
+  rev: e30d72fcbced0ab8a7b6d23be1dee129e2a7b849
+  hooks:
+    - id: kuttl-single-test-assert
+      args: ["tests/kuttl"]


### PR DESCRIPTION
Add a new pre-commit check to avoid using more than one TestAssert in a
single kuttl assert file as that can lead to false positives as only the
last TestAssert is run by kuttl.

Fortunately there was no such issue in this repo.
