### PR TITLE
Order nodes  when creating dnsdata

### DIFF
--- a/tests/kuttl/tests/dataplane-multinode-nodeset-create-test/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-multinode-nodeset-create-test/00-assert.yaml
@@ -1,0 +1,202 @@
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneNodeSet
+metadata:
+  name: openstack-edpm-multinode
+status:
+  allHostnames:
+    edpm-compute-0:
+      ctlplane: edpm-compute-0.ctlplane.example.com
+      internalapi: edpm-compute-0.internalapi.example.com
+      storage: edpm-compute-0.storage.example.com
+      tenant: edpm-compute-0.tenant.example.com
+    edpm-compute-1:
+      ctlplane: edpm-compute-1.ctlplane.example.com
+      internalapi: edpm-compute-1.internalapi.example.com
+      storage: edpm-compute-1.storage.example.com
+      tenant: edpm-compute-1.tenant.example.com
+  allIPs:
+    edpm-compute-0:
+      ctlplane: 192.168.122.100
+      internalapi: 172.17.0.100
+      storage: 172.18.0.100
+      tenant: 172.19.0.100
+    edpm-compute-1:
+      ctlplane: 192.168.122.101
+      internalapi: 172.17.0.101
+      storage: 172.18.0.101
+      tenant: 172.19.0.101
+  observedGeneration: 1
+  ctlplaneSearchDomain: ctlplane.example.com
+  conditions:
+  - message: Deployment not started
+    reason: Requested
+    status: "False"
+    type: Ready
+  - message: Deployment not started
+    reason: Requested
+    status: "False"
+    type: DeploymentReady
+  - message: Input data complete
+    reason: Ready
+    status: "True"
+    type: InputReady
+  - message: NodeSetDNSDataReady ready
+    reason: Ready
+    status: "True"
+    type: NodeSetDNSDataReady
+  - message: NodeSetIPReservationReady ready
+    reason: Ready
+    status: "True"
+    type: NodeSetIPReservationReady
+  - message: ServiceAccount created
+    reason: Ready
+    status: "True"
+    type: ServiceAccountReady
+  - message: Setup complete
+    reason: Ready
+    status: "True"
+    type: SetupReady
+---
+apiVersion: network.openstack.org/v1beta1
+kind: IPSet
+metadata:
+  name: edpm-compute-0
+status:
+  conditions:
+  - message: Setup complete
+    reason: Ready
+    status: "True"
+    type: Ready
+  - message: Input data complete
+    reason: Ready
+    status: "True"
+    type: InputReady
+  - message: Reservation successful
+    reason: Ready
+    status: "True"
+    type: ReservationReady
+  reservations:
+  - address: 192.168.122.100
+    cidr: 192.168.122.0/24
+    dnsDomain: ctlplane.example.com
+    gateway: 192.168.122.1
+    mtu: 1500
+    network: ctlplane
+    routes:
+    - destination: 0.0.0.0/0
+      nexthop: 192.168.122.1
+    subnet: subnet1
+  - address: 172.17.0.100
+    cidr: 172.17.0.0/24
+    dnsDomain: internalapi.example.com
+    mtu: 1500
+    network: internalapi
+    subnet: subnet1
+    vlan: 20
+  - address: 172.18.0.100
+    cidr: 172.18.0.0/24
+    dnsDomain: storage.example.com
+    mtu: 1500
+    network: storage
+    subnet: subnet1
+    vlan: 21
+  - address: 172.19.0.100
+    cidr: 172.19.0.0/24
+    dnsDomain: tenant.example.com
+    mtu: 1500
+    network: tenant
+    subnet: subnet1
+    vlan: 22
+---
+apiVersion: network.openstack.org/v1beta1
+kind: IPSet
+metadata:
+  name: edpm-compute-1
+status:
+  conditions:
+  - message: Setup complete
+    reason: Ready
+    status: "True"
+    type: Ready
+  - message: Input data complete
+    reason: Ready
+    status: "True"
+    type: InputReady
+  - message: Reservation successful
+    reason: Ready
+    status: "True"
+    type: ReservationReady
+  reservations:
+  - address: 192.168.122.101
+    cidr: 192.168.122.0/24
+    dnsDomain: ctlplane.example.com
+    gateway: 192.168.122.1
+    mtu: 1500
+    network: ctlplane
+    routes:
+    - destination: 0.0.0.0/0
+      nexthop: 192.168.122.1
+    subnet: subnet1
+  - address: 172.17.0.101
+    cidr: 172.17.0.0/24
+    dnsDomain: internalapi.example.com
+    mtu: 1500
+    network: internalapi
+    subnet: subnet1
+    vlan: 20
+  - address: 172.18.0.101
+    cidr: 172.18.0.0/24
+    dnsDomain: storage.example.com
+    mtu: 1500
+    network: storage
+    subnet: subnet1
+    vlan: 21
+  - address: 172.19.0.101
+    cidr: 172.19.0.0/24
+    dnsDomain: tenant.example.com
+    mtu: 1500
+    network: tenant
+    subnet: subnet1
+    vlan: 22
+---
+apiVersion: network.openstack.org/v1beta1
+kind: DNSData
+metadata:
+  name: openstack-edpm-multinode
+spec:
+  dnsDataLabelSelectorValue: dnsdata
+  hosts:
+  - hostnames:
+    - edpm-compute-0.ctlplane.example.com
+    ip: 192.168.122.100
+  - hostnames:
+    - edpm-compute-0.internalapi.example.com
+    ip: 172.17.0.100
+  - hostnames:
+    - edpm-compute-0.storage.example.com
+    ip: 172.18.0.100
+  - hostnames:
+    - edpm-compute-0.tenant.example.com
+    ip: 172.19.0.100
+  - hostnames:
+    - edpm-compute-1.ctlplane.example.com
+    ip: 192.168.122.101
+  - hostnames:
+    - edpm-compute-1.internalapi.example.com
+    ip: 172.17.0.101
+  - hostnames:
+    - edpm-compute-1.storage.example.com
+    ip: 172.18.0.101
+  - hostnames:
+    - edpm-compute-1.tenant.example.com
+    ip: 172.19.0.101
+status:
+  conditions:
+  - message: Setup complete
+    reason: Ready
+    status: "True"
+    type: Ready
+  - message: Input data complete
+    reason: Ready
+    status: "True"
+    type: ServiceConfigReady

--- a/tests/kuttl/tests/dataplane-multinode-nodeset-create-test/00-dataplane-create.yaml
+++ b/tests/kuttl/tests/dataplane-multinode-nodeset-create-test/00-dataplane-create.yaml
@@ -1,0 +1,118 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: network-config-template
+data:
+  network_config_template: |
+    ---
+    {% set mtu_list = [ctlplane_mtu] %}
+    {% for network in nodeset_networks %}
+    {{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+    {%- endfor %}
+    {% set min_viable_mtu = mtu_list | max %}
+    network_config:
+    - type: ovs_bridge
+      name: {{ neutron_physical_bridge_name }}
+      mtu: {{ min_viable_mtu }}
+      use_dhcp: false
+      dns_servers: {{ ctlplane_dns_nameservers }}
+      domain: {{ dns_search_domains }}
+      addresses:
+      - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+      routes: {{ ctlplane_host_routes }}
+      members:
+      - type: interface
+        name: nic1
+        mtu: {{ min_viable_mtu }}
+        # force the MAC address of the bridge to this interface
+        primary: true
+    {% for network in nodeset_networks %}
+      - type: vlan
+        mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+        vlan_id: {{ lookup('vars', networks_lower[network] ~ '_vlan_id') }}
+        addresses:
+        - ip_netmask:
+            {{ lookup('vars', networks_lower[network] ~ '_ip') }}/{{ lookup('vars', networks_lower[network] ~ '_cidr') }}
+        routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
+    {% endfor %}
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneNodeSet
+metadata:
+  name: openstack-edpm-multinode
+spec:
+  env:
+    - name: ANSIBLE_FORCE_COLOR
+      value: "True"
+  services:
+    - download-cache
+    - bootstrap
+    - configure-network
+    - validate-network
+    - install-os
+    - configure-os
+    - run-os
+    - install-certs
+    - ovn
+    - neutron-metadata
+    - libvirt
+    - nova
+  preProvisioned: true
+  nodes:
+    edpm-compute-1:
+      hostName: edpm-compute-1
+      networks:
+      - name: ctlplane
+        subnetName: subnet1
+        defaultRoute: true
+        fixedIP: 192.168.122.101
+      - name: internalapi
+        subnetName: subnet1
+        fixedIP: 172.17.0.101
+      - name: storage
+        subnetName: subnet1
+        fixedIP: 172.18.0.101
+      - name: tenant
+        subnetName: subnet1
+        fixedIP: 172.19.0.101
+    edpm-compute-0:
+      hostName: edpm-compute-0
+      networks:
+      - name: ctlplane
+        subnetName: subnet1
+        defaultRoute: true
+        fixedIP: 192.168.122.100
+      - name: internalapi
+        subnetName: subnet1
+        fixedIP: 172.17.0.100
+      - name: storage
+        subnetName: subnet1
+        fixedIP: 172.18.0.100
+      - name: tenant
+        subnetName: subnet1
+        fixedIP: 172.19.0.100
+  nodeTemplate:
+    ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
+    ansible:
+      ansibleUser: cloud-admin
+      ansiblePort: 22
+      ansibleVarsFrom:
+        - prefix: edpm_
+          configMapRef:
+            name: network-config-template
+      ansibleVars:
+         timesync_ntp_servers:
+           - hostname: clock.redhat.com
+         # edpm_network_config
+         # Default nic config template for a EDPM compute node
+         # These vars are edpm_network_config role vars
+         edpm_network_config_hide_sensitive_logs: false
+         edpm_nodes_validation_validate_controllers_icmp: false
+         edpm_nodes_validation_validate_gateway_icmp: false
+         gather_facts: false
+         enable_debug: false
+         # edpm firewall, change the allowed CIDR if needed
+         edpm_sshd_configure_firewall: true
+         edpm_sshd_allowed_ranges: ['192.168.122.0/24']
+         # SELinux module
+         edpm_selinux_mode: enforcing


### PR DESCRIPTION
Otherwise dnsdata could be different in every reconciliation and this would result in a reconciliation loop as
- NodeSet watches dnsmasq changes
- dnsmasq watches dnsdata changes

Also adds a multinode kuttl test where we can test these things.