### PR TITLE
Add EDPMRoleServiceName to OpenstackDataPlaneServiceCert

### DIFF
--- a/api/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
@@ -66,6 +66,8 @@ spec:
                     items:
                       type: string
                     type: array
+                  edpmRoleServiceName:
+                    type: string
                   issuer:
                     type: string
                   keyUsages:

--- a/api/v1beta1/openstackdataplaneservice_types.go
+++ b/api/v1beta1/openstackdataplaneservice_types.go
@@ -44,6 +44,15 @@ type OpenstackDataPlaneServiceCert struct {
 	// KeyUsages to be added to the issued cert
 	// +kubebuilder:validation:Optional
 	KeyUsages []certmgrv1.KeyUsage `json:"keyUsages,omitempty" yaml:"keyUsages,omitempty"`
+
+	// EDPMRoleServiceName is the value of the <role>_service_name variable from
+	// the edpm-ansible role where this certificate is used. For example if the
+	// certificate is for edpm_ovn from edpm-ansible, EDPMRoleServiceName must be
+	// ovn, which matches the edpm_ovn_service_name variable from the role.  If
+	// not set, OpenStackDataPlaneService.Spec.EDPMServiceName is used. If
+	// OpenStackDataPlaneService.Spec.EDPMServiceName is not set, then
+	// OpenStackDataPlaneService.Name is used.
+	EDPMRoleServiceName string `json:"edpmRoleServiceName,omitempty"`
 }
 
 // OpenStackDataPlaneServiceSpec defines the desired state of OpenStackDataPlaneService

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
@@ -66,6 +66,8 @@ spec:
                     items:
                       type: string
                     type: array
+                  edpmRoleServiceName:
+                    type: string
                   issuer:
                     type: string
                   keyUsages:

--- a/docs/assemblies/custom_resources.adoc
+++ b/docs/assemblies/custom_resources.adoc
@@ -405,6 +405,11 @@ OpenstackDataPlaneServiceCert defines the property of a TLS cert issued for a da
 | KeyUsages to be added to the issued cert
 | []certmgrv1.KeyUsage
 | false
+
+| edpmRoleServiceName
+| EDPMRoleServiceName is the value of the +++<role>+++_service_name variable from the edpm-ansible role where this certificate is used. For example if the certificate is for edpm_ovn from edpm-ansible, EDPMRoleServiceName must be ovn, which matches the edpm_ovn_service_name variable from the role. If not set, OpenStackDataPlaneService.Spec.EDPMServiceName is used. If OpenStackDataPlaneService.Spec.EDPMServiceName is not set, then OpenStackDataPlaneService.Name is used.+++</role>+++
+| string
+| false
 |===
 
 <<custom-resources,Back to Custom Resources>>

--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -273,9 +273,15 @@ func (d *Deployer) addCertMounts(
 					Projected: &projectedVolumeSource,
 				},
 			}
+			certMountDir := service.Spec.TLSCert.EDPMRoleServiceName
+			if certMountDir == "" && service.Spec.EDPMServiceName != "" {
+				certMountDir = service.Spec.EDPMServiceName
+			} else {
+				certMountDir = service.Name
+			}
 			certVolumeMount := corev1.VolumeMount{
 				Name:      GetServiceCertsSecretName(d.NodeSet, service.Name, 0),
-				MountPath: path.Join(CertPaths, service.Name),
+				MountPath: path.Join(CertPaths, certMountDir),
 			}
 			volMounts.Volumes = append(volMounts.Volumes, certVolume)
 			volMounts.Mounts = append(volMounts.Mounts, certVolumeMount)


### PR DESCRIPTION
EDPMRoleServiceName is used as the base dir for the mount path for the
cert. If not specified, OpenStackDataPlaneService.Spec.EDPMServiceName
is used, and if that is not specified OpenStackDataPlaneService.Name is
used.

This removes the coupling between the service name and the mount path so
that custom services can use the same ansible content, and the ansible
content can use a single consistent path.

Jira: https://issues.redhat.com/browse/OSPRH-7112
Related-To: https://github.com/openstack-k8s-operators/edpm-ansible/pull/658
Signed-off-by: James Slagle <jslagle@redhat.com>
