### PR TITLE
Set RoleRef.APIGroup to fix reconcile loop

### DIFF
--- a/controllers/openstackdataplanenodeset_controller.go
+++ b/controllers/openstackdataplanenodeset_controller.go
@@ -327,8 +327,9 @@ func (r *OpenStackDataPlaneNodeSetReconciler) Reconcile(ctx context.Context, req
 				},
 			},
 			RoleRef: rbacv1.RoleRef{
-				Kind: "ClusterRole",
-				Name: "registry-viewer",
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "ClusterRole",
+				Name:     "registry-viewer",
 			},
 		},
 		time.Duration(10),


### PR DESCRIPTION
Set RoleRef.APIGroup to fix reconcile loop

Without setting RoleRef.APIGroup, we keep updating RoleBinding since
APIGroup will be set automatically, and dataplane-operator will unset
it. Setting it explicitly fixes that loop.

Jira: https://issues.redhat.com/browse/OSPRH-7543
Signed-off-by: James Slagle <jslagle@redhat.com>
