### PR TITLE
 Add data-plane-adoption job to the zuul dataplane operator github-check layout

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -4,5 +4,15 @@
     github-check:
       jobs:
         - dataplane-operator-docs-preview
+        - openstack-k8s-operators-content-provider
+        - cifmw-data-plane-adoption-osp-17-to-extracted-crc:
+            dependencies:
+              - openstack-k8s-operators-content-provider
+            files:
+              - ^api/*
+              - ^config/*
+              - ^controllers/*
+              - ^pkg/*
+
     templates:
       - podified-multinode-edpm-baremetal-pipeline


### PR DESCRIPTION
This adds cifmw-data-plane-adoption-osp-17-to-extracted-crc so we get
adoption coverage in github-check.

https://issues.redhat.com/browse/OSPRH-5770