### PR TITLE
Add containerImageFields for dhcp and ovn agents

### DIFF
--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_neutron_dhcp.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_neutron_dhcp.yaml
@@ -7,3 +7,5 @@ spec:
   secrets:
   - neutron-dhcp-agent-neutron-config
   caCerts: combined-ca-bundle
+  containerImageFields:
+  - EdpmNeutronDhcpAgentImage

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_neutron_ovn.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_neutron_ovn.yaml
@@ -18,3 +18,5 @@ spec:
       - key encipherment
       - client auth
   caCerts: combined-ca-bundle
+  containerImageFields:
+  - EdpmNeutronOvnAgentImage

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_neutron_sriov.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_neutron_sriov.yaml
@@ -8,4 +8,4 @@ spec:
   - neutron-sriov-agent-neutron-config
   caCerts: combined-ca-bundle
   containerImageFields:
-  - EdpmSriovAgentImage
+  - EdpmNeutronSriovAgentImage

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_ovn_bgp_agent.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_ovn_bgp_agent.yaml
@@ -20,4 +20,4 @@ spec:
       - client auth
   caCerts: combined-ca-bundle
   containerImageFields:
-  - EdpmOvnBpgAgentImage
+  - EdpmOvnBgpAgentImage


### PR DESCRIPTION
Also fix wrong references for sriov and ovn bgp
agent images.

Related-Issue: [OSPRH-6639](https://issues.redhat.com//browse/OSPRH-6639)