### PR TITLE
Correct comment for OSDPS 'Play' object

### DIFF
--- a/api/v1beta1/openstackdataplaneservice_types.go
+++ b/api/v1beta1/openstackdataplaneservice_types.go
@@ -70,7 +70,9 @@ type OpenStackDataPlaneServiceSpec struct {
 	// +kubebuilder:validation:Optional
 	TLSCert *OpenstackDataPlaneServiceCert `json:"tlsCert,omitempty" yaml:"tlsCert,omitempty"`
 
-	// Play is an inline playbook contents that ansible will run on execution.
+	// Play is inline Ansible Play contents that ansible will run on execution.
+	// An Ansible Play should be in Dictionary format as per:
+	// https://github.com/ansible/ansible/blob/10f9b8e6554e024e3561170153b8e7fde5e7e4fb/test/units/playbook/test_play.py#L48
 	Play string `json:"play,omitempty"`
 
 	// Playbook is a path to the playbook that ansible will run on this execution

--- a/docs/assemblies/custom_resources.adoc
+++ b/docs/assemblies/custom_resources.adoc
@@ -315,7 +315,7 @@ OpenStackDataPlaneServiceSpec defines the desired state of OpenStackDataPlaneSer
 | false
 
 | play
-| Play is an inline playbook contents that ansible will run on execution.
+| Play is inline Ansible Play contents that ansible will run on execution. An Ansible Play should be in Dictionary format as per: https://github.com/ansible/ansible/blob/10f9b8e6554e024e3561170153b8e7fde5e7e4fb/test/units/playbook/test_play.py#L48
 | string
 | false
 


### PR DESCRIPTION
This change fixes the terminology used to describe the 'Play' object of the OpenStackDataPlaneService. This object is not an in-line 'playbook', but rather an individual Ansible 'Play'. The two are differentiated by their type. A Ansible Playbook is a list of Plays, where a Play is a dictionary object as per:

https://github.com/ansible/ansible/blob/10f9b8e6554e024e3561170153b8e7fde5e7e4fb/test/units/playbook/test_play.py#L48