### PR TITLE
Error when multiple DNSMasq resources found

### DIFF
--- a/api/v1beta1/conditions.go
+++ b/api/v1beta1/conditions.go
@@ -82,6 +82,9 @@ const (
 	// NodeSetDNSDataReadyErrorMessage error
 	NodeSetDNSDataReadyErrorMessage = "NodeSetDNSDataReady error occurred"
 
+	// NodeSetDNSDataMultipleDNSMasqErrorMessage error
+	NodeSetDNSDataMultipleDNSMasqErrorMessage = "NodeSet DNSData error occurred. Multiple DNSMasq resources exist."
+
 	// InputReadyWaitingMessage not yet ready
 	InputReadyWaitingMessage = "Waiting for input %s, not yet ready"
 


### PR DESCRIPTION
If multiple DNSMasq resources are found, we should error and not just
pick the first one, as the order returned is not consistent.

Jira: https://issues.redhat.com/browse/OSPRH-7465
Signed-off-by: James Slagle <jslagle@redhat.com>
