### PR TITLE
Mirror nsConditions always to NodeSetDeploymentReadyCondition

### DIFF
--- a/controllers/openstackdataplanedeployment_controller.go
+++ b/controllers/openstackdataplanedeployment_controller.go
@@ -335,6 +335,7 @@ func (r *OpenStackDataPlaneDeploymentReconciler) Reconcile(ctx context.Context, 
 		}
 
 		nsConditions := instance.Status.NodeSetConditions[nodeSet.Name]
+		nsConditions.Set(nsConditions.Mirror(dataplanev1.NodeSetDeploymentReadyCondition))
 
 		if err != nil {
 			util.LogErrorForObject(helper, err, fmt.Sprintf("OpenStackDeployment error for NodeSet %s", nodeSet.Name), instance)
@@ -346,7 +347,6 @@ func (r *OpenStackDataPlaneDeploymentReconciler) Reconcile(ctx context.Context, 
 			} else {
 				deploymentErrMsg = fmt.Sprintf("%s & %s", deploymentErrMsg, errMsg)
 			}
-			nsConditions.Set(nsConditions.Mirror(dataplanev1.NodeSetDeploymentReadyCondition))
 			errorReason := nsConditions.Get(dataplanev1.NodeSetDeploymentReadyCondition).Reason
 			backoffLimitReached = errorReason == condition.JobReasonBackoffLimitExceeded
 		}


### PR DESCRIPTION
Let's mirror the nscondtions conditions to NodeSetDeploymentReadyCondition irrespective of error or not.

Otherwise we see `Deployment Not Started` message for the nodeset when deployment is actually running.