### PR TITLE
Use the error message from deployment 

### DIFF
--- a/controllers/openstackdataplanenodeset_controller.go
+++ b/controllers/openstackdataplanenodeset_controller.go
@@ -443,7 +443,6 @@ func (r *OpenStackDataPlaneNodeSetReconciler) Reconcile(ctx context.Context, req
 		}
 		instance.Status.Conditions.MarkFalse(condition.DeploymentReadyCondition,
 			condition.ErrorReason, condition.SeverityError,
-			condition.DeploymentReadyErrorMessage,
 			deployErrorMsg)
 	}
 
@@ -498,8 +497,7 @@ func checkDeployment(helper *helper.Helper,
 			instance.Status.DeploymentStatuses[deployment.Name] = deploymentConditions
 			deploymentCondition := deploymentConditions.Get(dataplanev1.NodeSetDeploymentReadyCondition)
 			if condition.IsError(deploymentCondition) {
-				msg := strings.Replace(deploymentCondition.Message, strings.Split(condition.DeploymentReadyErrorMessage, "%")[0], "", -1)
-				err = fmt.Errorf(msg)
+				err = fmt.Errorf(deploymentCondition.Message)
 				isDeploymentFailed = true
 				break
 			} else if deploymentConditions.IsFalse(dataplanev1.NodeSetDeploymentReadyCondition) {


### PR DESCRIPTION
We don't need the hack for the message as we can use the message from the deployment directly.

Depends-On: https://github.com/openstack-k8s-operators/install_yamls/pull/847