### PR TITLE
Make TLS cert mount order consisitent

### DIFF
--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -273,7 +273,14 @@ func (d *Deployer) addCertMounts(
 		}
 
 		if service.Spec.TLSCerts != nil {
-			for certKey := range service.Spec.TLSCerts {
+			// sort cert list to ensure mount list is consistent
+			certKeyList := make([]string, 0, len(service.Spec.TLSCerts))
+			for ckey := range service.Spec.TLSCerts {
+				certKeyList = append(certKeyList, ckey)
+			}
+			sort.Strings(certKeyList)
+
+			for _, certKey := range certKeyList {
 				log.Info("Mounting TLS cert for service", "service", svc)
 				volMounts := storage.VolMounts{}
 


### PR DESCRIPTION
We iterate over the TLSCerts map to define the cert mounts.  Because this is a map, though, the order is undefined.  This causes kuttl tests to fail every so often because they expect a consistent mount order.

The simplest solution is to sort the map keys and then add the mounts in a consistent way.