### PR TITLE
Rename Play parameter to PlaybookContents

### DIFF
--- a/api/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
+++ b/api/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
@@ -75,9 +75,9 @@ spec:
                 type: string
               openStackAnsibleEERunnerImage:
                 type: string
-              play:
-                type: string
               playbook:
+                type: string
+              playbookContents:
                 type: string
               secrets:
                 items:

--- a/api/v1beta1/openstackdataplaneservice_types.go
+++ b/api/v1beta1/openstackdataplaneservice_types.go
@@ -74,8 +74,8 @@ type OpenStackDataPlaneServiceSpec struct {
 	// +kubebuilder:validation:Optional
 	TLSCerts map[string]OpenstackDataPlaneServiceCert `json:"tlsCerts,omitempty" yaml:"tlsCerts,omitempty"`
 
-	// Play is an inline playbook contents that ansible will run on execution.
-	Play string `json:"play,omitempty"`
+	// PlaybookContents is an inline playbook contents that ansible will run on execution.
+	PlaybookContents string `json:"playbookContents,omitempty"`
 
 	// Playbook is a path to the playbook that ansible will run on this execution
 	Playbook string `json:"playbook,omitempty"`

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
@@ -75,9 +75,9 @@ spec:
                 type: string
               openStackAnsibleEERunnerImage:
                 type: string
-              play:
-                type: string
               playbook:
+                type: string
+              playbookContents:
                 type: string
               secrets:
                 items:

--- a/docs/assemblies/custom_resources.adoc
+++ b/docs/assemblies/custom_resources.adoc
@@ -319,8 +319,8 @@ OpenStackDataPlaneServiceSpec defines the desired state of OpenStackDataPlaneSer
 | map[string]<<openstackdataplaneservicecert,OpenstackDataPlaneServiceCert>>
 | false
 
-| play
-| Play is an inline playbook contents that ansible will run on execution.
+| playbookContents
+| PlaybookContents is an inline playbook contents that ansible will run on execution.
 | string
 | false
 

--- a/docs/assemblies/proc_building-a-custom-ansible-runner-image.adoc
+++ b/docs/assemblies/proc_building-a-custom-ansible-runner-image.adoc
@@ -40,7 +40,7 @@ endif::[]
 ifeval::["{build}" == "downstream"]
   openStackAnsibleEERunnerImage: registry.redhat.io/rhosp-dev-preview/ee-openstack-ansible-ee-rhel9:0.1.3-5 <1>
 endif::[]
-  play: |
+  playbookContents: |
 ----
 +
 <1> Your container image that the `ansible-runner` execution environment uses to execute Ansible.

--- a/docs/assemblies/proc_creating-a-custom-service.adoc
+++ b/docs/assemblies/proc_creating-a-custom-service.adoc
@@ -51,7 +51,7 @@ metadata:
   name: custom-service
 spec:
   label: dataplane-deployment-custom-service
-  play: |
+  playbookContents: |
     hosts: all
     tasks:
       - name: Hello World!
@@ -77,7 +77,7 @@ metadata:
   name: custom-service
 spec:
   ...
-  play: |
+  playbookContents: |
     ...
   secrets:
     - name: hello-world-secret-0
@@ -97,7 +97,7 @@ metadata:
   name: custom-global-service
 spec:
   label: custom-global-service
-  play: |
+  playbookContents: |
     - hosts: localhost
       gather_facts: no
       name: global play

--- a/pkg/util/ansible_execution.go
+++ b/pkg/util/ansible_execution.go
@@ -101,8 +101,8 @@ func AnsibleExecution(
 			ansibleEE.Spec.CmdLine = strings.TrimSpace(cmdLineArguments.String())
 		}
 
-		if len(service.Spec.Play) > 0 {
-			ansibleEE.Spec.Play = service.Spec.Play
+		if len(service.Spec.PlaybookContents) > 0 {
+			ansibleEE.Spec.Play = service.Spec.PlaybookContents
 		}
 		if len(service.Spec.Playbook) > 0 {
 			ansibleEE.Spec.Playbook = service.Spec.Playbook
@@ -232,7 +232,6 @@ func AnsibleExecution(
 
 		return nil
 	})
-
 	if err != nil {
 		util.LogErrorForObject(helper, err, fmt.Sprintf("Unable to create AnsibleEE %s", ansibleEE.Name), ansibleEE)
 		return err
@@ -248,7 +247,8 @@ func AnsibleExecution(
 // "openstackdataplanenodeset":    <nodeSetName>,
 // If none or more than one is found, return nil and error
 func GetAnsibleExecution(ctx context.Context,
-	helper *helper.Helper, obj client.Object, labelSelector map[string]string) (*ansibleeev1.OpenStackAnsibleEE, error) {
+	helper *helper.Helper, obj client.Object, labelSelector map[string]string,
+) (*ansibleeev1.OpenStackAnsibleEE, error) {
 	var err error
 	ansibleEEs := &ansibleeev1.OpenStackAnsibleEEList{}
 
@@ -290,7 +290,8 @@ func getAnsibleExecutionNamePrefix(serviceName string) string {
 // GetAnsibleExecutionNameAndLabels Name and Labels of AnsibleEE
 func GetAnsibleExecutionNameAndLabels(service *dataplanev1.OpenStackDataPlaneService,
 	deploymentName string,
-	nodeSetName string) (string, map[string]string) {
+	nodeSetName string,
+) (string, map[string]string) {
 	executionName := fmt.Sprintf("%s-%s", getAnsibleExecutionNamePrefix(service.Name), deploymentName)
 	if !service.Spec.DeployOnAllNodeSets {
 		executionName = fmt.Sprintf("%s-%s", executionName, nodeSetName)

--- a/tests/kuttl/tests/dataplane-deploy-global-service-test/00-dataplane-create.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-global-service-test/00-dataplane-create.yaml
@@ -71,7 +71,7 @@ metadata:
   name: custom-global-service
 spec:
   label: custom-global-service
-  play: |
+  playbookContents: |
     - hosts: localhost
       gather_facts: no
       name: global kuttl play

--- a/tests/kuttl/tests/dataplane-deploy-multiple-secrets/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-multiple-secrets/00-assert.yaml
@@ -8,7 +8,7 @@ spec:
     default:
       contents:
       - dnsnames
-  play: |
+  playbookContents: |
     - hosts: localhost
       gather_facts: no
       name: kuttl play
@@ -23,7 +23,7 @@ metadata:
   name: install-certs-ovr
 spec:
   addCertMounts: True
-  play: |
+  playbookContents: |
     - hosts: localhost
       gather_facts: no
       name: kuttl play

--- a/tests/kuttl/tests/dataplane-deploy-multiple-secrets/00-dataplane-create.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-multiple-secrets/00-dataplane-create.yaml
@@ -8,7 +8,7 @@ spec:
     default:
       contents:
       - dnsnames
-  play: |
+  playbookContents: |
     - hosts: localhost
       gather_facts: no
       name: kuttl play
@@ -23,7 +23,7 @@ metadata:
   name: install-certs-ovr
 spec:
   addCertMounts: True
-  play: |
+  playbookContents: |
     - hosts: localhost
       gather_facts: no
       name: kuttl play

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/02-dataplane-deploy-services-override.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/02-dataplane-deploy-services-override.yaml
@@ -5,7 +5,7 @@ metadata:
   name: custom-svc
 spec:
   label: custom-svc
-  play: |
+  playbookContents: |
     - hosts: localhost
       gather_facts: no
       name: kuttl play

--- a/tests/kuttl/tests/dataplane-deploy-tls-test/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-tls-test/00-assert.yaml
@@ -11,7 +11,7 @@ spec:
     second:
       contents:
       - ips
-  play: |
+  playbookContents: |
     - hosts: localhost
       gather_facts: no
       name: kuttl play
@@ -26,7 +26,7 @@ metadata:
   name: install-certs-ovrd
 spec:
   addCertMounts: True
-  play: |
+  playbookContents: |
     - hosts: localhost
       gather_facts: no
       name: kuttl play

--- a/tests/kuttl/tests/dataplane-deploy-tls-test/00-dataplane-create.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-tls-test/00-dataplane-create.yaml
@@ -11,7 +11,7 @@ spec:
     second:
       contents:
       - ips
-  play: |
+  playbookContents: |
     - hosts: localhost
       gather_facts: no
       name: kuttl play
@@ -26,7 +26,7 @@ metadata:
   name: install-certs-ovrd
 spec:
   addCertMounts: True
-  play: |
+  playbookContents: |
     - hosts: localhost
       gather_facts: no
       name: kuttl play

--- a/tests/kuttl/tests/dataplane-deploy-tls-test/03-dataplane-deploy-services-override.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-tls-test/03-dataplane-deploy-services-override.yaml
@@ -13,7 +13,7 @@ spec:
       issuer: osp-rootca-issuer-internal
       networks:
       - ctlplane
-  play: |
+  playbookContents: |
     - hosts: localhost
       gather_facts: no
       name: kuttl play
@@ -37,7 +37,7 @@ spec:
       - digital signature
       - server auth
       - client auth
-  play: |
+  playbookContents: |
     - hosts: localhost
       gather_facts: no
       name: kuttl play
@@ -52,7 +52,7 @@ metadata:
   name: install-certs-ovrd
 spec:
   addCertMounts: True
-  play: |
+  playbookContents: |
     - hosts: localhost
       gather_facts: no
       name: kuttl play

--- a/tests/kuttl/tests/dataplane-service-config/00-create.yaml
+++ b/tests/kuttl/tests/dataplane-service-config/00-create.yaml
@@ -39,7 +39,7 @@ kind: OpenStackDataPlaneService
 metadata:
   name: kuttl-service
 spec:
-  play: |
+  playbookContents: |
     - hosts: localhost
       gather_facts: no
       name: kuttl play

--- a/tests/kuttl/tests/dataplane-service-failure/00-create.yaml
+++ b/tests/kuttl/tests/dataplane-service-failure/00-create.yaml
@@ -3,7 +3,7 @@ kind: OpenStackDataPlaneService
 metadata:
   name: failed-service
 spec:
-  play: |
+  playbookContents: |
     - hosts: localhost
       gather_facts: no
       name: kuttl play


### PR DESCRIPTION
We have a "Play" parameter in our Services that is leveraged to provide a in-line Ansible playbook. This parameter is ultimately passed into the AEE container using the RUNNER_PLAYBOOK env var. Given that an Ansible Play is a single component of a playbook. This change rectifies our use of Ansible terminology and provides a more accurate description of what the field expects to receive from the user.

Depends-On: https://github.com/openstack-k8s-operators/install_yamls/pull/847