### PR TITLE
Use dnf instead of rpm

### DIFF
--- a/docs/assemblies/proc_hotfixing-the-data-plane-rpm-content.adoc
+++ b/docs/assemblies/proc_hotfixing-the-data-plane-rpm-content.adoc
@@ -34,10 +34,9 @@ Repeat this step for each data plane node that the hotfix must be applied to.
 +
 ----
 $ ssh <ssh_user>@<data_plane_node>
-$ sudo rpm -F /tmp/<hotfix_id>/rpms/*.rpm
+$ sudo dnf in -y /tmp/<hotfix_id>/rpms/*.rpm
 ----
 +
-* The `-F` (`--freshen`) `rpm` command option updates the RPM content if earlier versions are already installed.
 * Replace `<ssh_user>` with the SSH user name.
 * Replace `<data_plane_node>` with the hostname or IP for the data plane node.
 * Replace `<hotfix_id>` with a hotfix identifier such as a Jira issue, for example `osprh-0000`.


### PR DESCRIPTION
This change updates the hotfix docs to use the dnf command instead of rpm directly