### PR TITLE
[tls] use cert duration/renewbefore from issuer annotation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,6 @@ require (
 	k8s.io/api v0.28.9
 	k8s.io/apimachinery v0.28.9
 	k8s.io/client-go v0.28.9
-	k8s.io/utils v0.0.0-20240423183400-0849a56e8f22
 	sigs.k8s.io/controller-runtime v0.16.5
 )
 
@@ -114,6 +113,7 @@ require (
 	k8s.io/component-base v0.28.9 // indirect
 	k8s.io/klog/v2 v2.120.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect
+	k8s.io/utils v0.0.0-20240423183400-0849a56e8f22 // indirect
 	sigs.k8s.io/gateway-api v0.8.0 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect


### PR DESCRIPTION
use cert duration and renewBefore from annotations set on issuer
- if no duration annotation is set, use the default from certmanager lib-common module,
- if no renewBefore annotation is set, the cert-manager default is used.

Depends-On: https://github.com/openstack-k8s-operators/lib-common/pull/506