### PR TITLE
Cleanup/fix how we manage DeploymentReadyCondition

### DIFF
--- a/tests/kuttl/tests/dataplane-service-custom-image/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-service-custom-image/00-assert.yaml
@@ -16,12 +16,12 @@ spec:
 status:
   observedGeneration: 1
   conditions:
-  - message: Deployment not started
+  - message: Deployment in progress
     reason: Requested
     severity: Info
     status: "False"
     type: Ready
-  - message: Deployment not started
+  - message: Deployment in progress
     reason: Requested
     severity: Info
     status: "False"


### PR DESCRIPTION
- Don't use deployemnt.Deployed as there could be more than one nodeset in a deployment.
- Check NodeSetDeploymentReadyCondition for the nodeset rather than Ready condition for the deployment.
- Break when a failed deployment for a nodeset is encountered. Continuing can overwrite the nodeset deployment conditions.

Jira: https://issues.redhat.com/browse/OSPRH-7617
Depends-On: https://github.com/openstack-k8s-operators/install_yamls/pull/847